### PR TITLE
Update python badge from readme with >=3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
     <a href="#">
-        <img src="https://img.shields.io/badge/Python-3.6, 3.7, 3.8-efefef">
+        <img src="https://img.shields.io/badge/Python-%E2%89%A53.7-efefef">
     </a>
     <a href="https://github.com/airbus/decomon/actions/workflows/python-lints.yml">
         <img alt="PyLint" src="https://github.com/airbus/decomon/actions/workflows/python-lints.yml/badge.svg">


### PR DESCRIPTION
Was stating 3.6, 3.7, 3.8 which is not corresponding to the specs from pyproject.toml.