### PR TITLE
Make ortools dependency optional

### DIFF
--- a/decomon/numpy/milp/activation.py
+++ b/decomon/numpy/milp/activation.py
@@ -1,7 +1,16 @@
 # do it with several solvers
 import numpy as np
 import six
-from ortools.linear_solver import pywraplp
+
+try:
+    import ortools
+except ImportError:
+    ortools_available = False
+else:
+    from ortools.linear_solver import pywraplp
+
+    ortools_available = True
+
 
 ORTOOLS = "ortools"
 GUROBI = "gurobi"

--- a/decomon/numpy/milp/activation.py
+++ b/decomon/numpy/milp/activation.py
@@ -26,9 +26,6 @@ def bound_B(x_min, x_max, m, W_up, b_up, W_low, b_low, mask, solver=ORTOOLS):
 
     return bound_B_ortools(x_min, x_max, m, W_low, b_low, W_up, b_up, mask)
 
-    func = get(solver)
-    return -func(x_min, x_max, m, -W_low, -b_low, -W_up, -b_up)
-
 
 def deserialize(name):
     """Get the activation from name.

--- a/decomon/numpy/milp/activation.py
+++ b/decomon/numpy/milp/activation.py
@@ -71,6 +71,10 @@ def bound_A_ortools(x_min, x_max, m, W_up, b_up, W_low, b_low, mask_A):
     W_low : (None, n_dim, n_out)
     b_low: (None, n_out)
     """
+    # Check ortools available
+    if not ortools_available:
+        raise ImportError("'ortools' must be installed to use this function.")
+
     # compute a mask that removes the constraints where we know it is not achievable
     n_out = W_up.shape[2]
     n_dim = W_up.shape[1]
@@ -142,6 +146,9 @@ def bound_B_ortools(x_min, x_max, m, W_up, b_up, W_low, b_low, mask_B):
     W_low : (None, n_dim, n_out)
     b_low: (None, n_out)
     """
+    # Check ortools available
+    if not ortools_available:
+        raise ImportError("'ortools' must be installed to use this function.")
 
     n_out = W_up.shape[2]
     n_dim = W_up.shape[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies =[
     "importlib-metadata; python_version<'3.8'",
     "tensorflow >=2.6.0, <2.7",
     "matplotlib",
-    "ortools",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
We want the library to work without ortools as long as we do not use the functions using it.