### PR TITLE
Fix default arguments that were mutable

### DIFF
--- a/decomon/backward_layers/activations.py
+++ b/decomon/backward_layers/activations.py
@@ -40,7 +40,7 @@ LINEAR = "linear"
 def backward_relu(
     x,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     alpha=0.0,
     max_value=None,
     threshold=0.0,
@@ -62,6 +62,8 @@ def backward_relu(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -100,7 +102,7 @@ def backward_relu(
 
 
 def backward_sigmoid(
-    inputs, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    inputs, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward  LiRPA of sigmoid
@@ -112,6 +114,8 @@ def backward_sigmoid(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -147,7 +151,7 @@ def backward_sigmoid(
 
 
 def backward_tanh(
-    inputs, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    inputs, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward  LiRPA of tanh
@@ -159,6 +163,8 @@ def backward_tanh(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -201,7 +207,7 @@ def backward_tanh(
 
 
 def backward_hard_sigmoid(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward  LiRPA of hard sigmoid
@@ -213,6 +219,8 @@ def backward_hard_sigmoid(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -220,7 +228,9 @@ def backward_hard_sigmoid(
     raise NotImplementedError()
 
 
-def backward_elu(x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs):
+def backward_elu(
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+):
     """
     Backward  LiRPA of Exponential Linear Unit
     :param x:
@@ -231,6 +241,8 @@ def backward_elu(x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -239,7 +251,7 @@ def backward_elu(x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=
 
 
 def backward_selu(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward LiRPA of Scaled Exponential Linear Unit (SELU)
@@ -251,6 +263,8 @@ def backward_selu(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -259,7 +273,7 @@ def backward_selu(
 
 
 def backward_linear(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward LiRPA of linear
@@ -270,6 +284,8 @@ def backward_linear(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
     if previous:
         return x[-4:]
 
@@ -277,7 +293,7 @@ def backward_linear(
 
 
 def backward_exponential(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward LiRPAof exponential
@@ -288,6 +304,8 @@ def backward_exponential(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -296,7 +314,7 @@ def backward_exponential(
 
 
 def backward_softplus(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward LiRPA of softplus
@@ -308,6 +326,8 @@ def backward_softplus(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
     if previous:
@@ -332,7 +352,7 @@ def backward_softplus(
 
 
 def backward_softsign(
-    x, dc_decom=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
+    x, dc_decom=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, **kwargs
 ):
     """
     Backward LiRPA of softsign
@@ -347,6 +367,8 @@ def backward_softsign(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if previous:
         y = x[:-4]
         w_out_u, b_out_u, w_out_l, b_out_l = x[-4:]
@@ -377,8 +399,10 @@ def backward_softsign(
         return [w_u_, b_u_, w_l_, b_l_]
 
 
-def backward_softsign_(y, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def backward_softsign_(y, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=None, mode=F_HYBRID.name, **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     w_u_0, b_u_0, w_l_0, b_l_0 = get_linear_hull_s_shape(
         y, func=K.softsign, f_prime=softsign_prime, convex_domain=convex_domain, mode=mode
     )
@@ -399,7 +423,7 @@ def backward_softsign_(y, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, 
 
 
 def backward_softmax(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, previous=True, axis=-1, **kwargs
+    x, dc_decomp=False, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, previous=True, axis=-1, **kwargs
 ):
     """
     Backward LiRPA of softmax
@@ -413,6 +437,8 @@ def backward_softmax(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 

--- a/decomon/backward_layers/backward_layers.py
+++ b/decomon/backward_layers/backward_layers.py
@@ -54,13 +54,15 @@ class BackwardDense(BackwardLayer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(BackwardDense, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.activation = get(layer.get_config()["activation"])  # ??? not sur
         self.activation_name = layer.get_config()["activation"]
@@ -315,13 +317,15 @@ class BackwardConv2D(BackwardLayer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(BackwardConv2D, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.activation = get(layer.get_config()["activation"])  # ??? not sur
         self.activation_name = layer.get_config()["activation"]
@@ -575,10 +579,12 @@ class BackwardConv2D(BackwardLayer):
 
 class BackwardActivation(BackwardLayer):
     def __init__(
-        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
         super(BackwardActivation, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.activation = get(layer.get_config()["activation"])  # ??? not sur
         self.activation_name = layer.get_config()["activation"]
@@ -846,9 +852,11 @@ class BackwardFlatten(BackwardLayer):
     """
 
     def __init__(
-        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
         super(BackwardFlatten, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.previous = previous
 
     def call(self, inputs, slope=V_slope.name):
@@ -876,9 +884,11 @@ class BackwardReshape(BackwardLayer):
     """
 
     def __init__(
-        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
         super(BackwardReshape, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.previous = previous
 
     """
@@ -937,9 +947,11 @@ class BackwardPermute(BackwardLayer):
     """
 
     def __init__(
-        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
         super(BackwardPermute, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.dims = layer.dims
         self.op = layer.call
         self.previous = previous
@@ -989,12 +1001,14 @@ class BackwardDropout(BackwardLayer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         rec=1,
         **kwargs,
     ):
         super(BackwardDropout, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
 
     def call(self, inputs, slope=V_slope.name):
 
@@ -1021,8 +1035,10 @@ class BackwardBatchNormalization(BackwardLayer):
     Backward  LiRPA of Batch Normalization
     """
 
-    def __init__(self, layer, slope=V_slope.name, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs):
+    def __init__(self, layer, slope=V_slope.name, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs):
         super(BackwardBatchNormalization, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         if not isinstance(layer, DecomonBatchNormalization):
             raise NotImplementedError()
         self.layer = layer
@@ -1073,9 +1089,11 @@ class BackwardBatchNormalization(BackwardLayer):
 
 class BackwardInputLayer(BackwardLayer):
     def __init__(
-        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+        self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
         super(BackwardInputLayer, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):
@@ -1105,10 +1123,12 @@ class BackwardInputLayer(BackwardLayer):
 
 
 def get_backward(
-    layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain={}, finetune=False, **kwargs
+    layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
 ):
     # do it better
     # either a Decomon layer or its pure Keras version
+    if convex_domain is None:
+        convex_domain = {}
     class_name = layer.__class__.__name__
     if class_name[:7] == "Decomon":
         class_name = "".join(layer.__class__.__name__.split("Decomon")[1:])

--- a/decomon/backward_layers/backward_maxpooling.py
+++ b/decomon/backward_layers/backward_maxpooling.py
@@ -24,12 +24,14 @@ class BackwardMaxPooling2D(Layer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):  # __init__(self, layer, slope=V_slope.name,
         super(BackwardMaxPooling2D, self).__init__(**kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         raise NotImplementedError()
         self.mode = layer.mode
         self.pool_size = layer.pool_size
@@ -55,10 +57,12 @@ class BackwardMaxPooling2D(Layer):
         strides,
         padding,
         data_format,
-        convex_domain={},
+        convex_domain=None,
         slope=V_slope.name,
     ):
 
+        if convex_domain is None:
+            convex_domain = {}
         if self.fast:
             return self._pooling_function_fast(
                 inputs,
@@ -99,10 +103,12 @@ class BackwardMaxPooling2D(Layer):
         strides,
         padding,
         data_format,
-        convex_domain={},
+        convex_domain=None,
         slope=V_slope.name,
     ):
 
+        if convex_domain is None:
+            convex_domain = {}
         if self.mode == F_HYBRID.name:
             x_0, u_c, w_u, b_u, l_c, w_l, b_l = inputs[:7]
         if self.mode == F_FORWARD.name:
@@ -146,7 +152,7 @@ class BackwardMaxPooling2D(Layer):
         strides,
         padding,
         data_format,
-        convex_domain={},
+        convex_domain=None,
         slope=V_slope.name,
     ):
         """
@@ -159,6 +165,8 @@ class BackwardMaxPooling2D(Layer):
         :return:
         """
 
+        if convex_domain is None:
+            convex_domain = {}
         if self.mode == F_HYBRID.name:
             x_0, u_c, w_u, b_u, l_c, w_l, b_l = inputs[:7]
         if self.mode == F_FORWARD.name:

--- a/decomon/backward_layers/backward_merge.py
+++ b/decomon/backward_layers/backward_merge.py
@@ -48,7 +48,7 @@ class BackwardAdd(BackwardMerge):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
@@ -56,6 +56,8 @@ class BackwardAdd(BackwardMerge):
         super(BackwardAdd, self).__init__(**kwargs)
         # if not isinstance(layer, DecomonAdd):
         #    raise KeyError()
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):
@@ -192,13 +194,15 @@ class BackwardAverage(BackwardMerge):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(BackwardAverage, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):

--- a/decomon/backward_layers/deel_lip.py
+++ b/decomon/backward_layers/deel_lip.py
@@ -38,13 +38,15 @@ class BackwardDense(Layer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(BackwardDense, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.activation = get(layer.get_config()["activation"])  # ??? not sur
         self.activation_name = layer.get_config()["activation"]
@@ -88,12 +90,14 @@ class BackwardGroupSort2(Layer):
         slope=V_slope.name,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(BackwardGroupSort2, self).__init__(kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
         self.slope = slope
         self.finetune = finetune

--- a/decomon/backward_layers/utils.py
+++ b/decomon/backward_layers/utils.py
@@ -42,7 +42,7 @@ class O_slope:
     name = "one-lb"
 
 
-def backward_add(inputs_0, inputs_1, w_out_u_, b_out_u_, w_out_l_, b_out_l_, convex_domain={}, mode=F_HYBRID.name):
+def backward_add(inputs_0, inputs_1, w_out_u_, b_out_u_, w_out_l_, b_out_l_, convex_domain=None, mode=F_HYBRID.name):
     """
     Backward  LiRPA of inputs_0+inputs_1
     :param inputs_0:
@@ -55,6 +55,8 @@ def backward_add(inputs_0, inputs_1, w_out_u_, b_out_u_, w_out_l_, b_out_l_, con
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
     op_flat = Flatten(dtype=K.floatx())  # pas terrible  a revoir
     nb_tensors = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if mode == F_IBP.name:
@@ -156,7 +158,16 @@ def merge_with_previous(inputs):
 
 
 def backward_relu_(
-    x, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, fast=True, **kwargs
+    x,
+    w_out_u,
+    b_out_u,
+    w_out_l,
+    b_out_l,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_HYBRID.name,
+    fast=True,
+    **kwargs,
 ):
     """
     Backward  LiRPA of relu
@@ -172,6 +183,8 @@ def backward_relu_(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     nb_tensors = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if mode == F_HYBRID.name:
         # y, x_0, u_c, w_u, b_u, l_c, w_l, b_l = x[:8]
@@ -235,7 +248,16 @@ def backward_relu_(
 
 
 def backward_softplus_(
-    x, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, fast=True, **kwargs
+    x,
+    w_out_u,
+    b_out_u,
+    w_out_l,
+    b_out_l,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_HYBRID.name,
+    fast=True,
+    **kwargs,
 ):
     """
     Backward  LiRPA of relu
@@ -251,6 +273,8 @@ def backward_softplus_(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     nb_tensors = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if mode == F_HYBRID.name:
         # y, x_0, u_c, w_u, b_u, l_c, w_l, b_l = x[:8]
@@ -361,7 +385,7 @@ def backward_maximum(
     b_out_u,
     w_out_l,
     b_out_l,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_HYBRID.name,
     **kwargs,
@@ -380,6 +404,8 @@ def backward_maximum(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     input_step_a_0 = substract(inputs_0, inputs_1, dc_decomp=False, convex_domain=convex_domain, mode=mode)
 
     input_step_0_ = relu_(input_step_a_0, dc_decomp=False, convex_domain=convex_domain, mode=mode, **kwargs)
@@ -400,7 +426,7 @@ def backward_maximum(
 
 # convex hull of the maximum between two functions
 def backward_max_(
-    x, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name, axis=-1, **kwargs
+    x, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name, axis=-1, **kwargs
 ):
     """
     Backward  LiRPA of max
@@ -413,6 +439,8 @@ def backward_max_(
     :param axis: axis to perform the maximum
     :return: max operation  along an axis
     """
+    if convex_domain is None:
+        convex_domain = {}
     nb_tensor = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     z_value = K.cast(0.0, x.dtype)
     if mode == F_HYBRID.name:
@@ -537,7 +565,7 @@ def backward_minimum(
     b_out_u,
     w_out_l,
     b_out_l,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_HYBRID.name,
     **kwargs,
@@ -556,6 +584,8 @@ def backward_minimum(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     w_out_u_, b_out_u_, w_out_l_, b_out_l_ = backward_minus(
         w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=convex_domain, slope=slope, mode=mode
     )
@@ -585,7 +615,7 @@ def backward_minimum(
     return bounds_0_, bounds_1_
 
 
-def backward_minus(w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name):
+def backward_minus(w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name):
     """
     Backward  LiRPA of -x
     :param w_out_u:
@@ -598,6 +628,8 @@ def backward_minus(w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     w_u_ = -w_out_l
     b_u_ = -b_out_l
     w_l_ = -w_out_u
@@ -625,7 +657,7 @@ def backward_scale(scale_factor, w_out_u, b_out_u, w_out_l, b_out_l):
 
 
 def backward_substract(
-    inputs_0, inputs_1, w_out_u_, b_out_u_, w_out_l_, b_out_l_, convex_domain={}, mode=F_HYBRID.name
+    inputs_0, inputs_1, w_out_u_, b_out_u_, w_out_l_, b_out_l_, convex_domain=None, mode=F_HYBRID.name
 ):
     """
     Backward  LiRPA of inputs_0 - inputs_1
@@ -640,6 +672,8 @@ def backward_substract(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     inputs_1_ = minus(inputs_1, mode=mode)
     bounds_0, bounds_1 = backward_add(
         inputs_0, inputs_1_, w_out_u_, b_out_u_, w_out_l_, b_out_l_, convex_domain=convex_domain, mode=mode
@@ -650,7 +684,7 @@ def backward_substract(
 
 
 def backward_multiply(
-    inputs_0, inputs_1, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain={}, slope=V_slope.name, mode=F_HYBRID.name
+    inputs_0, inputs_1, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=None, slope=V_slope.name, mode=F_HYBRID.name
 ):
     """
     Backward  LiRPA of element-wise multiply inputs_0*inputs_1
@@ -671,6 +705,8 @@ def backward_multiply(
     # b_out_u = b_out_u[:, 0]
     # b_out_l = b_out_l[:, 0]
 
+    if convex_domain is None:
+        convex_domain = {}
     if mode == F_IBP.name:
         u_0, l_0 = inputs_0
         u_1, l_1 = inputs_1
@@ -748,7 +784,7 @@ def backward_sort(
     w_out_l,
     b_out_l,
     axis=-1,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_HYBRID.name,
     **kwargs,
@@ -766,6 +802,8 @@ def backward_sort(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
     z_value = K.cast(0.0, w_out_u.dtype)
     # build the tightest contain bounds for inputs_
     if mode == F_IBP.name:

--- a/decomon/gradient/core.py
+++ b/decomon/gradient/core.py
@@ -13,8 +13,10 @@ class GradientLayer(ABC, Layer):
     """
 
     def __init__(
-        self, convex_domain={}, mode=F_HYBRID.name, input_mode=F_HYBRID.name, finetune=False, shared=False, **kwargs
+        self, convex_domain=None, mode=F_HYBRID.name, input_mode=F_HYBRID.name, finetune=False, shared=False, **kwargs
     ):
+        if convex_domain is None:
+            convex_domain = {}
         self.convex_domain = convex_domain
         self.mode = mode
         self.input_mode = input_mode

--- a/decomon/gradient/gradient_layers.py
+++ b/decomon/gradient/gradient_layers.py
@@ -33,13 +33,15 @@ class GradientDense(Layer):
         layer,
         previous=True,
         mode=F_HYBRID.name,
-        convex_domain={},
+        convex_domain=None,
         finetune=False,
         input_dim=-1,
         **kwargs,
     ):
         super(GradientDense, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.layer = layer
 
     def call(self, inputs, mode, convex_domain):

--- a/decomon/gradient/utils.py
+++ b/decomon/gradient/utils.py
@@ -5,9 +5,11 @@ from ..layers import F_FORWARD, F_HYBRID, F_IBP, StaticVariables
 from ..layers.utils import get_lower, get_upper
 
 
-def gradient_relu(inputs, dc_decomp=False, mode=F_HYBRID.name, convex_domain={}, **kwargs):
+def gradient_relu(inputs, dc_decomp=False, mode=F_HYBRID.name, convex_domain=None, **kwargs):
 
     # get upper and lower
+    if convex_domain is None:
+        convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
         raise ValueError("unknown mode {}".format(mode))
 

--- a/decomon/layers/activations.py
+++ b/decomon/layers/activations.py
@@ -42,7 +42,9 @@ LINEAR = "linear"
 GROUP_SORT_2 = "GroupSort2"
 
 
-def relu(x, dc_decomp=False, convex_domain={}, alpha=0.0, max_value=None, threshold=0.0, mode=F_HYBRID.name, **kwargs):
+def relu(
+    x, dc_decomp=False, convex_domain=None, alpha=0.0, max_value=None, threshold=0.0, mode=F_HYBRID.name, **kwargs
+):
     """
 
     :param x: list of input tensors
@@ -57,6 +59,8 @@ def relu(x, dc_decomp=False, convex_domain={}, alpha=0.0, max_value=None, thresh
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if threshold != 0:
         raise NotImplementedError()
 
@@ -72,7 +76,7 @@ def linear_hull_s_shape(
     func=K.sigmoid,
     f_prime=sigmoid_prime,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     mode=F_HYBRID.name,
 ):
     """
@@ -87,6 +91,8 @@ def linear_hull_s_shape(
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -142,7 +148,7 @@ def linear_hull_s_shape(
     # TO DO linear relaxation
 
 
-def sigmoid(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def sigmoid(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Sigmoid activation function .
     `1 / (1 + exp(-x))`.
 
@@ -155,12 +161,14 @@ def sigmoid(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     func = K.sigmoid
     f_prime = sigmoid_prime
     return linear_hull_s_shape(x, func, f_prime, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
 
 
-def tanh(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def tanh(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Hyperbolic activation function.
     `tanh(x)=2*sigmoid(2*x)+1`
 
@@ -173,12 +181,14 @@ def tanh(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     func = K.tanh
     f_prime = tanh_prime
     return linear_hull_s_shape(x, func, f_prime, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
 
 
-def hard_sigmoid(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def hard_sigmoid(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Hard sigmoid activation function.
        Faster to compute than sigmoid activation.
 
@@ -191,6 +201,8 @@ def hard_sigmoid(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwa
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -198,7 +210,7 @@ def hard_sigmoid(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwa
     raise NotImplementedError()
 
 
-def elu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def elu(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Exponential linear unit.
 
     :param x: list of input tensors
@@ -210,6 +222,8 @@ def elu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -217,7 +231,7 @@ def elu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     raise NotImplementedError()
 
 
-def selu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def selu(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Scaled Exponential Linear Unit (SELU).
 
     SELU is equal to: `scale * elu(x, alpha)`, where alpha and scale
@@ -236,6 +250,8 @@ def selu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -243,7 +259,7 @@ def selu(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     raise NotImplementedError()
 
 
-def linear(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def linear(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA foe Linear (i.e. identity) activation function.
 
     :param x: list of input tensors
@@ -255,10 +271,12 @@ def linear(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     return x
 
 
-def exponential(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def exponential(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Exponential activation function.
 
     :param x: list of input tensors
@@ -271,10 +289,12 @@ def exponential(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwar
 
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     return exp(x, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode, **kwargs)
 
 
-def softplus(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def softplus(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Softplus activation function `log(exp(x) + 1)`.
 
     :param x: list of input tensors
@@ -286,6 +306,8 @@ def softplus(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs)
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -294,7 +316,7 @@ def softplus(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs)
     raise NotImplementedError()
 
 
-def softsign(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def softsign(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """LiRPA for Softsign activation function `x / (abs(x) + 1)`.
 
     :param x: list of input tensors
@@ -307,12 +329,14 @@ def softsign(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs)
 
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     func = K.softsign
     f_prime = softsign_prime
     return linear_hull_s_shape(x, func, f_prime, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
 
 
-def softmax(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, clip=True, **kwargs):
+def softmax(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, axis=-1, clip=True, **kwargs):
     """LiRPA for Softmax activation function.
 
     :param x: list of input tensors
@@ -324,6 +348,8 @@ def softmax(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, c
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -355,8 +381,10 @@ def softmax(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, c
     raise NotImplementedError()
 
 
-def group_sort_2(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, data_format="channels_last", **kwargs):
+def group_sort_2(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, data_format="channels_last", **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     raise NotImplementedError()
 
     input_shape = x[-1].shape

--- a/decomon/layers/core.py
+++ b/decomon/layers/core.py
@@ -87,7 +87,7 @@ class DecomonLayer(ABC, Layer):
 
     def __init__(
         self,
-        convex_domain={},
+        convex_domain=None,
         dc_decomp: Optional[bool] = False,
         mode: Optional[str] = F_HYBRID.name,
         finetune: Optional[bool] = False,
@@ -105,6 +105,8 @@ class DecomonLayer(ABC, Layer):
         """
         super(DecomonLayer, self).__init__(**kwargs)
 
+        if convex_domain is None:
+            convex_domain = {}
         self.nb_tensors = StaticVariables(dc_decomp, mode).nb_tensors
         self.dc_decomp = dc_decomp
         self.convex_domain = convex_domain

--- a/decomon/layers/decomon_layers.py
+++ b/decomon/layers/decomon_layers.py
@@ -1791,7 +1791,15 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
 
 
 def to_monotonic(
-    layer, input_dim, dc_decomp=False, convex_domain={}, finetune=False, IBP=True, forward=True, shared=True, fast=True
+    layer,
+    input_dim,
+    dc_decomp=False,
+    convex_domain=None,
+    finetune=False,
+    IBP=True,
+    forward=True,
+    shared=True,
+    fast=True,
 ):
     """Transform a standard keras layer into a Decomon layer.
 
@@ -1809,6 +1817,8 @@ def to_monotonic(
     """
 
     # get class name
+    if convex_domain is None:
+        convex_domain = {}
     class_name = layer.__class__.__name__
     # remove deel-lip dependency
     if class_name[: len(DEEL_LIP.name)] == DEEL_LIP.name:

--- a/decomon/layers/decomon_merge_layers.py
+++ b/decomon/layers/decomon_merge_layers.py
@@ -602,7 +602,7 @@ def to_monotonic_merge(
     layer,
     input_dim,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     finetune=False,
     IBP=True,
     forward=True,
@@ -623,6 +623,8 @@ def to_monotonic_merge(
     """
 
     # get class name
+    if convex_domain is None:
+        convex_domain = {}
     class_name = layer.__class__.__name__
     # check if layer has a built argument that built is set to True
     if hasattr(layer, "built"):

--- a/decomon/layers/utils.py
+++ b/decomon/layers/utils.py
@@ -322,7 +322,7 @@ def get_lower_ball(x_0, eps, p, w, b, **kwargs):
         return K.sum(w * x_0, 1) + lower
 
 
-def get_upper(x, w, b, convex_domain={}, **kwargs):
+def get_upper(x, w, b, convex_domain=None, **kwargs):
     """
     Meta function that aggregates all the way
     to compute a constant upper bounds depending on the convex domain
@@ -332,6 +332,8 @@ def get_upper(x, w, b, convex_domain={}, **kwargs):
     :param convex_domain: the type of convex domain (see ???)
     :return: a constant upper bound of the affine function
     """
+    if convex_domain is None:
+        convex_domain = {}
     if convex_domain is None or len(convex_domain) == 0:
         # box
         x_min = x[:, 0]
@@ -357,7 +359,7 @@ def get_upper(x, w, b, convex_domain={}, **kwargs):
     raise NotImplementedError()
 
 
-def get_lower(x, w, b, convex_domain={}, **kwargs):
+def get_lower(x, w, b, convex_domain=None, **kwargs):
     """
      Meta function that aggregates all the way
      to compute a constant lower bound depending on the convex domain
@@ -367,6 +369,8 @@ def get_lower(x, w, b, convex_domain={}, **kwargs):
     :param convex_domain: the type of convex domain (see ???)
     :return: a constant upper bound of the affine function
     """
+    if convex_domain is None:
+        convex_domain = {}
     if convex_domain is None or len(convex_domain) == 0:
 
         # box
@@ -662,8 +666,10 @@ class Project_initializer_neg(Initializer):
         return K.minimum(0.0, w_)
 
 
-def relu_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, slope=V_slope.name, **kwargs):
+def relu_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, slope=V_slope.name, **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
         raise ValueError("unknown mode {}".format(mode))
 
@@ -731,8 +737,10 @@ def relu_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, slope=V_slop
     return output
 
 
-def softplus_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, slope=V_slope.name, **kwargs):
+def softplus_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, slope=V_slope.name, **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
         raise ValueError("unknown mode {}".format(mode))
 
@@ -781,7 +789,7 @@ def softplus_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, slope=V_
         return [x_0, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_]
 
 
-def substract(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def substract(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of inputs_0-inputs_1
 
@@ -792,13 +800,15 @@ def substract(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBR
     :param convex_domain: the type of convex domain
     :return: inputs_0 - inputs_1
     """
+    if convex_domain is None:
+        convex_domain = {}
     inputs_1_ = minus(inputs_1, mode=mode, dc_decomp=dc_decomp)
     output = add(inputs_0, inputs_1_, dc_decomp=dc_decomp, mode=mode, convex_domain=convex_domain)
 
     return output
 
 
-def add(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def add(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of inputs_0+inputs_1
 
@@ -809,6 +819,8 @@ def add(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.nam
     :param convex_domain: the type of convex domain
     :return: inputs_0 + inputs_1
     """
+    if convex_domain is None:
+        convex_domain = {}
     nb_tensor = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if dc_decomp:
         h_0, g_0 = inputs_0[-2:]
@@ -896,8 +908,10 @@ def sum(x, axis=-1, dc_decomp=False, mode=F_HYBRID.name, **kwargs):
         return [x_0, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_]
 
 
-def frac_pos(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def frac_pos(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
     # frac_pos is convex for positive values
@@ -933,7 +947,7 @@ def frac_pos(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs)
             return [x_0, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_]
 
 
-def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, finetune=False, **kwargs):
+def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, finetune=False, **kwargs):
     """
     LiRPA implementation of element-wise max
 
@@ -944,6 +958,8 @@ def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     :param convex_domain: the type of convex domain
     :return: maximum(inputs_0, inputs_1)
     """
+    if convex_domain is None:
+        convex_domain = {}
     output_0 = substract(inputs_1, inputs_0, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
     if finetune:
         finetune = kwargs["finetune_params"]
@@ -960,7 +976,7 @@ def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     )
 
 
-def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, finetune=False, **kwargs):
+def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, finetune=False, **kwargs):
     """
     LiRPA implementation of element-wise min
 
@@ -972,6 +988,8 @@ def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     return minus(
         maximum(
             minus(inputs_0, dc_decomp=dc_decomp, mode=mode),
@@ -988,7 +1006,7 @@ def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
 
 
 # convex hull of the maximum between two functions
-def max_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, finetune=False, **kwargs):
+def max_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, axis=-1, finetune=False, **kwargs):
     """
     LiRPA implementation of max(x, axis)
 
@@ -1000,6 +1018,8 @@ def max_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, fine
     :return: max operation  along an axis
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         h, g = x[-2:]
 
@@ -1248,7 +1268,7 @@ def minus(inputs, mode=F_HYBRID.name, dc_decomp=False, **kwargs):
     return output
 
 
-def multiply_old(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def multiply_old(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of (element-wise) multiply(x,y)=-x*y.
 
@@ -1262,6 +1282,8 @@ def multiply_old(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_H
     :return: maximum(inputs_0, inputs_1)
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -1379,7 +1401,7 @@ def multiply_old(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_H
     return output
 
 
-def multiply(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def multiply(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of (element-wise) multiply(x,y)=-x*y.
 
@@ -1393,6 +1415,8 @@ def multiply(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRI
     :return: maximum(inputs_0, inputs_1)
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -1622,7 +1646,7 @@ def split(input_, axis=-1, mode=F_HYBRID.name):
     return outputs
 
 
-def sort(input_, axis=-1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def sort(input_, axis=-1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of sort by selection
 
@@ -1634,6 +1658,8 @@ def sort(input_, axis=-1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name)
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
     # remove grad bounds
@@ -1742,7 +1768,7 @@ def sort(input_, axis=-1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name)
     return output
 
 
-def pow(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def pow(inputs_, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of pow(x )=x**2
 
@@ -1753,10 +1779,12 @@ def pow(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     return multiply(inputs_, inputs_, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
 
 
-def abs(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def abs(inputs_, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of |x|
 
@@ -1767,6 +1795,8 @@ def abs(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     inputs_0 = relu_(inputs_, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
     inputs_1 = minus(
         relu_(minus(inputs_, mode=mode), dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode), mode=mode
@@ -1775,7 +1805,7 @@ def abs(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
     return add(inputs_0, inputs_1, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
 
 
-def frac_pos_hull(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def frac_pos_hull(inputs_, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of 1/x for x>0
     :param inputs_:
@@ -1785,6 +1815,8 @@ def frac_pos_hull(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
     nb_tensor = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
@@ -1822,7 +1854,7 @@ def frac_pos_hull(inputs_, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name
 
 
 # convex hull for min
-def min_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, finetune=False, **kwargs):
+def min_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, axis=-1, finetune=False, **kwargs):
     """
     LiRPA implementation of min(x, axis=axis)
     :param x:
@@ -1833,6 +1865,8 @@ def min_(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, axis=-1, fine
     :return:
     """
     # return - max - x
+    if convex_domain is None:
+        convex_domain = {}
     return minus(
         max_(
             minus(x, mode=mode),
@@ -1899,7 +1933,7 @@ def expand_dims(inputs_, dc_decomp=False, mode=F_HYBRID.name, axis=-1, **kwargs)
     return output
 
 
-def log(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def log(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """Exponential activation function.
 
     :param x: list of input tensors
@@ -1911,6 +1945,8 @@ def log(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -1948,7 +1984,7 @@ def log(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
         return [x_0, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_]
 
 
-def exp(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def exp(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """Exponential activation function.
 
     :param x: list of input tensors
@@ -1960,6 +1996,8 @@ def exp(x, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name, **kwargs):
     :return: the updated list of tensors
 
     """
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 

--- a/decomon/loading/load_onnx.py
+++ b/decomon/loading/load_onnx.py
@@ -21,7 +21,9 @@ def get_all_input_names(onnx_model):
 
 
 # check for issue with data_format
-def check_compatibility_data_format(k_model, allowed_format=["channels_last"]):
+def check_compatibility_data_format(k_model, allowed_format=None):
+    if allowed_format is None:
+        allowed_format = ["channels_last"]
     for layer in k_model.layers:
         if hasattr(layer, "data_format") and layer.data_format not in allowed_format:
             return True

--- a/decomon/metrics/utils.py
+++ b/decomon/metrics/utils.py
@@ -7,9 +7,11 @@ from ..layers.utils import add, exp, expand_dims, log, minus, sum
 # compute categorical cross entropy
 
 
-def categorical_cross_entropy(input_, dc_decomp=False, mode=F_HYBRID.name, convex_domain={}):
+def categorical_cross_entropy(input_, dc_decomp=False, mode=F_HYBRID.name, convex_domain=None):
 
     # step 1: exponential
+    if convex_domain is None:
+        convex_domain = {}
     exp_ = exp(input_, mode=mode, convex_domain=convex_domain, dc_decomp=dc_decomp)
     # step 2: sum
     sum_exp_ = sum(exp_, axis=-1, mode=mode)

--- a/decomon/models/backward_cloning.py
+++ b/decomon/models/backward_cloning.py
@@ -589,19 +589,23 @@ def get_input_nodes(
 def crown_model(
     model,
     input_tensors=None,
-    back_bounds=[],
+    back_bounds=None,
     input_dim=-1,
     IBP=True,
     forward=True,
     convex_domain=None,
     finetune=False,
-    forward_map={},
+    forward_map=None,
     softmax_to_linear=True,
     joint=True,
     layer_fn=get_backward_,
     fuse=True,
     **kwargs,
 ):
+    if back_bounds is None:
+        back_bounds = []
+    if forward_map is None:
+        forward_map = {}
     if not isinstance(model, Model):
         raise ValueError()
     # import time
@@ -709,13 +713,13 @@ def crown_model(
 def get_backward_model(
     model,
     input_tensors=None,
-    back_bounds=[],
+    back_bounds=None,
     input_dim=-1,
     IBP=True,
     forward=True,
     convex_domain=None,
     finetune=False,
-    forward_map={},
+    forward_map=None,
     softmax_to_linear=True,
     joint=True,
     layer_fn=get_backward_,
@@ -723,6 +727,10 @@ def get_backward_model(
     final_forward=False,
     **kwargs,
 ):
+    if back_bounds is None:
+        back_bounds = []
+    if forward_map is None:
+        forward_map = {}
     if len(back_bounds):
         if len(back_bounds) == 1:
             C = back_bounds[0]

--- a/decomon/models/convert.py
+++ b/decomon/models/convert.py
@@ -84,15 +84,15 @@ def convert(
     method=CROWN.name,
     ibp=False,
     forward=False,
-    back_bounds=[],
+    back_bounds=None,
     layer_fn=to_monotonic,
     input_dim=-1,
-    convex_domain={},
+    convex_domain=None,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    layer_map={},
-    forward_map={},
+    layer_map=None,
+    forward_map=None,
     finetune_forward=False,
     finetune_backward=False,
     final_ibp=False,
@@ -100,6 +100,14 @@ def convert(
     **kwargs,
 ):
 
+    if back_bounds is None:
+        back_bounds = []
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if finetune:
         finetune_forward = True
         finetune_backward = True
@@ -162,21 +170,29 @@ def clone(
     model,
     layer_fn=to_monotonic,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     ibp=True,
     forward=True,
     method="crown",
-    back_bounds=[],
+    back_bounds=None,
     finetune=False,
     shared=True,
     finetune_forward=False,
     finetune_backward=False,
-    extra_inputs=[],
+    extra_inputs=None,
     to_keras=True,
-    dico_grid={},
+    dico_grid=None,
     **kwargs,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if back_bounds is None:
+        back_bounds = []
+    if extra_inputs is None:
+        extra_inputs = []
+    if dico_grid is None:
+        dico_grid = {}
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
 

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -38,7 +38,7 @@ def include_dim_layer_fn(
     layer_fn,
     input_dim,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=True,
@@ -52,6 +52,8 @@ def include_dim_layer_fn(
     :param finetune:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
     if input_dim <= 0:
 
         # if n_subgrad and "n_subgrad" in inspect.signature(layer_fn).parameters:
@@ -120,7 +122,7 @@ def clone(
     layer_fn=to_monotonic,
     input_dim=-1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     mode="backward",
     slope_backward=V_slope.name,
     IBP=True,
@@ -139,6 +141,8 @@ def clone(
     :return: a decomon model
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if mode.lower() not in [Forward.name, Backward.name]:
         raise NotImplementedError()
 
@@ -179,7 +183,7 @@ def clone_sequential_model(
     layer_fn=to_monotonic,
     input_dim=-1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
@@ -203,6 +207,8 @@ def clone_sequential_model(
     :return: An instance of `Sequential` reproducing the behavior of the original model with decomon layers.
     :raises: ValueError: in case of invalid `model` argument value or `layer_fn` argument value.
     """
+    if convex_domain is None:
+        convex_domain = {}
     if input_dim == -1:
         input_dim_init = -1
         input_dim = np.prod(model.input_shape[1:])
@@ -391,7 +397,7 @@ def clone_functional_model(
     layer_fn=to_monotonic,
     input_dim=1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
@@ -409,6 +415,8 @@ def clone_functional_model(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
     if isinstance(model, Sequential):
@@ -724,14 +732,14 @@ def convert(
     input_tensors=None,
     layer_fn=to_monotonic,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     mode="backward",
     slope_backward=V_slope.name,
     IBP=True,
     forward=False,
     linearize=True,
     finetune=False,
-    options={},
+    options=None,
 ):
     """
 
@@ -746,6 +754,10 @@ def convert(
     """
 
     # raise NotImplementedError()
+    if convex_domain is None:
+        convex_domain = {}
+    if options is None:
+        options = {}
     if not mode.lower() in [Forward.name, Backward.name]:
         raise NotImplementedError()
 
@@ -886,7 +898,7 @@ class DecomonModel(tf.keras.Model):
         self,
         input,
         output,
-        convex_domain={},
+        convex_domain=None,
         dc_decomp=False,
         mode=Forward.name,
         optimize="True",
@@ -896,6 +908,8 @@ class DecomonModel(tf.keras.Model):
         **kwargs,
     ):
         super(DecomonModel, self).__init__(input, output, **kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.convex_domain = convex_domain
         self.optimize = optimize
         self.nb_tensors = StaticVariables(dc_decomp).nb_tensors
@@ -942,7 +956,7 @@ class DecomonSequential(tf.keras.Sequential):
     def __init__(
         self,
         layers=None,
-        convex_domain={},
+        convex_domain=None,
         dc_decomp=False,
         mode=Forward.name,
         optimize="False",
@@ -952,6 +966,8 @@ class DecomonSequential(tf.keras.Sequential):
         **kwargs,
     ):
         super(DecomonSequential, self).__init__(layers=layers, name=name, **kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.convex_domain = convex_domain
         self.optimize = optimize
         self.nb_tensors = StaticVariables(dc_decomp).nb_tensors
@@ -994,7 +1010,7 @@ class DecomonSequential(tf.keras.Sequential):
 
 
 # BACKWARD MODE
-def get_backward(model, back_bounds=None, slope=V_slope.name, input_dim=-1, options={}):
+def get_backward(model, back_bounds=None, slope=V_slope.name, input_dim=-1, options=None):
     """
 
     :param model:
@@ -1007,6 +1023,8 @@ def get_backward(model, back_bounds=None, slope=V_slope.name, input_dim=-1, opti
     # it implies that the bounds are on the input of the network directly
 
     # input_backward = model.input
+    if options is None:
+        options = {}
     input_backward = []
     for elem in to_list(model.input):
         input_backward.append(Input(elem.shape[1:]))
@@ -1128,8 +1146,10 @@ def get_backward_model_(model, back_bounds, input_model, slope=V_slope.name):
     return output_bounds
 
 
-def get_backward_model(model, back_bounds, input_model, slope=V_slope.name, options={}):
+def get_backward_model(model, back_bounds, input_model, slope=V_slope.name, options=None):
     # retrieve all layers inside
+    if options is None:
+        options = {}
     if hasattr(model, "dc_decomp") and model.dc_decomp:
         raise NotImplementedError()
 
@@ -1205,8 +1225,10 @@ def get_backward_model(model, back_bounds, input_model, slope=V_slope.name, opti
     return output_bounds
 
 
-def get_backward_layer(layer, back_bounds, input_layers, input_tensors, slope=V_slope.name, options={}):
+def get_backward_layer(layer, back_bounds, input_layers, input_tensors, slope=V_slope.name, options=None):
 
+    if options is None:
+        options = {}
     input = input_tensors[layer.name]
     if isinstance(layer, Model):
 

--- a/decomon/models/draft.py
+++ b/decomon/models/draft.py
@@ -114,7 +114,7 @@ def convert_forward(
     layer_fn=to_monotonic,
     input_dim=-1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
@@ -122,6 +122,8 @@ def convert_forward(
     softmax_to_linear=True,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
     if not isinstance(model, Model):
         raise ValueError()
     """
@@ -164,17 +166,25 @@ def convert_forward_functional_model(
     layer_fn=to_monotonic,
     input_dim=1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    layer_map={},
-    forward_map={},
-    name_history=set(),
+    layer_map=None,
+    forward_map=None,
+    name_history=None,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
+    if name_history is None:
+        name_history = set()
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
 

--- a/decomon/models/draft_backward_cloning.py
+++ b/decomon/models/draft_backward_cloning.py
@@ -52,13 +52,19 @@ def get_backward_layer(
     back_bounds,
     mode,
     finetune=False,
-    convex_domain={},
-    layer_map={},
-    forward_map={},
+    convex_domain=None,
+    layer_map=None,
+    forward_map=None,
     shared=True,
     softmax_to_linear=True,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if isinstance(layer, Model):
         # call clone
         if layer.name in layer_map:
@@ -110,13 +116,15 @@ def clone_backward_layer(
     mode,
     back_bounds,
     finetune=False,
-    convex_domain={},
+    convex_domain=None,
     input_tensors=None,
     upper_layer=None,
     lower_layer=None,
     x_tensor=None,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
 
@@ -343,16 +351,22 @@ def convert_backward(
     input_tensors=None,
     back_bounds=None,
     input_dim=-1,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    layer_map={},
-    forward_map={},
+    layer_map=None,
+    forward_map=None,
     **kwargs,
 ):
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if not isinstance(model, Model):
         raise ValueError()
 
@@ -428,7 +442,7 @@ def clone_backward_layer_last(
     mode,
     back_bounds,
     finetune=False,
-    convex_domain={},
+    convex_domain=None,
     input_tensors=None,
     upper_layer=None,
     lower_layer=None,
@@ -436,6 +450,8 @@ def clone_backward_layer_last(
     combine_with_input=False,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
     if isinstance(layer_, InputLayer):

--- a/decomon/models/draft_cloning_bis.py
+++ b/decomon/models/draft_cloning_bis.py
@@ -54,15 +54,21 @@ def back_bounds_from_model(
     back_bounds,
     mode,
     finetune,
-    convex_domain={},
-    layer_map={},
-    forward_map={},
+    convex_domain=None,
+    layer_map=None,
+    forward_map=None,
     shared=True,
     softmax_to_linear=True,
     input_tensors=None,
     input_dim=-1,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if layer.name in layer_map:
         _, output_tensor, _, _ = convert_backward(
             layer,
@@ -105,15 +111,21 @@ def get_backward_layer(
     back_bounds,
     mode,
     finetune,
-    convex_domain={},
-    layer_map={},
-    forward_map={},
+    convex_domain=None,
+    layer_map=None,
+    forward_map=None,
     shared=True,
     softmax_to_linear=True,
     input_tensors=None,
     input_dim=-1,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if isinstance(layer, Model):
 
         if layer.name in layer_map:
@@ -174,7 +186,7 @@ def clone_backward_layer(
     mode,
     back_bounds,
     finetune=False,
-    convex_domain={},
+    convex_domain=None,
     input_tensors=None,
     upper_layer=None,
     lower_layer=None,
@@ -182,6 +194,8 @@ def clone_backward_layer(
     combine_with_input=False,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
 
@@ -472,16 +486,22 @@ def convert_backward(
     input_tensors=None,
     back_bounds=None,
     input_dim=-1,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    layer_map={},
-    forward_map={},
+    layer_map=None,
+    forward_map=None,
     **kwargs,
 ):
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if not isinstance(model, Model):
         raise ValueError()
 

--- a/decomon/models/forward_cloning.py
+++ b/decomon/models/forward_cloning.py
@@ -47,17 +47,21 @@ def convert_forward(
     layer_fn=to_monotonic,
     input_dim=-1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    back_bounds=[],
+    back_bounds=None,
     joint=True,
     **kwargs,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if back_bounds is None:
+        back_bounds = []
     if not isinstance(model, Model):
         raise ValueError()
 

--- a/decomon/models/models.py
+++ b/decomon/models/models.py
@@ -22,7 +22,7 @@ class DecomonModel(tf.keras.Model):
         self,
         input,
         output,
-        convex_domain={},
+        convex_domain=None,
         dc_decomp=False,
         method=Forward.name,
         optimize="True",
@@ -34,6 +34,8 @@ class DecomonModel(tf.keras.Model):
         **kwargs,
     ):
         super(DecomonModel, self).__init__(input, output, **kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.convex_domain = convex_domain
         self.optimize = optimize
         self.nb_tensors = StaticVariables(dc_decomp).nb_tensors
@@ -81,7 +83,7 @@ class DecomonSequential(tf.keras.Sequential):
     def __init__(
         self,
         layers=None,
-        convex_domain={},
+        convex_domain=None,
         dc_decomp=False,
         mode=Forward.name,
         optimize="False",
@@ -91,6 +93,8 @@ class DecomonSequential(tf.keras.Sequential):
         **kwargs,
     ):
         super(DecomonSequential, self).__init__(layers=layers, name=name, **kwargs)
+        if convex_domain is None:
+            convex_domain = {}
         self.convex_domain = convex_domain
         self.optimize = optimize
         self.nb_tensors = StaticVariables(dc_decomp).nb_tensors

--- a/decomon/models/old_backward_cloning.py
+++ b/decomon/models/old_backward_cloning.py
@@ -596,19 +596,27 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, input_di
 def get_backward_model(
     model,
     input_tensors=None,
-    back_bounds=[],
+    back_bounds=None,
     input_dim=-1,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
-    layer_map={},
-    forward_map={},
+    layer_map=None,
+    forward_map=None,
     fuse_with_input=True,
     softmax_to_linear=True,
     rec=1,
     **kwargs,
 ):
+    if back_bounds is None:
+        back_bounds = []
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if not isinstance(model, Model):
         raise ValueError()
 

--- a/decomon/models/old_forward_cloning.py
+++ b/decomon/models/old_forward_cloning.py
@@ -214,16 +214,20 @@ def convert_forward(
     layer_fn=to_monotonic,
     input_dim=-1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    back_bounds=[],
+    back_bounds=None,
     **kwargs,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if back_bounds is None:
+        back_bounds = []
     if not isinstance(model, Model):
         raise ValueError()
 
@@ -251,20 +255,30 @@ def convert_forward_functional_model(
     layer_fn=to_monotonic,
     input_dim=1,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
     shared=True,
     softmax_to_linear=True,
-    layer_map={},
-    forward_map={},
-    name_history=set(),
+    layer_map=None,
+    forward_map=None,
+    name_history=None,
     finetune_output=False,
     opt_linear=True,  # detect linear successive parts by design
-    back_bounds=[],
+    back_bounds=None,
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
+    if name_history is None:
+        name_history = set()
+    if back_bounds is None:
+        back_bounds = []
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
 

--- a/decomon/models/tmp_clone_backward.py
+++ b/decomon/models/tmp_clone_backward.py
@@ -363,17 +363,25 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, **kwargs
 def get_backward_model(
     model,
     input_tensors=None,
-    back_bounds=[],
+    back_bounds=None,
     input_dim=-1,
-    convex_domain={},
+    convex_domain=None,
     IBP=True,
     forward=True,
     finetune=False,
-    layer_map={},
-    forward_map={},
+    layer_map=None,
+    forward_map=None,
     fuse_with_input=True,
     **kwargs,
 ):
+    if back_bounds is None:
+        back_bounds = []
+    if convex_domain is None:
+        convex_domain = {}
+    if layer_map is None:
+        layer_map = {}
+    if forward_map is None:
+        forward_map = {}
     if not isinstance(model, Model):
         raise ValueError()
 

--- a/decomon/models/utils.py
+++ b/decomon/models/utils.py
@@ -365,9 +365,11 @@ def get_back_bounds_model(back_bounds, model):
 
 
 def fuse_forward_backward(
-    mode, inputs, back_bounds, upper_layer=None, lower_layer=None, convex_domain={}, x_tensor=None
+    mode, inputs, back_bounds, upper_layer=None, lower_layer=None, convex_domain=None, x_tensor=None
 ):
 
+    if convex_domain is None:
+        convex_domain = {}
     if mode in [F_IBP.name, F_HYBRID.name]:
 
         if upper_layer is None:

--- a/decomon/numpy/backward/activation.py
+++ b/decomon/numpy/backward/activation.py
@@ -26,14 +26,14 @@ LINEAR = "linear"
 def backward_relu(
     x,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     alpha=0.0,
     max_value=None,
     threshold=0.0,
     slope=V_slope.name,
     mode=F_FORWARD.name,
     previous=False,
-    params=[],
+    params=None,
     **kwargs,
 ):
     """
@@ -49,6 +49,10 @@ def backward_relu(
     :return:
     """
 
+    if params is None:
+        params = []
+    if convex_domain is None:
+        convex_domain = {}
     if dc_decomp:
         raise NotImplementedError()
 
@@ -71,11 +75,11 @@ def backward_relu(
 def backward_sigmoid(
     inputs,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_FORWARD.name,
     previous=True,
-    params=[],
+    params=None,
     **kwargs,
 ):
     """
@@ -87,17 +91,21 @@ def backward_sigmoid(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     raise NotImplementedError()
 
 
 def backward_tanh(
     inputs,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_FORWARD.name,
     previous=True,
-    params=[],
+    params=None,
     **kwargs,
 ):
     """
@@ -109,11 +117,22 @@ def backward_tanh(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     raise NotImplementedError()
 
 
 def backward_hard_sigmoid(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=True, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=True,
+    params=None,
+    **kwargs,
 ):
     """
     Backward  LiRPA of hard sigmoid
@@ -125,6 +144,10 @@ def backward_hard_sigmoid(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -133,7 +156,14 @@ def backward_hard_sigmoid(
 
 
 def backward_elu(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=True, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=True,
+    params=None,
+    **kwargs,
 ):
     """
     Backward  LiRPA of Exponential Linear Unit
@@ -145,6 +175,10 @@ def backward_elu(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -153,7 +187,14 @@ def backward_elu(
 
 
 def backward_selu(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=True, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=True,
+    params=None,
+    **kwargs,
 ):
     """
     Backward LiRPA of Scaled Exponential Linear Unit (SELU)
@@ -165,6 +206,10 @@ def backward_selu(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -173,7 +218,14 @@ def backward_selu(
 
 
 def backward_linear(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=False, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=False,
+    params=None,
+    **kwargs,
 ):
     """
     Backward LiRPA of linear
@@ -184,6 +236,10 @@ def backward_linear(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if previous:
         z, _, _, _, _, w_b_u, b_b_u, w_b_l, b_b_l = x
         return [z, w_b_u, b_b_u, w_b_l, b_b_l]
@@ -197,7 +253,14 @@ def backward_linear(
 
 
 def backward_exponential(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=True, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=True,
+    params=None,
+    **kwargs,
 ):
     """
     Backward LiRPAof exponential
@@ -208,6 +271,10 @@ def backward_exponential(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -216,7 +283,14 @@ def backward_exponential(
 
 
 def backward_softplus(
-    x, dc_decomp=False, convex_domain={}, slope=V_slope.name, mode=F_FORWARD.name, previous=True, params=[], **kwargs
+    x,
+    dc_decomp=False,
+    convex_domain=None,
+    slope=V_slope.name,
+    mode=F_FORWARD.name,
+    previous=True,
+    params=None,
+    **kwargs,
 ):
     """
     Backward LiRPA of softplus
@@ -228,6 +302,10 @@ def backward_softplus(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -238,11 +316,11 @@ def backward_softplus(
 def backward_softsign(
     inputs,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_FORWARD.name,
     previous=True,
-    params=[],
+    params=None,
     **kwargs,
 ):
     """
@@ -257,6 +335,10 @@ def backward_softsign(
     :param mode:
     :return:
     """
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 
@@ -267,12 +349,12 @@ def backward_softsign(
 def backward_softmax(
     x,
     dc_decomp=False,
-    convex_domain={},
+    convex_domain=None,
     slope=V_slope.name,
     mode=F_FORWARD.name,
     previous=True,
     axis=-1,
-    params=[],
+    params=None,
     **kwargs,
 ):
     """
@@ -287,6 +369,10 @@ def backward_softmax(
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     if dc_decomp:
         raise NotImplementedError()
 

--- a/decomon/numpy/backward/core.py
+++ b/decomon/numpy/backward/core.py
@@ -8,7 +8,7 @@ CROWN implementation in numpy (useful for MILP compatibility)
 
 
 class BackwardNumpyLayer(object):
-    def __init__(self, keras_layer, convex_domain={}, mode=F_FORWARD.name, rec=1, params=[], **kwargs):
+    def __init__(self, keras_layer, convex_domain=None, mode=F_FORWARD.name, rec=1, params=None, **kwargs):
         """
 
         :param convex_domain: type of convex input domain (None or dict)
@@ -17,6 +17,10 @@ class BackwardNumpyLayer(object):
         :param mode: type of Forward propagation (IBP, Forward or Hybrid)
         :param kwargs: extra parameters
         """
+        if convex_domain is None:
+            convex_domain = {}
+        if params is None:
+            params = []
         self.update_slope = False
         self.reuse_slope = False
         if "update_slope" in kwargs:
@@ -39,10 +43,14 @@ class BackwardNumpyLayer(object):
 
         pass
 
-    def store_layer(self, joint=False, convex_domain={}, reuse_slope=False):
+    def store_layer(self, joint=False, convex_domain=None, reuse_slope=False):
+        if convex_domain is None:
+            convex_domain = {}
         return False
 
-    def store_output(self, joint=False, convex_domain={}, reuse_slope=False):
+    def store_output(self, joint=False, convex_domain=None, reuse_slope=False):
+        if convex_domain is None:
+            convex_domain = {}
         return True
 
     def update(self, x, params):

--- a/decomon/numpy/backward/layers.py
+++ b/decomon/numpy/backward/layers.py
@@ -15,7 +15,9 @@ CROWN implementation in numpy (useful for MILP compatibility)
 
 
 class BackwardNumpyActivation(BackwardNumpyLayer):
-    def __init__(self, keras_layer, previous=False, convex_domain={}, mode=F_FORWARD.name, rec=1, params=[], **kwargs):
+    def __init__(
+        self, keras_layer, previous=False, convex_domain=None, mode=F_FORWARD.name, rec=1, params=None, **kwargs
+    ):
         """
 
         :param convex_domain: type of convex input domain (None or dict)
@@ -27,6 +29,10 @@ class BackwardNumpyActivation(BackwardNumpyLayer):
         super(BackwardNumpyActivation, self).__init__(
             keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, params=params, **kwargs
         )
+        if convex_domain is None:
+            convex_domain = {}
+        if params is None:
+            params = []
         self.activation_name = keras_layer.get_config()["activation"]
         self.activation = get(keras_layer.get_config()["activation"])
 
@@ -65,13 +71,17 @@ class BackwardNumpyActivation(BackwardNumpyLayer):
     def call_no_previous(self, inputs, **kwargs):
         return self.activation(inputs, convex_domain=self.convex_domain, mode=self.mode, params=self.params, **kwargs)
 
-    def store_output(self, joint=False, convex_domain={}, reuse_slope=False):
+    def store_output(self, joint=False, convex_domain=None, reuse_slope=False):
+        if convex_domain is None:
+            convex_domain = {}
         if joint:
             return not reuse_slope
 
         return False
 
-    def store_layer(self, joint=False, convex_domain={}, reuse_slope=False):
+    def store_layer(self, joint=False, convex_domain=None, reuse_slope=False):
+        if convex_domain is None:
+            convex_domain = {}
         if joint:
             return not reuse_slope
 
@@ -80,7 +90,7 @@ class BackwardNumpyActivation(BackwardNumpyLayer):
 
 class BackwardNumpyInputLayer(BackwardNumpyLayer):
     def __init__(
-        self, keras_layer, previous=False, fusion=True, convex_domain={}, mode=F_FORWARD.name, rec=1, **kwargs
+        self, keras_layer, previous=False, fusion=True, convex_domain=None, mode=F_FORWARD.name, rec=1, **kwargs
     ):
         """
 
@@ -94,6 +104,8 @@ class BackwardNumpyInputLayer(BackwardNumpyLayer):
             keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs
         )
 
+        if convex_domain is None:
+            convex_domain = {}
         if not isinstance(self.keras_layer, InputLayer):
             raise KeyError()
 
@@ -126,7 +138,7 @@ class BackwardNumpyInputLayer(BackwardNumpyLayer):
 
 
 class BackwardNumpyDense(BackwardNumpyLayer):
-    def __init__(self, keras_layer, previous=False, convex_domain={}, mode=F_FORWARD.name, rec=1, **kwargs):
+    def __init__(self, keras_layer, previous=False, convex_domain=None, mode=F_FORWARD.name, rec=1, **kwargs):
         """
 
         :param convex_domain: type of convex input domain (None or dict)
@@ -139,6 +151,8 @@ class BackwardNumpyDense(BackwardNumpyLayer):
             keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs
         )
 
+        if convex_domain is None:
+            convex_domain = {}
         if not isinstance(self.keras_layer, Dense):
             raise KeyError()
 
@@ -179,10 +193,14 @@ class BackwardNumpyDense(BackwardNumpyLayer):
         return [w_, b_, w_, b_]
 
 
-def get_backward(keras_layer, previous=True, mode=F_FORWARD.name, convex_domain={}, rec=1, params=[], **kwargs):
+def get_backward(keras_layer, previous=True, mode=F_FORWARD.name, convex_domain=None, rec=1, params=None, **kwargs):
 
     # do it better
     # either a Decomon layer or its pure Keras version
+    if convex_domain is None:
+        convex_domain = {}
+    if params is None:
+        params = []
     class_name = keras_layer.__class__.__name__
 
     backward_class_name = "BackwardNumpy{}".format(class_name)

--- a/decomon/numpy/backward/utils.py
+++ b/decomon/numpy/backward/utils.py
@@ -29,7 +29,9 @@ def get_upper_box(x, w, b):
     return np.sum(np.maximum(0.0, w) * x[:, 1, :, None], 1) + np.sum(np.minimum(0.0, w) * x[:, 0, :, None], 1) + b
 
 
-def get_lower(x, w, b, convex_domain={}):
+def get_lower(x, w, b, convex_domain=None):
+    if convex_domain is None:
+        convex_domain = {}
     if not len(convex_domain) or convex_domain["name"] in [Box.name, Grid.name]:
         return get_lower_box(x, w, b)
     else:
@@ -38,7 +40,9 @@ def get_lower(x, w, b, convex_domain={}):
         )
 
 
-def get_upper(x, w, b, convex_domain={}):
+def get_upper(x, w, b, convex_domain=None):
+    if convex_domain is None:
+        convex_domain = {}
     if not len(convex_domain) or convex_domain["name"] in [Box.name, Grid.name]:
         return get_upper_box(x, w, b)
     else:
@@ -47,17 +51,21 @@ def get_upper(x, w, b, convex_domain={}):
         )
 
 
-def get_linear_hull_relu(inputs, convex_domain, params=[], **kwargs):
+def get_linear_hull_relu(inputs, convex_domain, params=None, **kwargs):
 
+    if params is None:
+        params = []
     if len(convex_domain) and convex_domain["name"] == Grid.name:
         return get_linear_hull_relu_quantized(inputs, convex_domain=convex_domain, params=params, **kwargs)
     else:
         return get_linear_hull_relu_continuous(inputs, convex_domain=convex_domain, **kwargs)
 
 
-def get_linear_hull_relu_quantized(inputs, convex_domain, params=[], **kwargs):
+def get_linear_hull_relu_quantized(inputs, convex_domain, params=None, **kwargs):
 
     # compute upper, lower, A, B
+    if params is None:
+        params = []
     x, w_f_u, b_f_u, w_f_l, b_f_l = inputs[:5]
     # computer upper and lower bounds
 
@@ -397,8 +405,10 @@ def get_linear_lower_crown_old(upper, lower, A, B):
     return [w_l, b_l]
 
 
-def get_linear_hull_relu_continuous(inputs, convex_domain={}, **kwargs):
+def get_linear_hull_relu_continuous(inputs, convex_domain=None, **kwargs):
 
+    if convex_domain is None:
+        convex_domain = {}
     x, w_f_u, b_f_u, w_f_l, b_f_l = inputs[:5]
     # computer upper and lower bounds
     upper = get_upper(x, w_f_u, b_f_u, convex_domain)

--- a/decomon/numpy/models/backward_cloning.py
+++ b/decomon/numpy/models/backward_cloning.py
@@ -11,19 +11,33 @@ from ..backward.utils import merge_with_previous
 
 def crown_(
     node,
-    backward_bounds=[],
-    forward_init=[],
-    log_bounds=dict(),
-    log_layers={},
-    convex_domain={},
-    dico_grid={},
-    slope_grid={},
+    backward_bounds=None,
+    forward_init=None,
+    log_bounds=None,
+    log_layers=None,
+    convex_domain=None,
+    dico_grid=None,
+    slope_grid=None,
     update_slope=False,
     reuse_slope=True,
     joint=False,
     rec=1,
 ):
 
+    if backward_bounds is None:
+        backward_bounds = []
+    if forward_init is None:
+        forward_init = []
+    if log_bounds is None:
+        log_bounds = dict()
+    if log_layers is None:
+        log_layers = {}
+    if convex_domain is None:
+        convex_domain = {}
+    if dico_grid is None:
+        dico_grid = {}
+    if slope_grid is None:
+        slope_grid = {}
     previous = bool(len(backward_bounds))
 
     params_key = "{}_{}".format(node.outbound_layer.name, rec)
@@ -133,16 +147,28 @@ def crown_(
 
 def crown_old(
     node,
-    backward_bounds=[],
-    forward_init=[],
-    log_bounds=dict(),
-    convex_domain={},
-    dico_grid={},
-    slope_grid={},
+    backward_bounds=None,
+    forward_init=None,
+    log_bounds=None,
+    convex_domain=None,
+    dico_grid=None,
+    slope_grid=None,
     update_slope=False,
     reuse_slope=True,
     rec=1,
 ):
+    if backward_bounds is None:
+        backward_bounds = []
+    if forward_init is None:
+        forward_init = []
+    if log_bounds is None:
+        log_bounds = dict()
+    if convex_domain is None:
+        convex_domain = {}
+    if dico_grid is None:
+        dico_grid = {}
+    if slope_grid is None:
+        slope_grid = {}
     previous = bool(len(backward_bounds))
 
     params_key = "{}_{}".format(node.outbound_layer.name, rec)
@@ -222,16 +248,26 @@ def crown_old(
 
 def crown(
     model,
-    backward_bounds=[],
-    forward_init=[],
-    convex_domain={},
-    dico_grid={},
-    slope_grid={},
+    backward_bounds=None,
+    forward_init=None,
+    convex_domain=None,
+    dico_grid=None,
+    slope_grid=None,
     reuse_slope=False,
     update_slope=False,
     joint=False,
 ):
     # get nodes by depth
+    if backward_bounds is None:
+        backward_bounds = []
+    if forward_init is None:
+        forward_init = []
+    if convex_domain is None:
+        convex_domain = {}
+    if dico_grid is None:
+        dico_grid = {}
+    if slope_grid is None:
+        slope_grid = {}
     outputs_nodes = model._nodes_by_depth[0][0]
 
     if len(forward_init) == 1:
@@ -261,15 +297,21 @@ class NumpyModel(object):
         model,
         ibp=False,
         forward=True,
-        convex_domain={},
+        convex_domain=None,
         has_back_bounds=False,
-        dico_grid={},
-        slope_grid={},
+        dico_grid=None,
+        slope_grid=None,
         update_slope=False,
         reuse_slope=False,
         joint=False,
         **kwargs,
     ):
+        if convex_domain is None:
+            convex_domain = {}
+        if dico_grid is None:
+            dico_grid = {}
+        if slope_grid is None:
+            slope_grid = {}
         self.IBP = ibp
         self.forward = forward
         self.convex_domain = convex_domain
@@ -291,10 +333,10 @@ class NumpyCROWNModel(NumpyModel):
         model,
         ibp=False,
         forward=True,
-        convex_domain={},
+        convex_domain=None,
         has_back_bounds=False,
-        dico_grid={},
-        slope_grid={},
+        dico_grid=None,
+        slope_grid=None,
         update_slope=False,
         reuse_slope=False,
         joint=False,
@@ -313,6 +355,12 @@ class NumpyCROWNModel(NumpyModel):
             joint=joint,
             **kwargs,
         )
+        if convex_domain is None:
+            convex_domain = {}
+        if dico_grid is None:
+            dico_grid = {}
+        if slope_grid is None:
+            slope_grid = {}
 
     def predict(self, inputs):
         if not isinstance(inputs, list):

--- a/decomon/numpy/models/convert.py
+++ b/decomon/numpy/models/convert.py
@@ -3,19 +3,25 @@ from .backward_cloning import NumpyCROWNModel
 
 def clone(
     model,
-    convex_domain={},
+    convex_domain=None,
     ibp=False,
     forward=True,
     method="crown",
-    back_bounds=[],
+    back_bounds=None,
     shared=True,
-    dico_grid={},
+    dico_grid=None,
     final_ibp=True,
     final_forward=True,
     **kwargs,
 ):
 
     # use shared in the layers
+    if convex_domain is None:
+        convex_domain = {}
+    if back_bounds is None:
+        back_bounds = []
+    if dico_grid is None:
+        dico_grid = {}
     if method != "crown":
         raise NotImplementedError()
     if not shared:

--- a/decomon/utils.py
+++ b/decomon/utils.py
@@ -257,7 +257,7 @@ def get_lower_ball(x_0, eps, p, w, b):
         return K.sum(w * x_0, 1) + lower
 
 
-def get_upper(x, w, b, convex_domain={}):
+def get_upper(x, w, b, convex_domain=None):
     """
     Meta function that aggregates all the way
     to compute a constant upper bounds depending on the convex domain
@@ -268,6 +268,8 @@ def get_upper(x, w, b, convex_domain={}):
     :return: a constant upper bound of the affine function
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     if convex_domain is None or len(convex_domain) == 0:
         # box
         x_min = x[:, 0]
@@ -291,7 +293,7 @@ def get_upper(x, w, b, convex_domain={}):
     raise NotImplementedError()
 
 
-def get_lower(x, w, b, convex_domain={}):
+def get_lower(x, w, b, convex_domain=None):
     """
      Meta function that aggregates all the way
      to compute a constant lower bound depending on the convex domain
@@ -301,6 +303,8 @@ def get_lower(x, w, b, convex_domain={}):
     :param convex_domain: the type of convex domain (see ???)
     :return: a constant upper bound of the affine function
     """
+    if convex_domain is None:
+        convex_domain = {}
     if convex_domain is None or len(convex_domain) == 0:
 
         # box
@@ -327,14 +331,20 @@ def get_lower(x, w, b, convex_domain={}):
     raise NotImplementedError()
 
 
-def get_lower_layer(convex_domain={}):
+def get_lower_layer(convex_domain=None):
+    if convex_domain is None:
+        convex_domain = {}
+
     def func(inputs):
         return get_lower(inputs[0], inputs[1], inputs[2], convex_domain=convex_domain)
 
     return Lambda(func)
 
 
-def get_upper_layer(convex_domain={}):
+def get_upper_layer(convex_domain=None):
+    if convex_domain is None:
+        convex_domain = {}
+
     def func(inputs):
         return get_upper(inputs[0], inputs[1], inputs[2], convex_domain=convex_domain)
 
@@ -571,7 +581,7 @@ def get_linear_softplus_hull(upper, lower, slope, **kwargs):
     return [w_u_, b_u_, w_l_, b_l_]
 
 
-def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of element-wise max
 
@@ -582,6 +592,8 @@ def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     :param convex_domain: the type of convex domain
     :return: maximum(inputs_0, inputs_1)
     """
+    if convex_domain is None:
+        convex_domain = {}
     output_0 = substract(inputs_1, inputs_0, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
     output_1 = relu_(
         output_0,
@@ -599,7 +611,7 @@ def maximum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     )
 
 
-def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID.name):
+def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name):
     """
     LiRPA implementation of element-wise min
 
@@ -611,10 +623,12 @@ def minimum(inputs_0, inputs_1, dc_decomp=False, convex_domain={}, mode=F_HYBRID
     :return:
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     return minus(maximum(minus(inputs_0), minus(inputs_1), dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode))
 
 
-def get_linear_hull_s_shape(x, func=K.sigmoid, f_prime=sigmoid_prime, convex_domain={}, mode=F_HYBRID.name, **kwargs):
+def get_linear_hull_s_shape(x, func=K.sigmoid, f_prime=sigmoid_prime, convex_domain=None, mode=F_HYBRID.name, **kwargs):
     """
     Computing the linear hull of shape functions  given the pre activation neurons
 
@@ -626,6 +640,8 @@ def get_linear_hull_s_shape(x, func=K.sigmoid, f_prime=sigmoid_prime, convex_dom
     :return: the updated list of tensors
     """
 
+    if convex_domain is None:
+        convex_domain = {}
     z_value = K.cast(0.0, dtype=x[0].dtype)
     o_value = K.cast(1.0, dtype=x[0].dtype)
     t_value = K.cast(2.0, dtype=x[0].dtype)
@@ -812,8 +828,10 @@ def get_t_lower(u_c_flat, l_c_flat, s_u, func=K.sigmoid, f_prime=sigmoid_prime):
     return [w_l, b_l]
 
 
-def set_mode(x, final_mode, mode, convex_domain={}):
+def set_mode(x, final_mode, mode, convex_domain=None):
 
+    if convex_domain is None:
+        convex_domain = {}
     if final_mode == mode:
         return x
 

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -121,8 +121,10 @@ def toy_struct_cnn(dtype="float32"):
 # @pytest.mark.parametrize(
 #    "n, activation, mode, shared, floatx",
 #
-def test_toy_network_1D(n=0, archi=[4, 1], activation="relu", use_bias=True):
+def test_toy_network_1D(n=0, archi=None, activation="relu", use_bias=True):
 
+    if archi is None:
+        archi = [4, 1]
     inputs = get_tensor_decomposition_1d_box()
     inputs_ = get_standart_values_1d_box(n)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
@@ -140,8 +142,10 @@ def test_toy_network_1D(n=0, archi=[4, 1], activation="relu", use_bias=True):
     np.allclose(y_0, y_1)
 
 
-def test_toy_network_multiD(odd=0, archi=[4, 1], activation="relu", use_bias=True):
+def test_toy_network_multiD(odd=0, archi=None, activation="relu", use_bias=True):
 
+    if archi is None:
+        archi = [4, 1]
     inputs = get_tensor_decomposition_multid_box(odd)
     inputs_ = get_standard_values_multid_box(odd)
 


### PR DESCRIPTION
Using mutable default arguments in python can lead to tricky bugs. See
https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments for more information about it.