### PR TITLE
Infer version number from git tags thanks to setuptools_scm

### DIFF
--- a/decomon/__init__.py
+++ b/decomon/__init__.py
@@ -6,8 +6,7 @@ techniques for certified perturbation analysis
 """
 from __future__ import absolute_import
 
-
-
+import sys
 
 from . import layers
 from . import models
@@ -30,4 +29,18 @@ from .wrapper import (
 from .wrapper_with_tuning import get_upper_box_tuning, get_lower_box_tuning
 from .metrics.loss import get_model, get_upper_loss, get_lower_loss, get_adv_loss
 
-__version__ = '0.0.1'
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import (  # pylint: disable=no-name-in-module
+        PackageNotFoundError,
+        version,
+    )
+else:
+    from importlib_metadata import PackageNotFoundError, version
+
+
+try:
+    __version__ = version("decomon")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 ]
 requires-python = ">=3.7"
 dependencies =[
+    "importlib-metadata; python_version<'3.8'",
     "tensorflow >=2.6.0, <2.7",
     "matplotlib",
     "ortools",
@@ -19,12 +20,11 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["pytest>=6.2.2", "black", "tox>=3.20.1"]
 
-[tool.setuptools.dynamic]
-version = {attr = "decomon.__version__"}
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["decomon*"]
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
To be consistent, we define `decomon.__version__` by looking at metadata of installed package. If not installed,  `__version__ `remains undefined. We need importlib-metadata for that which is by default on python 3.8 but must be installed for previous versions.

cf https://github.com/pypa/setuptools_scm#retrieving-package-version-at-runtime

The version will be inferred from distance to tags of the form "v{x}.{y}.{z}" or "{x}.{y}.{z}" where {x}, {y}, and {z} are numbers.