### PR TITLE
Update pyproject.toml to switch from poetry to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,30 @@
-[tool.poetry]
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "decomon"
-version = "0.1.0"
 description = "Linear Relaxation for Certified Robustness Bound for Tensorflow Neural Networks"
-authors = ["melanie.ducoffe <melanie.ducoffe@gmail.com>"]
+authors = [
+    {name = "melanie.ducoffe", email ="melanie.ducoffe@gmail.com"},
+]
+requires-python = ">=3.7"
+dependencies =[
+    "tensorflow >=2.6.0, <2.7",
+    "matplotlib",
+    "ortools",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+dev = ["pytest>=6.2.2", "black", "tox>=3.20.1"]
+
+[tool.setuptools.dynamic]
+version = {attr = "decomon.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["decomon*"]
 
 [tool.black]
 line-length = 120
@@ -28,21 +50,4 @@ exclude = '''
                      # the root of the project
 )
 '''
-
-[tool.poetry.dependencies]
-python = ">=3.7.1,<4.0"
-tensorflow = "^2.6.0"
-six = "^1.15.0"
-matplotlib = "^3.4.1"
-
-
-[tool.poetry.dev-dependencies]
-pytest = "^6.2.2"
-black = { version = "*", allow-prereleases = true }
-tox = "^3.20.1"
-
-
-[build-system]
-requires = ["poetry-core>=1.0.0","setuptools >= 35.0.2", "setuptools_scm >= 2.0.0, <3"]
-build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
The version number is inferred from decomon.__version__ defined in decomon/__init__.py.

The dependencies are a bit relaxed:
- the spec with ^ is specific to poetry
- some dependencies where included by other ones