### PR TITLE
Clean code with changes proposed by code.review.doctor

### DIFF
--- a/decomon/applications/cv/wrapper.py
+++ b/decomon/applications/cv/wrapper.py
@@ -69,7 +69,7 @@ def get_adv_brightness(
     z[:, 0] = bright_min
     z[:, 1] = bright_max
 
-    if isinstance(source_labels, int) or isinstance(source_labels, np.int64):
+    if isinstance(source_labels, (int, np.int64)):
         source_labels = np.zeros((len(x_), 1)) + source_labels
 
     if isinstance(source_labels, list):

--- a/decomon/backward_layers/backward_layers.py
+++ b/decomon/backward_layers/backward_layers.py
@@ -701,14 +701,14 @@ class BackwardActivation(BackwardLayer):
             finetune_grid_A = self.add_weight(
                 shape=(input_dim,),
                 initializer="zeros",
-                name="A_{}_{}".format(self.layer.name, self.rec),
+                name=f"A_{self.layer.name}_{self.rec}",
                 regularizer=None,
                 trainable=False,
             )  # constraint=NonPos()
             finetune_grid_B = self.add_weight(
                 shape=(input_dim,),
                 initializer="zeros",
-                name="B_{}_{}".format(self.layer.name, self.rec),
+                name=f"B_{self.layer.name}_{self.rec}",
                 regularizer=None,
                 trainable=False,
             )  # constraint=NonNeg()
@@ -1133,7 +1133,7 @@ def get_backward(
     if class_name[:7] == "Decomon":
         class_name = "".join(layer.__class__.__name__.split("Decomon")[1:])
 
-    backward_class_name = "Backward{}".format(class_name)
+    backward_class_name = f"Backward{class_name}"
     class_ = globals()[backward_class_name]
     try:
         return class_(

--- a/decomon/backward_layers/backward_layers.py
+++ b/decomon/backward_layers/backward_layers.py
@@ -59,7 +59,7 @@ class BackwardDense(BackwardLayer):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardDense, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -322,7 +322,7 @@ class BackwardConv2D(BackwardLayer):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardConv2D, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -581,7 +581,7 @@ class BackwardActivation(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super(BackwardActivation, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -854,7 +854,7 @@ class BackwardFlatten(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super(BackwardFlatten, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.previous = previous
@@ -886,7 +886,7 @@ class BackwardReshape(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super(BackwardReshape, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.previous = previous
@@ -949,7 +949,7 @@ class BackwardPermute(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super(BackwardPermute, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.dims = layer.dims
@@ -1006,7 +1006,7 @@ class BackwardDropout(BackwardLayer):
         rec=1,
         **kwargs,
     ):
-        super(BackwardDropout, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
 
@@ -1036,7 +1036,7 @@ class BackwardBatchNormalization(BackwardLayer):
     """
 
     def __init__(self, layer, slope=V_slope.name, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs):
-        super(BackwardBatchNormalization, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         if not isinstance(layer, DecomonBatchNormalization):
@@ -1091,7 +1091,7 @@ class BackwardInputLayer(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super(BackwardInputLayer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.layer = layer

--- a/decomon/backward_layers/backward_maxpooling.py
+++ b/decomon/backward_layers/backward_maxpooling.py
@@ -29,7 +29,7 @@ class BackwardMaxPooling2D(Layer):
         input_dim=-1,
         **kwargs,
     ):  # __init__(self, layer, slope=V_slope.name,
-        super(BackwardMaxPooling2D, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if convex_domain is None:
             convex_domain = {}
         raise NotImplementedError()

--- a/decomon/backward_layers/backward_merge.py
+++ b/decomon/backward_layers/backward_merge.py
@@ -34,7 +34,7 @@ from .utils import (
 
 class BackwardMerge(BackwardLayer):
     def __init__(self, **kwargs):
-        super(BackwardMerge, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class BackwardAdd(BackwardMerge):
@@ -53,7 +53,7 @@ class BackwardAdd(BackwardMerge):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardAdd, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # if not isinstance(layer, DecomonAdd):
         #    raise KeyError()
         if convex_domain is None:
@@ -199,7 +199,7 @@ class BackwardAverage(BackwardMerge):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardAverage, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -292,7 +292,7 @@ class BackwardSubtract(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardSubtract, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonSubtract):
             raise KeyError()
 
@@ -334,7 +334,7 @@ class BackwardMaximum(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardMaximum, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonMaximum):
             raise KeyError()
 
@@ -376,7 +376,7 @@ class BackwardMinimum(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardMinimum, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonMinimum):
             raise KeyError()
 
@@ -418,7 +418,7 @@ class BackwardConcatenate(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardConcatenate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonConcatenate):
             raise KeyError()
 
@@ -458,7 +458,7 @@ class BackwardMultiply(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardMultiply, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonMultiply):
             raise KeyError()
 
@@ -500,7 +500,7 @@ class BackwardDot(BackwardMerge):
     """
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super(BackwardDot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if not isinstance(layer, DecomonDot):
             raise KeyError()
 

--- a/decomon/backward_layers/core.py
+++ b/decomon/backward_layers/core.py
@@ -5,7 +5,7 @@ from tensorflow.keras.layers import Layer
 
 class BackwardLayer(Layer):
     def __init__(self, rec=1, **kwargs):
-        super(BackwardLayer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.rec = rec
 
     def set_previous(self, previous):

--- a/decomon/backward_layers/deel_lip.py
+++ b/decomon/backward_layers/deel_lip.py
@@ -43,7 +43,7 @@ class BackwardDense(Layer):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardDense, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -95,7 +95,7 @@ class BackwardGroupSort2(Layer):
         input_dim=-1,
         **kwargs,
     ):
-        super(BackwardGroupSort2, self).__init__(kwargs)
+        super().__init__(kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.layer = layer

--- a/decomon/gradient/gradient_layers.py
+++ b/decomon/gradient/gradient_layers.py
@@ -38,7 +38,7 @@ class GradientDense(Layer):
         input_dim=-1,
         **kwargs,
     ):
-        super(GradientDense, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}

--- a/decomon/gradient/utils.py
+++ b/decomon/gradient/utils.py
@@ -11,7 +11,7 @@ def gradient_relu(inputs, dc_decomp=False, mode=F_HYBRID.name, convex_domain=Non
     if convex_domain is None:
         convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
-        raise ValueError("unknown mode {}".format(mode))
+        raise ValueError(f"unknown mode {mode}")
 
     z_value = K.cast(0.0, K.floatx())
     o_value = K.cast(1.0, K.floatx())

--- a/decomon/layers/core.py
+++ b/decomon/layers/core.py
@@ -72,7 +72,7 @@ class StaticVariables:
         elif self.mode == F_FORWARD.name:
             nb_tensors = 5
         else:
-            raise NotImplementedError("unknown forward mode {}".format(mode))
+            raise NotImplementedError(f"unknown forward mode {mode}")
 
         if dc_decomp:
             nb_tensors += 2

--- a/decomon/layers/core.py
+++ b/decomon/layers/core.py
@@ -103,7 +103,7 @@ class DecomonLayer(ABC, Layer):
         :param mode: type of Forward propagation (IBP, Forward or Hybrid)
         :param kwargs: extra parameters
         """
-        super(DecomonLayer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if convex_domain is None:
             convex_domain = {}

--- a/decomon/layers/decomon_layers.py
+++ b/decomon/layers/decomon_layers.py
@@ -81,7 +81,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
         activation = kwargs["activation"]
         if "activation" in kwargs:
             kwargs["activation"] = None
-        super(DecomonConv2D, self).__init__(filters=filters, kernel_size=kernel_size, mode=mode, **kwargs)
+        super().__init__(filters=filters, kernel_size=kernel_size, mode=mode, **kwargs)
         self.kernel_constraint_pos_ = NonNeg()
         self.kernel_constraint_neg_ = NonPos()
 
@@ -713,7 +713,7 @@ class DecomonDense(Dense, DecomonLayer):
         activation = kwargs["activation"]
         kwargs["units"] = units
         kwargs["kernel_constraint"] = None
-        super(DecomonDense, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
         self.mode = mode
         self.kernel_constraint_pos_ = NonNeg()
         self.kernel_constraint_neg_ = NonPos()
@@ -1311,7 +1311,7 @@ class DecomonActivation(Activation, DecomonLayer):
 
     def __init__(self, activation, mode=F_HYBRID.name, **kwargs):
 
-        super(DecomonActivation, self).__init__(activation, mode=mode, **kwargs)
+        super().__init__(activation, mode=mode, **kwargs)
 
         self.supports_masking = True
         self.activation = activations.get(activation)
@@ -1403,7 +1403,7 @@ class DecomonFlatten(Flatten, DecomonLayer):
         :param kwargs:
 
         """
-        super(DecomonFlatten, self).__init__(data_format=data_format, mode=mode, **kwargs)
+        super().__init__(data_format=data_format, mode=mode, **kwargs)
 
         if self.mode == F_HYBRID.name:
             self.input_spec = [
@@ -1446,7 +1446,7 @@ class DecomonFlatten(Flatten, DecomonLayer):
 
     def call(self, inputs):
 
-        op = super(DecomonFlatten, self).call
+        op = super().call
 
         if self.dc_decomp:
             h, g = inputs[-2:]
@@ -1517,7 +1517,7 @@ class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
         mode=F_HYBRID.name,
         **kwargs,
     ):
-        super(DecomonBatchNormalization, self).__init__(
+        super().__init__(
             axis=axis,
             momentum=momentum,
             epsilon=epsilon,
@@ -1536,13 +1536,13 @@ class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
         )
 
     def build(self, input_shape):
-        super(DecomonBatchNormalization, self).build(input_shape[0])
+        super().build(input_shape[0])
 
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
     def compute_output_shape(self, input_shape):
 
-        output_shape_ = super(DecomonBatchNormalization, self).compute_output_shape(input_shape[-1])
+        output_shape_ = super().compute_output_shape(input_shape[-1])
 
         if self.mode in [F_FORWARD.name, F_HYBRID.name]:
             x_shape = input_shape[0]
@@ -1577,7 +1577,7 @@ class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
         if training:
             raise NotImplementedError("not working during training")
 
-        call_op = super(DecomonBatchNormalization, self).call
+        call_op = super().call
 
         if self.dc_decomp:
             raise NotImplementedError()
@@ -1660,13 +1660,13 @@ class DecomonDropout(Dropout, DecomonLayer):
     """
 
     def __init__(self, rate, noise_shape=None, seed=None, mode=F_HYBRID.name, **kwargs):
-        super(DecomonDropout, self).__init__(rate=rate, noise_shape=noise_shape, seed=seed, mode=mode, **kwargs)
+        super().__init__(rate=rate, noise_shape=noise_shape, seed=seed, mode=mode, **kwargs)
 
     def compute_output_shape(self, input_shape):
         return input_shape
 
     def build(self, input_shape):
-        super(DecomonDropout, self).build(input_shape[0])
+        super().build(input_shape[0])
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
     def call(self, inputs, training=None):
@@ -1680,7 +1680,7 @@ class DecomonDropout(Dropout, DecomonLayer):
 
         return inputs
 
-        call_op = super(DecomonDropout, self).call
+        call_op = super().call
 
         if self.mode == F_HYBRID.name:
             if self.dc_decomp:
@@ -1752,7 +1752,7 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
     ):
 
         if type_spec is not None:
-            super(DecomonInputLayer, self).__init__(
+            super().__init__(
                 input_shape=input_shape,
                 batch_size=batch_size,
                 dtype=dtype,
@@ -1765,7 +1765,7 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
                 **kwargs,
             )
         else:
-            super(DecomonInputLayer, self).__init__(
+            super().__init__(
                 input_shape=input_shape,
                 batch_size=batch_size,
                 dtype=dtype,

--- a/decomon/layers/decomon_layers.py
+++ b/decomon/layers/decomon_layers.py
@@ -269,7 +269,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
             raise ValueError("A merge layer should be called " "on a list of inputs.")
 
         if self.mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
-            raise ValueError("unknown  forward mode {}".format(self.mode))
+            raise ValueError(f"unknown  forward mode {self.mode}")
 
         if self.mode == F_HYBRID.name:
             if self.dc_decomp:
@@ -1241,7 +1241,7 @@ class DecomonDense(Dense, DecomonLayer):
                 params += self.get_weights()[2:]
             self.set_weights(params)
         else:
-            raise ValueError("the layer {} has not been built yet".format(dense.name))
+            raise ValueError(f"the layer {dense.name} has not been built yet")
 
     def freeze_weights(self):
 
@@ -1827,7 +1827,7 @@ def to_monotonic(
     # check if layer has a built argument that built is set to True
     if hasattr(layer, "built"):
         if not layer.built:
-            raise ValueError("the layer {} has not been built yet".format(layer.name))
+            raise ValueError(f"the layer {layer.name} has not been built yet")
 
     if isinstance(layer, Merge):
         return to_monotonic_merge(layer, input_dim, dc_decomp, convex_domain, finetune, IBP, forward)
@@ -1838,10 +1838,10 @@ def to_monotonic(
         # two runs before sending a failure
         if k == 2:
             # the immediate parent is not a native Keras class
-            raise KeyError("unknown class {}".format(class_name))
+            raise KeyError(f"unknown class {class_name}")
         try:
 
-            monotonic_class_name = "Decomon{}".format(class_name)
+            monotonic_class_name = f"Decomon{class_name}"
             config_layer = layer.get_config()
             config_layer["name"] = layer.name + "_monotonic"
             config_layer["dc_decomp"] = dc_decomp

--- a/decomon/layers/decomon_layers.py
+++ b/decomon/layers/decomon_layers.py
@@ -124,7 +124,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=4), InputSpec(min_ndim=4)]
 
-        self.diag_op = Lambda(lambda x: tf.linalg.diag(x))
+        self.diag_op = Lambda(tf.linalg.diag)
 
     def build(self, input_shape):
         """

--- a/decomon/layers/decomon_merge_layers.py
+++ b/decomon/layers/decomon_merge_layers.py
@@ -38,8 +38,8 @@ class DecomonAdd(Add, DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonAdd, self).__init__(mode=mode, **kwargs)
-        # self.op = super(DecomonAdd, self).call
+        super().__init__(mode=mode, **kwargs)
+        # self.op = super().call
 
     def build(self, input_shape):
         n_comp = self.nb_tensors
@@ -48,7 +48,7 @@ class DecomonAdd(Add, DecomonLayer):
         # if self.mode == F_HYBRID.name:
         #    n_comp = 8
         input_shape_y = input_shape[::n_comp]
-        super(DecomonAdd, self).build(input_shape_y)
+        super().build(input_shape_y)
 
     def compute_output_shape(self, input_shape):
         return input_shape  # ????
@@ -156,8 +156,8 @@ class DecomonAverage(Average, DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonAverage, self).__init__(mode=mode, **kwargs)
-        # self.op = super(DecomonAverage, self).call
+        super().__init__(mode=mode, **kwargs)
+        # self.op = super().call
         self.op = Lambda(lambda x: sum(x) / len(x))
 
     def compute_output_shape(self, input_shape):
@@ -171,7 +171,7 @@ class DecomonAverage(Average, DecomonLayer):
         # if self.mode == F_HYBRID.name:
         #    n_comp = 8
         input_shape_y = input_shape[::n_comp]
-        super(DecomonAverage, self).build(input_shape_y)
+        super().build(input_shape_y)
 
     def call(self, inputs):
 
@@ -244,7 +244,7 @@ class DecomonSubtract(DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonSubtract, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
 
     def compute_output_shape(self, input_shape):
 
@@ -277,7 +277,7 @@ class DecomonMinimum(DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonMinimum, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
 
     def compute_output_shape(self, input_shape):
 
@@ -322,7 +322,7 @@ class DecomonMaximum(DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonMaximum, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
 
     def compute_output_shape(self, input_shape):
         return input_shape  # ????
@@ -363,9 +363,9 @@ class DecomonConcatenate(Concatenate, DecomonLayer):
     """
 
     def __init__(self, axis=-1, mode=F_HYBRID.name, **kwargs):
-        super(DecomonConcatenate, self).__init__(axis=axis, mode=mode, **kwargs)
+        super().__init__(axis=axis, mode=mode, **kwargs)
 
-        self.op = super(DecomonConcatenate, self).call
+        self.op = super().call
         if self.axis == -1:
             self.op_w = self.op
         else:
@@ -387,7 +387,7 @@ class DecomonConcatenate(Concatenate, DecomonLayer):
             input_shape_y = input_shape[1::n_comp]
         if self.mode == F_FORWARD.name:
             input_shape_y = input_shape[2::n_comp]
-        super(DecomonConcatenate, self).build(input_shape_y)
+        super().build(input_shape_y)
 
     def call(self, inputs):
         if self.dc_decomp:
@@ -457,7 +457,7 @@ class DecomonMultiply(Multiply, DecomonLayer):
     """
 
     def __init__(self, mode=F_HYBRID.name, **kwargs):
-        super(DecomonMultiply, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
 
     def build(self, input_shape):
 
@@ -473,7 +473,7 @@ class DecomonMultiply(Multiply, DecomonLayer):
         if self.mode == F_FORWARD.name:
             input_shape_ = input_shape[2::n_comp]
         # input_shape_ = input_shape[::n_comp]
-        super(DecomonMultiply, self).build(input_shape_)
+        super().build(input_shape_)
 
     def call(self, inputs):
 
@@ -508,7 +508,7 @@ class DecomonDot(Dot, DecomonLayer):
     """
 
     def __init__(self, axes=(-1, -1), mode=F_HYBRID.name, **kwargs):
-        super(DecomonDot, self).__init__(axes=axes, mode=mode, **kwargs)
+        super().__init__(axes=axes, mode=mode, **kwargs)
         self.axes = axes
 
     def build(self, input_shape):
@@ -525,7 +525,7 @@ class DecomonDot(Dot, DecomonLayer):
         if self.mode == F_FORWARD.name:
             input_shape_ = input_shape[2::n_comp]
         # input_shape_ = input_shape[::n_comp]
-        super(DecomonDot, self).build(input_shape_)
+        super().build(input_shape_)
 
     def call(self, inputs):
 

--- a/decomon/layers/decomon_merge_layers.py
+++ b/decomon/layers/decomon_merge_layers.py
@@ -629,9 +629,9 @@ def to_monotonic_merge(
     # check if layer has a built argument that built is set to True
     if hasattr(layer, "built"):
         if not layer.built:
-            raise ValueError("the layer {} has not been built yet".format(layer.name))
+            raise ValueError(f"the layer {layer.name} has not been built yet")
 
-    monotonic_class_name = "Decomon{}".format(class_name)
+    monotonic_class_name = f"Decomon{class_name}"
     config_layer = layer.get_config()
     config_layer["name"] = layer.name + "_monotonic"
     config_layer["dc_decomp"] = dc_decomp

--- a/decomon/layers/decomon_reshape.py
+++ b/decomon/layers/decomon_reshape.py
@@ -21,7 +21,7 @@ class DecomonReshape(Reshape, DecomonLayer):
         :param kwargs:
 
         """
-        super(DecomonReshape, self).__init__(target_shape=target_shape, mode=mode, **kwargs)
+        super().__init__(target_shape=target_shape, mode=mode, **kwargs)
 
         if self.mode == F_HYBRID.name:
             self.input_spec = [
@@ -63,11 +63,11 @@ class DecomonReshape(Reshape, DecomonLayer):
         """
 
         y_input_shape = input_shape[0]
-        super(DecomonReshape, self).build(y_input_shape)
+        super().build(y_input_shape)
 
     def call(self, inputs):
 
-        op = super(DecomonReshape, self).call
+        op = super().call
         nb_tensors = self.nb_tensors
         if self.dc_decomp:
             h, g = inputs[-2:]
@@ -135,7 +135,7 @@ class DecomonPermute(Permute, DecomonLayer):
         :param kwargs:
 
         """
-        super(DecomonPermute, self).__init__(dims=dims, mode=mode, **kwargs)
+        super().__init__(dims=dims, mode=mode, **kwargs)
 
         if self.mode == F_HYBRID.name:
             self.input_spec = [
@@ -177,11 +177,11 @@ class DecomonPermute(Permute, DecomonLayer):
         """
 
         y_input_shape = input_shape[-1]
-        super(DecomonPermute, self).build(y_input_shape)
+        super().build(y_input_shape)
 
     def call(self, inputs):
 
-        op = super(DecomonPermute, self).call
+        op = super().call
         nb_tensors = self.nb_tensors
         if self.dc_decomp:
             h, g = inputs[-2:]

--- a/decomon/layers/deel_lip.py
+++ b/decomon/layers/deel_lip.py
@@ -59,7 +59,7 @@ except:
 
 class DecomonGroupSort(DecomonLayer):
     def __init__(self, n=None, data_format="channels_last", k_coef_lip=1.0, mode=F_HYBRID.name, **kwargs):
-        super(DecomonGroupSort, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mode = mode
 
         if data_format == "channels_last":
@@ -123,7 +123,7 @@ class DecomonGroupSort(DecomonLayer):
 
 class DecomonGroupSort2(DecomonLayer):
     def __init__(self, n=2, data_format="channels_last", k_coef_lip=1.0, mode=F_HYBRID.name, **kwargs):
-        super(DecomonGroupSort2, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mode = mode
         self.data_format = data_format
 

--- a/decomon/layers/maxpooling.py
+++ b/decomon/layers/maxpooling.py
@@ -25,7 +25,7 @@ class DecomonMaxPooling2D(MaxPooling2D, DecomonLayer):
         self, pool_size=(2, 2), strides=None, padding="valid", data_format=None, mode=F_HYBRID.name, fast=True, **kwargs
     ):
 
-        super(DecomonMaxPooling2D, self).__init__(
+        super().__init__(
             pool_size=pool_size,
             strides=strides,
             padding=padding,
@@ -121,7 +121,7 @@ class DecomonMaxPooling2D(MaxPooling2D, DecomonLayer):
         if self.grad_bounds:
             raise NotImplementedError()
 
-        output_shape_ = super(DecomonMaxPooling2D, self).compute_output_shape(input_shape[0])
+        output_shape_ = super().compute_output_shape(input_shape[0])
         input_dim = input_shape[-1][1]
         if self.mode in [F_HYBRID.name, F_FORWARD.name]:
             x_shape = input_shape[1]

--- a/decomon/layers/old_conv.py
+++ b/decomon/layers/old_conv.py
@@ -340,7 +340,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
             raise ValueError("A merge layer should be called " "on a list of inputs.")
 
         if self.mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
-            raise ValueError("unknown  forward mode {}".format(self.mode))
+            raise ValueError(f"unknown  forward mode {self.mode}")
 
         if self.mode == F_HYBRID.name:
             if self.dc_decomp:

--- a/decomon/layers/old_conv.py
+++ b/decomon/layers/old_conv.py
@@ -86,7 +86,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=4), InputSpec(min_ndim=4)]
 
-        self.diag_op = Lambda(lambda x: tf.linalg.diag(x))
+        self.diag_op = Lambda(tf.linalg.diag)
 
     def build(self, input_shape):
         """

--- a/decomon/layers/old_conv.py
+++ b/decomon/layers/old_conv.py
@@ -43,7 +43,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
         activation = kwargs["activation"]
         if "activation" in kwargs:
             kwargs["activation"] = None
-        super(DecomonConv2D, self).__init__(filters=filters, kernel_size=kernel_size, mode=mode, **kwargs)
+        super().__init__(filters=filters, kernel_size=kernel_size, mode=mode, **kwargs)
         self.kernel_constraint_pos_ = NonNeg()
         self.kernel_constraint_neg_ = NonPos()
 

--- a/decomon/layers/reading_nnet_acas_2_numpy.py
+++ b/decomon/layers/reading_nnet_acas_2_numpy.py
@@ -6,7 +6,7 @@ from NNet.utils.readNNet import readNNet
 
 
 def convert_nnet_2_numpy(repo, filename, clipping=True, normalize_in=True, normalize_out=False, verbose=0):
-    with closing(open("{}/{}".format(repo, filename), "rb")) as f:
+    with closing(open(f"{repo}/{filename}", "rb")) as f:
         lines = f.readlines()
 
     index = 0
@@ -41,7 +41,7 @@ def convert_nnet_2_numpy(repo, filename, clipping=True, normalize_in=True, norma
     MEAN_in = MEAN[:-1]
 
     # retrieve the parameters of the networks (weights and biases)
-    weights, biases = readNNet("{}/{}".format(repo, filename))
+    weights, biases = readNNet(f"{repo}/{filename}")
     params = []
     for w, b in zip(weights, biases):
         params += [w.T, b]

--- a/decomon/layers/utils.py
+++ b/decomon/layers/utils.py
@@ -671,7 +671,7 @@ def relu_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, slope=V_sl
     if convex_domain is None:
         convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
-        raise ValueError("unknown mode {}".format(mode))
+        raise ValueError(f"unknown mode {mode}")
 
     z_value = K.cast(0.0, K.floatx())
     o_value = K.cast(1.0, K.floatx())
@@ -742,7 +742,7 @@ def softplus_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, slope=
     if convex_domain is None:
         convex_domain = {}
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
-        raise ValueError("unknown mode {}".format(mode))
+        raise ValueError(f"unknown mode {mode}")
 
     nb_tensors = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if mode == F_HYBRID.name:

--- a/decomon/layers/utils.py
+++ b/decomon/layers/utils.py
@@ -628,7 +628,7 @@ class MultipleConstraint(Constraint):
     """
 
     def __init__(self, constraint_0, constraint_1, **kwargs):
-        super(MultipleConstraint, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if constraint_0:
             self.constraints = [constraint_0, constraint_1]
         else:
@@ -646,7 +646,7 @@ class Project_initializer_pos(Initializer):
     """Initializer that generates tensors initialized to 1."""
 
     def __init__(self, initializer, **kwargs):
-        super(Project_initializer_pos, **kwargs)
+        super()
         self.initializer = initializer
 
     def __call__(self, shape, dtype=None):
@@ -658,7 +658,7 @@ class Project_initializer_neg(Initializer):
     """Initializer that generates tensors initialized to 1."""
 
     def __init__(self, initializer, **kwargs):
-        super(Project_initializer_neg, **kwargs)
+        super()
         self.initializer = initializer
 
     def __call__(self, shape, dtype=None):

--- a/decomon/layers/utils.py
+++ b/decomon/layers/utils.py
@@ -646,7 +646,7 @@ class Project_initializer_pos(Initializer):
     """Initializer that generates tensors initialized to 1."""
 
     def __init__(self, initializer, **kwargs):
-        super()
+        super().__init__(**kwargs)
         self.initializer = initializer
 
     def __call__(self, shape, dtype=None):
@@ -658,7 +658,7 @@ class Project_initializer_neg(Initializer):
     """Initializer that generates tensors initialized to 1."""
 
     def __init__(self, initializer, **kwargs):
-        super()
+        super().__init__(**kwargs)
         self.initializer = initializer
 
     def __call__(self, shape, dtype=None):

--- a/decomon/loading/load_onnx.py
+++ b/decomon/loading/load_onnx.py
@@ -60,7 +60,7 @@ def clone(layer, data_format=CHANNEL_LAST, prev_format=CHANNEL_LAST, node=None):
         class_name = layer.__class__.__name__
         if hasattr(layer, "built"):
             if not layer.built:
-                raise ValueError("the layer {} has not been built yet".format(layer.name))
+                raise ValueError(f"the layer {layer.name} has not been built yet")
 
         config_layer = layer.get_config()
         config_layer["name"] = layer.name + "_last"

--- a/decomon/metrics/complexity.py
+++ b/decomon/metrics/complexity.py
@@ -14,7 +14,7 @@ def get_graph_complexity(model):
     for depth in depth_keys:
         nodes = model._nodes_by_depth[depth]
         for node in nodes:
-            if isinstance(node.outbound_layer, InputLayer) or isinstance(node.outbound_layer, Lambda):
+            if isinstance(node.outbound_layer, (InputLayer, Lambda)):
                 continue
 
             nb_nodes += 1

--- a/decomon/metrics/coverage.py
+++ b/decomon/metrics/coverage.py
@@ -65,7 +65,7 @@ def get_adv_coverage_box(
 
     z = np.concatenate([x_min, x_max], 1)
 
-    if isinstance(source_labels, int) or isinstance(source_labels, np.int64):
+    if isinstance(source_labels, (int, np.int64)):
         source_labels = np.zeros((n_batch, 1)) + source_labels
 
     if isinstance(source_labels, list):

--- a/decomon/metrics/loss.py
+++ b/decomon/metrics/loss.py
@@ -349,7 +349,7 @@ def get_adv_loss(model, sigmoid=False, clip_value=None, softmax=False):
 # create a layer
 class DecomonLossFusion(DecomonLayer):
     def __init__(self, mode=F_HYBRID.name, asymptotic=False, backward=False, **kwargs):
-        super(DecomonLossFusion, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
         self.final_mode = F_IBP.name
         self.asymptotic = asymptotic
         self.backward = backward
@@ -419,7 +419,7 @@ class DecomonLossFusion(DecomonLayer):
 # new layer for new loss functions
 class DecomonRadiusRobust(DecomonLayer):
     def __init__(self, mode=F_HYBRID.name, backward=False, **kwargs):
-        super(DecomonRadiusRobust, self).__init__(mode=mode, **kwargs)
+        super().__init__(mode=mode, **kwargs)
 
         if self.mode == F_IBP.name:
             raise NotImplementedError

--- a/decomon/metrics/metric.py
+++ b/decomon/metrics/metric.py
@@ -22,7 +22,7 @@ class Adversarial_score(Layer):
         :param convex_domain: the type of input convex domain for the linear relaxation
         :param kwargs:
         """
-        super(Adversarial_score, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.ibp = ibp
         self.forward = forward
         self.mode = mode
@@ -132,7 +132,7 @@ class Adversarial_check(Layer):
         :param convex_domain: the type of input convex domain for the linear relaxation
         :param kwargs:
         """
-        super(Adversarial_check, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.ibp = ibp
         self.forward = forward
         self.mode = mode
@@ -271,7 +271,7 @@ class Upper_score(Layer):
     """
 
     def __init__(self, ibp, forward, mode, convex_domain, **kwargs):
-        super(Upper_score, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.ibp = ibp
         self.forward = forward
         self.mode = mode

--- a/decomon/models/backward_cloning.py
+++ b/decomon/models/backward_cloning.py
@@ -26,9 +26,9 @@ from .utils import (
 
 def is_purely_linear(layer):
     return False
-    if isinstance(layer, Reshape) or isinstance(layer, Dropout) or isinstance(layer, Permute):
+    if isinstance(layer, (Reshape, Dropout, Permute)):
         return True
-    if (isinstance(layer, Dense) or isinstance(layer, Conv)) and layer.get_config()["activation"] == "linear":
+    if (isinstance(layer, (Dense, Conv))) and layer.get_config()["activation"] == "linear":
         return True
 
     return False

--- a/decomon/models/convert.py
+++ b/decomon/models/convert.py
@@ -281,7 +281,7 @@ def clone(
 
     for input_layer in model._input_layers:
         if len(input_layer.input_shape) > 1:
-            raise ValueError("Expected one input tensor but got {}".format(len(input_layer.input_shape)))
+            raise ValueError(f"Expected one input tensor but got {len(input_layer.input_shape)}")
         input_shape_vec_ = input_layer.input_shape[0]
         input_shape_ = tuple(list(input_shape_vec_)[1:])
 

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -1155,7 +1155,7 @@ def get_backward_model(model, back_bounds, input_model, slope=V_slope.name, opti
 
     name = [layer.name for layer in model.layers]
 
-    dico = dict([(l.name, []) for l in model.layers])
+    dico = {l.name: [] for l in model.layers}
     for l in model.layers:
         output_nodes = l.outbound_nodes
         for output_node in output_nodes:

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -1044,7 +1044,7 @@ def get_backward(model, back_bounds=None, slope=V_slope.name, input_dim=-1, opti
 
             return [w_out_, b_out_, w_out_, b_out_]
 
-        lambda_backward = Lambda(lambda x: get_init_backward(x))
+        lambda_backward = Lambda(get_init_backward)
         back_bounds = lambda_backward(y_pred)
 
     back_bounds = list(get_backward_model(model, back_bounds, input_backward, slope=slope, options=options))

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -1111,7 +1111,7 @@ def get_backward_model_(model, back_bounds, input_model, slope=V_slope.name):
     names = [l.name for l in model.layers]
     for layer in model.layers:
         for n_ in layer._outbound_nodes:
-            if n_.layer.name not in names or isinstance(n_.layer, InputLayer) or isinstance(n_.layer, Lambda):
+            if n_.layer.name not in names or isinstance(n_.layer, (InputLayer, Lambda)):
                 continue
             if n_.layer.name in input_neighbors:
                 input_neighbors[n_.layer.name] += [layer]
@@ -1255,7 +1255,7 @@ def get_backward_layer(layer, back_bounds, input_layers, input_tensors, slope=V_
         return get_backward_layer(layers_[0], back_bounds, input_layers, input_tensors, slope=slope)
     else:
         if not isinstance(back_bounds[0], list) and not len(
-            [l for l in layers_ if not (isinstance(l, InputLayer) or isinstance(l, Lambda))]
+            [l for l in layers_ if not (isinstance(l, (InputLayer, Lambda)))]
         ):
             return back_bounds
             # check that we reach an input layer

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -907,7 +907,7 @@ class DecomonModel(tf.keras.Model):
         finetune=False,
         **kwargs,
     ):
-        super(DecomonModel, self).__init__(input, output, **kwargs)
+        super().__init__(input, output, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.convex_domain = convex_domain
@@ -965,7 +965,7 @@ class DecomonSequential(tf.keras.Sequential):
         finetune=False,
         **kwargs,
     ):
-        super(DecomonSequential, self).__init__(layers=layers, name=name, **kwargs)
+        super().__init__(layers=layers, name=name, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.convex_domain = convex_domain

--- a/decomon/models/decomon_sequential.py
+++ b/decomon/models/decomon_sequential.py
@@ -443,7 +443,7 @@ def clone_functional_model(
     model = softmax_to_linear(model)  # do not modify the previous model or send an alert message
 
     # we only handle one input
-    assert len(model._input_layers) == 1, "error: Expected one input only but got {}".format(len(model._input_layers))
+    assert len(model._input_layers) == 1, f"error: Expected one input only but got {len(model._input_layers)}"
 
     def clone(layer):
         return layer.__class__.from_config(layer.get_config())
@@ -571,7 +571,7 @@ def clone_functional_model(
 
             if not K.is_keras_tensor(x):
                 name = model._input_layers[0].name
-                input_tensor = Input(tensor=x, name=name + "_{}".format(names_i[i]))
+                input_tensor = Input(tensor=x, name=name + f"_{names_i[i]}")
                 _input_tensors.append(input_tensor)
                 # Cache newly created input layer.
                 original_input_layer = x._keras_history[0]

--- a/decomon/models/draft.py
+++ b/decomon/models/draft.py
@@ -53,21 +53,21 @@ def get_forward_map(inputs, model, id_node_init=None):
             layer = node.outbound_layer
             extra_names = get_original_layer_name(layer)
 
-            if "{}_{}".format(layer.name, id_node) in forward_map:
+            if f"{layer.name}_{id_node}" in forward_map:
                 import pdb
 
                 pdb.set_trace()
 
             if depth == max(depth_keys):
                 if isinstance(layer, InputLayer):
-                    forward_map["{}_{}".format(layer.name, id_node)] = inputs
+                    forward_map[f"{layer.name}_{id_node}"] = inputs
                     for extra_name in extra_names:
-                        forward_map["{}_{}".format(extra_name, id_node)] = inputs
+                        forward_map[f"{extra_name}_{id_node}"] = inputs
                 else:
                     tmp_0 = layer(inputs)
-                    forward_map["{}_{}".format(layer.name, id_node)] = tmp_0
+                    forward_map[f"{layer.name}_{id_node}"] = tmp_0
                     for extra_name in extra_names:
-                        forward_map["{}_{}".format(extra_name, id_node)] = tmp_0
+                        forward_map[f"{extra_name}_{id_node}"] = tmp_0
             else:
                 node_inbound = to_list(node.parent_nodes)
                 # input_layers = to_list(node.inbound_layers)
@@ -78,7 +78,7 @@ def get_forward_map(inputs, model, id_node_init=None):
                     if not isinstance(layer_i, InputLayer):
                         input_layer_only = False
                     if layer_i.name in list_layers:
-                        inputs_ += forward_map["{}_{}".format(layer_i.name, get_node_by_id(node_i))]
+                        inputs_ += forward_map[f"{layer_i.name}_{get_node_by_id(node_i)}"]
                 if len(inputs_) == 0:
                     inputs_ = inputs
 
@@ -89,21 +89,21 @@ def get_forward_map(inputs, model, id_node_init=None):
                     forward_map = {**forward_map, **f_map}
 
                 tmp_1 = layer(inputs_)
-                forward_map["{}_{}".format(layer.name, id_node)] = tmp_1
+                forward_map[f"{layer.name}_{id_node}"] = tmp_1
                 for extra_name in extra_names:
-                    forward_map["{}_{}".format(extra_name, id_node)] = tmp_1
+                    forward_map[f"{extra_name}_{id_node}"] = tmp_1
 
                 if input_layer_only and not (id_node_init is None):
-                    forward_map["{}_{}".format(layer.name, id_node_init)] = tmp_1
+                    forward_map[f"{layer.name}_{id_node_init}"] = tmp_1
                     for extra_name in extra_names:
-                        forward_map["{}_{}".format(extra_name, id_node_init)] = tmp_1
+                        forward_map[f"{extra_name}_{id_node_init}"] = tmp_1
 
     output = []
     nodes = model._nodes_by_depth[0]
     for node in nodes:
         id_node = get_node_by_id(node)
         layer = node.outbound_layer
-        output += forward_map["{}_{}".format(layer.name, id_node)]
+        output += forward_map[f"{layer.name}_{id_node}"]
 
     return output, forward_map
 
@@ -230,15 +230,15 @@ def convert_forward_functional_model(
 
             id_node = get_node_by_id(node)
             layer_ = node.outbound_layer
-            if "{}_{}".format(layer_, id_node) in tensor_map.keys():
+            if f"{layer_}_{id_node}" in tensor_map.keys():
                 continue
 
             input_layers = to_list(node.inbound_layers)
 
             if isinstance(layer_, InputLayer):
                 output = input_tensors
-                tensor_map["{}_{}".format(layer_.name, id_node)] = output
-                forward_map["{}_{}".format(layer_.name, id_node)] = output
+                tensor_map[f"{layer_.name}_{id_node}"] = output
+                forward_map[f"{layer_.name}_{id_node}"] = output
                 continue
             if len(input_layers) == 0:
                 output = input_tensors
@@ -258,7 +258,7 @@ def convert_forward_functional_model(
                     forward=forward,
                     name_history=name_history,
                 )
-                name_ = "{}_to_monotonic".format(layer_.name)
+                name_ = f"{layer_.name}_to_monotonic"
                 """
                 if '{}_to_monotonic'.format(layer_.name) in name_history:
                     count=0
@@ -276,7 +276,7 @@ def convert_forward_functional_model(
             for layer_decomon_i in layer_decomon:
                 if layer_decomon_i.name in name_history:
                     count = 0
-                    while "{}_{}".format(layer_decomon_i.name, count) in name_history:
+                    while f"{layer_decomon_i.name}_{count}" in name_history:
                         count += 1
                     # set the name in l_map as well
                     set_name(layer_decomon_i, count)
@@ -296,16 +296,16 @@ def convert_forward_functional_model(
                     output = layer_decomon_i(output)
                     # forward_map[layer_decomon_i.name] = output
 
-                    forward_map["{}_{}".format(layer_decomon_i.name, id_node)] = output
+                    forward_map[f"{layer_decomon_i.name}_{id_node}"] = output
 
-            forward_map["{}_{}".format(layer_.name, id_node)] = output
-            tensor_map["{}_{}".format(layer_.name, id_node)] = output
+            forward_map[f"{layer_.name}_{id_node}"] = output
+            tensor_map[f"{layer_.name}_{id_node}"] = output
 
             if isinstance(layer_, Model):
                 # layer_map = {**layer_map, **l_map}
-                layer_map["{}_{}".format(layer_.name, id_node)] = l_map
+                layer_map[f"{layer_.name}_{id_node}"] = l_map
             else:
-                layer_map["{}_{}".format(layer_.name, id_node)] = layer_decomon
+                layer_map[f"{layer_.name}_{id_node}"] = layer_decomon
 
     output = []
     nodes = model._nodes_by_depth[0]

--- a/decomon/models/draft_backward_cloning.py
+++ b/decomon/models/draft_backward_cloning.py
@@ -340,7 +340,7 @@ def clone_backward_layer(
                 l_c, w_l, b_l = inputs_1[-3:]
                 return [x, u_c, w_u, b_u, l_c, w_l, b_l]
 
-        lambda_f = Lambda(lambda x: func(x))
+        lambda_f = Lambda(func)
 
         output = lambda_f(max_bounds + min_bounds)
         return output, layer_map, forward_map
@@ -721,7 +721,7 @@ def clone_backward_layer_last(
                 l_c, w_l, b_l = inputs_1[-3:]
                 return [x, u_c, w_u, b_u, l_c, w_l, b_l]
 
-        lambda_f = Lambda(lambda x: func(x))
+        lambda_f = Lambda(func)
 
         output = lambda_f(max_bounds + min_bounds)
         return output, layer_map, forward_map

--- a/decomon/models/draft_backward_cloning.py
+++ b/decomon/models/draft_backward_cloning.py
@@ -135,7 +135,7 @@ def clone_backward_layer(
         else:
             return update_input(back_bounds, x_tensor, mode, upper_layer, lower_layer), layer_map, forward_map
 
-    if "{}_{}".format(layer_.name, id_node) not in layer_map:
+    if f"{layer_.name}_{id_node}" not in layer_map:
         # crown mode
 
         layer_back = get_backward_layer(
@@ -179,8 +179,8 @@ def clone_backward_layer(
                 for inbound_node in inbound_nodes:
                     input_layer_i = inbound_node.outbound_layer
                     node_id_i = get_node_by_id(inbound_node)
-                    if "{}_{}".format(input_layer_i.name, node_id_i) in forward_map:
-                        input_tensor_list.append(forward_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                    if f"{input_layer_i.name}_{node_id_i}" in forward_map:
+                        input_tensor_list.append(forward_map[f"{input_layer_i.name}_{node_id_i}"])
                     else:
                         if input_layer_i.name[-6::] == "_input":
                             input_tensor_list.append(input_tensors)
@@ -204,7 +204,7 @@ def clone_backward_layer(
                 IBP=get_IBP(mode),
                 forward=get_FORWARD(mode),
                 finetune=finetune,
-                layer_map=layer_map["{}_{}".format(layer_.name, id_node)],
+                layer_map=layer_map[f"{layer_.name}_{id_node}"],
                 forward_map=forward_map,
                 x_tensor=x_tensor,
             )
@@ -228,7 +228,7 @@ def clone_backward_layer(
 
             # layer_list = to_list(layer_map[layer_.name])
             # update the key
-            layer_list = to_list(layer_map["{}_{}".format(layer_.name, id_node)])
+            layer_list = to_list(layer_map[f"{layer_.name}_{id_node}"])
             layer_list = layer_list[::-1]
 
             for i in range(len(layer_list) - 1):
@@ -240,10 +240,10 @@ def clone_backward_layer(
                     finetune=finetune,
                     convex_domain=convex_domain,
                 )
-                if "{}_{}".format(layer_list[i + 1].name, id_node) not in forward_map:
+                if f"{layer_list[i + 1].name}_{id_node}" not in forward_map:
                     input_tensor_i = forward_map[get_key(layer_list[i + 1], id_node, forward_map)]
                 else:
-                    input_tensor_i = forward_map["{}_{}".format(layer_list[i + 1].name, id_node)]
+                    input_tensor_i = forward_map[f"{layer_list[i + 1].name}_{id_node}"]
                 back_bounds_ = layer_back(input_tensor_i + back_bounds)
                 if back_bounds_[0].shape[-1] != back_bounds_[1].shape[-1]:
                     import pdb
@@ -265,8 +265,8 @@ def clone_backward_layer(
                 for inbound_node in inbound_nodes:
                     input_layer_i = inbound_node.outbound_layer
                     node_id_i = get_node_by_id(inbound_node)
-                    if "{}_{}".format(input_layer_i.name, node_id_i) in forward_map:
-                        input_tensor_list.append(forward_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                    if f"{input_layer_i.name}_{node_id_i}" in forward_map:
+                        input_tensor_list.append(forward_map[f"{input_layer_i.name}_{node_id_i}"])
                     else:
                         if input_layer_i.name[-6::] == "_input":
                             input_tensor_list.append(input_tensors)
@@ -486,7 +486,7 @@ def clone_backward_layer_last(
         # else:
         #    return update_input(back_bounds, x_tensor, mode, upper_layer, lower_layer), layer_map, forward_map
 
-    if "{}_{}".format(layer_.name, id_node) not in layer_map:
+    if f"{layer_.name}_{id_node}" not in layer_map:
         # crown mode
 
         input_nodes = node.parent_nodes
@@ -537,15 +537,15 @@ def clone_backward_layer_last(
                 # tensorflow can create fake inputs when we reach the first layers of the model, those are not stored
                 # in our forward  map
                 input_tensor_list = []
-                f_map = forward_map["{}_{}".format(layer_.name, id_node)][1]
+                f_map = forward_map[f"{layer_.name}_{id_node}"][1]
                 for inbound_node in inbound_nodes:
                     input_layer_i = inbound_node.outbound_layer
                     node_id_i = get_node_by_id(inbound_node)
-                    if "{}_{}".format(input_layer_i.name, node_id_i) in f_map:
+                    if f"{input_layer_i.name}_{node_id_i}" in f_map:
                         if isinstance(input_layer_i, Model):
-                            input_tensor_list.append(f_map["{}_{}".format(input_layer_i.name, node_id_i)][0])
+                            input_tensor_list.append(f_map[f"{input_layer_i.name}_{node_id_i}"][0])
                         else:
-                            input_tensor_list.append(f_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                            input_tensor_list.append(f_map[f"{input_layer_i.name}_{node_id_i}"])
                     else:
                         import pdb
 
@@ -574,7 +574,7 @@ def clone_backward_layer_last(
                     IBP=get_IBP(mode),
                     forward=get_FORWARD(mode),
                     finetune=finetune,
-                    layer_map=layer_map["{}_{}".format(layer_.name, id_node)],
+                    layer_map=layer_map[f"{layer_.name}_{id_node}"],
                     forward_map=forward_map,
                     fuse_with_input=False,
                     x_tensor=x_tensor,
@@ -588,7 +588,7 @@ def clone_backward_layer_last(
                     IBP=get_IBP(mode),
                     forward=get_FORWARD(mode),
                     finetune=finetune,
-                    layer_map=layer_map["{}_{}".format(layer_.name, id_node)],
+                    layer_map=layer_map[f"{layer_.name}_{id_node}"],
                     forward_map=forward_map,
                     fuse_with_input=False,
                 )
@@ -605,7 +605,7 @@ def clone_backward_layer_last(
 
             # layer_list = to_list(layer_map[layer_.name])
             # update the key
-            layer_list = to_list(layer_map["{}_{}".format(layer_.name, id_node)])
+            layer_list = to_list(layer_map[f"{layer_.name}_{id_node}"])
             layer_list = layer_list[::-1]
 
             for i in range(len(layer_list) - 1):
@@ -616,10 +616,10 @@ def clone_backward_layer_last(
                     finetune=finetune,
                     convex_domain=convex_domain,
                 )
-                if "{}_{}".format(layer_list[i + 1].name, id_node) not in forward_map:
+                if f"{layer_list[i + 1].name}_{id_node}" not in forward_map:
                     input_tensor_i = forward_map[get_key(layer_list[i + 1], id_node, forward_map)]
                 else:
-                    input_tensor_i = forward_map["{}_{}".format(layer_list[i + 1].name, id_node)]
+                    input_tensor_i = forward_map[f"{layer_list[i + 1].name}_{id_node}"]
                 back_bounds_ = layer_back(input_tensor_i + back_bounds)
                 if back_bounds_[0].shape[-1] != back_bounds_[1].shape[-1]:
                     import pdb
@@ -643,12 +643,12 @@ def clone_backward_layer_last(
                     node_id_i = get_node_by_id(inbound_node)
 
                     if isinstance(input_layer_i, Model):
-                        toto = forward_map["{}_{}".format(input_layer_i.name, node_id_i)][0]
+                        toto = forward_map[f"{input_layer_i.name}_{node_id_i}"][0]
                         input_tensor_list.append(toto)
                     else:
 
-                        if "{}_{}".format(input_layer_i.name, node_id_i) in forward_map:
-                            input_tensor_list.append(forward_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                        if f"{input_layer_i.name}_{node_id_i}" in forward_map:
+                            input_tensor_list.append(forward_map[f"{input_layer_i.name}_{node_id_i}"])
                         else:
                             if input_layer_i.name[-6::] == "_input":
                                 input_tensor_list.append(input_tensors)

--- a/decomon/models/draft_cloning_bis.py
+++ b/decomon/models/draft_cloning_bis.py
@@ -475,7 +475,7 @@ def clone_backward_layer(
                 l_c, w_l, b_l = inputs_1[-3:]
                 return [x, u_c, w_u, b_u, l_c, w_l, b_l]
 
-        lambda_f = Lambda(lambda x: func(x))
+        lambda_f = Lambda(func)
 
         output = lambda_f(max_bounds + min_bounds)
         return output, layer_map, forward_map

--- a/decomon/models/draft_cloning_bis.py
+++ b/decomon/models/draft_cloning_bis.py
@@ -231,7 +231,7 @@ def clone_backward_layer(
         # else:
         #    return update_input(back_bounds, x_tensor, mode, upper_layer, lower_layer), layer_map, forward_map
 
-    if "{}_{}".format(layer_.name, id_node) not in layer_map:
+    if f"{layer_.name}_{id_node}" not in layer_map:
         # crown mode
 
         input_nodes = node.parent_nodes
@@ -295,15 +295,15 @@ def clone_backward_layer(
                 # tensorflow can create fake inputs when we reach the first layers of the model, those are not stored
                 # in our forward  map
                 input_tensor_list = []
-                f_map = forward_map["{}_{}".format(layer_.name, id_node)][1]
+                f_map = forward_map[f"{layer_.name}_{id_node}"][1]
                 for inbound_node in inbound_nodes:
                     input_layer_i = inbound_node.outbound_layer
                     node_id_i = get_node_by_id(inbound_node)
-                    if "{}_{}".format(input_layer_i.name, node_id_i) in f_map:
+                    if f"{input_layer_i.name}_{node_id_i}" in f_map:
                         if isinstance(input_layer_i, Model):
-                            input_tensor_list.append(f_map["{}_{}".format(input_layer_i.name, node_id_i)][0])
+                            input_tensor_list.append(f_map[f"{input_layer_i.name}_{node_id_i}"][0])
                         else:
-                            input_tensor_list.append(f_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                            input_tensor_list.append(f_map[f"{input_layer_i.name}_{node_id_i}"])
                     else:
                         import pdb
 
@@ -332,7 +332,7 @@ def clone_backward_layer(
                     IBP=get_IBP(mode),
                     forward=get_FORWARD(mode),
                     finetune=finetune,
-                    layer_map=layer_map["{}_{}".format(layer_.name, id_node)],
+                    layer_map=layer_map[f"{layer_.name}_{id_node}"],
                     forward_map=forward_map,
                     fuse_with_input=False,
                     x_tensor=x_tensor,
@@ -346,7 +346,7 @@ def clone_backward_layer(
                     IBP=get_IBP(mode),
                     forward=get_FORWARD(mode),
                     finetune=finetune,
-                    layer_map=layer_map["{}_{}".format(layer_.name, id_node)],
+                    layer_map=layer_map[f"{layer_.name}_{id_node}"],
                     forward_map=forward_map,
                     fuse_with_input=False,
                 )
@@ -363,7 +363,7 @@ def clone_backward_layer(
 
             # layer_list = to_list(layer_map[layer_.name])
             # update the key
-            layer_list = to_list(layer_map["{}_{}".format(layer_.name, id_node)])
+            layer_list = to_list(layer_map[f"{layer_.name}_{id_node}"])
             layer_list = layer_list[::-1]
 
             for i in range(len(layer_list) - 1):
@@ -374,10 +374,10 @@ def clone_backward_layer(
                     finetune=finetune,
                     convex_domain=convex_domain,
                 )
-                if "{}_{}".format(layer_list[i + 1].name, id_node) not in forward_map:
+                if f"{layer_list[i + 1].name}_{id_node}" not in forward_map:
                     input_tensor_i = forward_map[get_key(layer_list[i + 1], id_node, forward_map)]
                 else:
-                    input_tensor_i = forward_map["{}_{}".format(layer_list[i + 1].name, id_node)]
+                    input_tensor_i = forward_map[f"{layer_list[i + 1].name}_{id_node}"]
                 back_bounds_ = layer_back(input_tensor_i + back_bounds)
                 if back_bounds_[0].shape[-1] != back_bounds_[1].shape[-1]:
                     import pdb
@@ -401,12 +401,12 @@ def clone_backward_layer(
                     node_id_i = get_node_by_id(inbound_node)
 
                     if isinstance(input_layer_i, Model):
-                        toto = forward_map["{}_{}".format(input_layer_i.name, node_id_i)][0]
+                        toto = forward_map[f"{input_layer_i.name}_{node_id_i}"][0]
                         input_tensor_list.append(toto)
                     else:
 
-                        if "{}_{}".format(input_layer_i.name, node_id_i) in forward_map:
-                            input_tensor_list.append(forward_map["{}_{}".format(input_layer_i.name, node_id_i)])
+                        if f"{input_layer_i.name}_{node_id_i}" in forward_map:
+                            input_tensor_list.append(forward_map[f"{input_layer_i.name}_{node_id_i}"])
                         else:
                             if input_layer_i.name[-6::] == "_input":
                                 input_tensor_list.append(input_tensors)

--- a/decomon/models/forward_cloning.py
+++ b/decomon/models/forward_cloning.py
@@ -189,12 +189,12 @@ def convert_forward_functional_model(
                 list_layer_decomon = layer_fn(layer)
                 layer_map[id(node)] = []
                 for layer_decomon in list_layer_decomon:
-                    layer_decomon._name = "{}_{}".format(layer_decomon.name, count)
+                    layer_decomon._name = f"{layer_decomon.name}_{count}"
                     count += 1
                     output = layer_decomon(output)
                     layer_map[id(node)].append(layer_decomon)
                     if len(list_layer_decomon) > 1:
-                        output_map["{}_{}".format(id(node), layer_decomon.name)] = output
+                        output_map[f"{id(node)}_{layer_decomon.name}"] = output
 
                 # output_map['{}_{}'.format(id(node), layer_decomon.name)]
             output_map[id(node)] = output

--- a/decomon/models/models.py
+++ b/decomon/models/models.py
@@ -33,7 +33,7 @@ class DecomonModel(tf.keras.Model):
         backward_bounds=False,
         **kwargs,
     ):
-        super(DecomonModel, self).__init__(input, output, **kwargs)
+        super().__init__(input, output, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.convex_domain = convex_domain
@@ -92,7 +92,7 @@ class DecomonSequential(tf.keras.Sequential):
         finetune=False,
         **kwargs,
     ):
-        super(DecomonSequential, self).__init__(layers=layers, name=name, **kwargs)
+        super().__init__(layers=layers, name=name, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.convex_domain = convex_domain

--- a/decomon/models/old_backward_cloning.py
+++ b/decomon/models/old_backward_cloning.py
@@ -496,14 +496,11 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, input_di
         else:
             f_map = {}
 
-        kwargs_ = dict(
-            [
-                (key, kwargs[key])
-                for key in kwargs
-                if key
-                not in ["forward_map", "layer_map", "convex_domain", "IBP", "forward", "finetune", "fuse_with_input"]
-            ]
-        )
+        kwargs_ = {
+            key: kwargs[key]
+            for key in kwargs
+            if key not in ["forward_map", "layer_map", "convex_domain", "IBP", "forward", "finetune", "fuse_with_input"]
+        }
 
         back_bounds_ = get_backward_model(
             layer_,

--- a/decomon/models/old_backward_cloning.py
+++ b/decomon/models/old_backward_cloning.py
@@ -146,7 +146,7 @@ def update_input(backward_bound, input_tensors, mode, output_shape, reshape=Fals
 
         return w_out_u_0, b_out_u_0, w_out_l_0, b_out_l_0
 
-    lambda_ = Lambda(lambda var: func(var))
+    lambda_ = Lambda(func)
 
     w_out_u_, b_out_u_, w_out_l_, b_out_l_ = lambda_([w_u, b_u, w_l, b_l] + backward_bound)
     w_out_u_ = op_reshape_w(w_out_u_)
@@ -296,7 +296,7 @@ def fuse_backward_bounds(back_bounds_list, input_tensors, mode, **kwargs):
 
         return [w_u, b_u, w_l, b_l]
 
-    lambda_f = Lambda(lambda x: func(x))
+    lambda_f = Lambda(func)
     output = lambda_f(max_bounds + min_bounds)
     return output
 

--- a/decomon/models/old_backward_cloning.py
+++ b/decomon/models/old_backward_cloning.py
@@ -316,23 +316,23 @@ def get_backward_layer_input(
         input_dim=input_dim,
         rec=rec,
     )
-    input_layer_ = forward_map["{}_{}".format(layer_.name, id_node)]
+    input_layer_ = forward_map[f"{layer_.name}_{id_node}"]
     back_bounds_ = layer_back(input_layer_ + back_bounds)
     if isinstance(back_bounds_, tuple):
         back_bounds_ = list(back_bounds_)
 
-    return {"{}_{}".format(layer_.name, id_node): back_bounds}
+    return {f"{layer_.name}_{id_node}": back_bounds}
 
 
 def get_output_model(node, layer_map, forward_map, mode, input_dim, rec=1, **kwargs):
 
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
-    if "{}_{}".format(layer_.name, id_node) in forward_map:
+    if f"{layer_.name}_{id_node}" in forward_map:
         if isinstance(layer_, Model):
-            return forward_map["{}_{}".format(layer_.name, id_node)][0], False
+            return forward_map[f"{layer_.name}_{id_node}"][0], False
         else:
-            return forward_map["{}_{}".format(layer_.name, id_node)], False
+            return forward_map[f"{layer_.name}_{id_node}"], False
     else:
         if len(to_list(layer_.output_shape)) > 1:
             raise NotImplementedError("Decomon cannot handle nodes with a list of output tensors")
@@ -362,11 +362,11 @@ def get_output_layer(node, layer_map, forward_map, mode, input_dim, rec=1, **kwa
 
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
-    if "{}_{}".format(layer_.name, id_node) in forward_map:
+    if f"{layer_.name}_{id_node}" in forward_map:
         if isinstance(layer_, Model):
-            return forward_map["{}_{}".format(layer_.name, id_node)][0]
+            return forward_map[f"{layer_.name}_{id_node}"][0]
         else:
-            return forward_map["{}_{}".format(layer_.name, id_node)]
+            return forward_map[f"{layer_.name}_{id_node}"]
     else:
         if len(to_list(layer_.get_output_shape_at(0))) > 1:
             raise NotImplementedError("Decomon cannot handle nodes with a list of output tensors")
@@ -393,13 +393,13 @@ def get_output_layer(node, layer_map, forward_map, mode, input_dim, rec=1, **kwa
             output_min = outputs
 
         if mode == F_IBP.name:
-            forward_map["{}_{}".format(layer_.name, id_node)] = [output_max[0], output_min[-1]]
+            forward_map[f"{layer_.name}_{id_node}"] = [output_max[0], output_min[-1]]
             return [output_max[0], output_min[-1]]
         if mode == F_FORWARD.name:
-            forward_map["{}_{}".format(layer_.name, id_node)] = output_max[:3] + output_min[-2:]
+            forward_map[f"{layer_.name}_{id_node}"] = output_max[:3] + output_min[-2:]
             return output_max[:3] + output_min[-2:]
         if mode == F_HYBRID.name:
-            forward_map["{}_{}".format(layer_.name, id_node)] = output_max[:4] + output_min[-3:]
+            forward_map[f"{layer_.name}_{id_node}"] = output_max[:4] + output_min[-3:]
             return output_max[:4] + output_min[-3:]
 
 
@@ -430,21 +430,21 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, input_di
             layer_, id_node, forward_map, mode, back_bounds, finetune, convex_domain, input_dim, rec=rec
         )
 
-    if "{}_{}".format(layer_.name, id_node) not in layer_map or isinstance(layer_, Model):
+    if f"{layer_.name}_{id_node}" not in layer_map or isinstance(layer_, Model):
         layer_list = [layer_]
     else:
-        layer_list = to_list(layer_map["{}_{}".format(layer_.name, id_node)])
+        layer_list = to_list(layer_map[f"{layer_.name}_{id_node}"])
         layer_list = layer_list[::-1]
 
     for i in range(len(layer_list) - 1):
         # if layer_list has more than one element, then there has been a forward pass
         # hence forward_map contains the related input
-        if "{}_{}".format(layer_list[i + 1].name, id_node) not in forward_map:
+        if f"{layer_list[i + 1].name}_{id_node}" not in forward_map:
             # split name
-            new_name = "{}{}".format(layer_list[i + 1].name.split("_monotonic")[0], "_monotonic")
-            inputs_i = forward_map["{}_{}".format(new_name, id_node)]
+            new_name = f"{layer_list[i + 1].name.split('_monotonic')[0]}_monotonic"
+            inputs_i = forward_map[f"{new_name}_{id_node}"]
         else:
-            inputs_i = forward_map["{}_{}".format(layer_list[i + 1].name, id_node)]
+            inputs_i = forward_map[f"{layer_list[i + 1].name}_{id_node}"]
 
         back_layer_i = get_backward_(
             layer_list[i],
@@ -486,13 +486,13 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, input_di
             finetune_ = kwargs["finetune"]
         if "convex_domain" in kwargs:
             convex_domain_ = kwargs["convex_domain"]
-        if "{}_{}".format(layer_.name, id_node) in layer_map:
-            l_map = layer_map["{}_{}".format(layer_.name, id_node)]
+        if f"{layer_.name}_{id_node}" in layer_map:
+            l_map = layer_map[f"{layer_.name}_{id_node}"]
         else:
             l_map = {}
 
-        if "{}_{}".format(layer_.name, id_node) in forward_map:
-            f_map = forward_map["{}_{}".format(layer_.name, id_node)][-1]
+        if f"{layer_.name}_{id_node}" in forward_map:
+            f_map = forward_map[f"{layer_.name}_{id_node}"][-1]
         else:
             f_map = {}
 
@@ -639,13 +639,13 @@ def get_backward_model(
         for node_i in nodes_input:
             layer_i = node_i.outbound_layer
             id_node_i = get_node_by_id(node_i)
-            if "{}_{}".format(layer_i, id_node_i) not in forward_map:
+            if f"{layer_i}_{id_node_i}" not in forward_map:
                 if input_dim == -1:
                     input_dim_i = np.prod(layer_i.input_shape[1:])
                 else:
                     input_dim_i = input_dim
-                if "{}_{}".format(layer_i.name, id_node_i) not in forward_map:
-                    forward_map["{}_{}".format(layer_i.name, id_node_i)] = check_input_tensors_sequential(
+                if f"{layer_i.name}_{id_node_i}" not in forward_map:
+                    forward_map[f"{layer_i.name}_{id_node_i}"] = check_input_tensors_sequential(
                         model, None, input_dim_i, input_dim_init, IBP, forward, False, convex_domain
                     )
     else:
@@ -654,8 +654,8 @@ def get_backward_model(
         for i, node_i in enumerate(nodes_input):
             layer_i = node_i.outbound_layer
             id_node_i = get_node_by_id(node_i)
-            if "{}_{}".format(layer_i.name, id_node_i) not in forward_map:
-                forward_map["{}_{}".format(layer_i.name, id_node_i)] = input_tensors[i]
+            if f"{layer_i.name}_{id_node_i}" not in forward_map:
+                forward_map[f"{layer_i.name}_{id_node_i}"] = input_tensors[i]
 
             input_dim = input_tensors[i][0].shape[-1]
 
@@ -725,14 +725,14 @@ def get_backward_model(
             layer_name_j = layer_j.name
             id_j = get_node_by_id(node_j)
 
-            if "{}_{}".format(layer_name_j, id_j) not in back_bound_i_dict:
+            if f"{layer_name_j}_{id_j}" not in back_bound_i_dict:
                 raise NotImplementedError()
             else:
-                output_i = back_bound_i_dict["{}_{}".format(layer_name_j, id_j)]
+                output_i = back_bound_i_dict[f"{layer_name_j}_{id_j}"]
                 if not fuse_with_input:
                     back_bound_i.append(output_i)
                 else:
-                    inputs_tensors_i = forward_map["{}_{}".format(layer_name_j, id_j)]
+                    inputs_tensors_i = forward_map[f"{layer_name_j}_{id_j}"]
                     kwargs["convex_domain"] = convex_domain
                     if final_mode:
                         # do not return the same mode as the one used in the internal layers
@@ -776,7 +776,7 @@ def get_backward_model(
                         lambda_f = Lambda(lambda x: func(x))
                         output_i = lambda_f(max_bounds + min_bounds)
                     """
-                    forward_map["{}_{}".format(node_i.outbound_layer.name, get_node_by_id(node_i))] = output_i
+                    forward_map[f"{node_i.outbound_layer.name}_{get_node_by_id(node_i)}"] = output_i
                     # print("{}_{}".format(node_i.outbound_layer.name, get_node_by_id(node_i)))
                     back_bound_i.append(output_i)
 
@@ -794,7 +794,7 @@ def get_backward_model(
         layer_j = node_j.outbound_layer
         layer_name_j = layer_j.name
         id_j = get_node_by_id(node_j)
-        inputs_ += forward_map["{}_{}".format(layer_name_j, id_j)]
+        inputs_ += forward_map[f"{layer_name_j}_{id_j}"]
 
     for elem in back_bounds:
         inputs_ += elem

--- a/decomon/models/tmp_clone_backward.py
+++ b/decomon/models/tmp_clone_backward.py
@@ -124,7 +124,7 @@ def update_input(backward_bound, input_tensors, mode, output_shape, **kwargs):
 
             return w_out_u_, b_out_u_, w_out_l_, b_out_l_
 
-        lambda_ = Lambda(lambda var: func(var))
+        lambda_ = Lambda(func)
 
         w_out_u_, b_out_u_, w_out_l_, b_out_l_ = lambda_([w_u, b_u, w_l, b_l] + backward_bound)
         w_out_u_ = op_reshape_w(w_out_u_)
@@ -219,7 +219,7 @@ def fuse_backward_bounds(back_bounds_list, input_tensors, mode, **kwargs):
 
         return [w_u, b_u, w_l, b_l]
 
-    lambda_f = Lambda(lambda x: func(x))
+    lambda_f = Lambda(func)
     output = lambda_f(max_bounds + min_bounds)
     return output
 

--- a/decomon/models/tmp_clone_backward.py
+++ b/decomon/models/tmp_clone_backward.py
@@ -231,20 +231,20 @@ def get_backward_layer_input(layer_, id_node, forward_map, mode, back_bounds, fi
     layer_back = get_backward_(
         layer_, previous=(len(back_bounds) > 0), mode=mode, finetune=finetune, convex_domain=convex_domain
     )
-    input_layer_ = forward_map["{}_{}".format(layer_.name, id_node)]
+    input_layer_ = forward_map[f"{layer_.name}_{id_node}"]
     back_bounds_ = layer_back(input_layer_ + back_bounds)
     if isinstance(back_bounds_, tuple):
         back_bounds_ = list(back_bounds_)
 
-    return {"{}_{}".format(layer_.name, id_node): back_bounds}
+    return {f"{layer_.name}_{id_node}": back_bounds}
 
 
 def get_output_layer(node, layer_map, forward_map, mode, **kwargs):
 
     layer_ = node.outbound_layer
     id_node = get_node_by_id(node)
-    if "{}_{}".format(layer_.name, id_node) in forward_map:
-        return forward_map["{}_{}".format(layer_.name, id_node)]
+    if f"{layer_.name}_{id_node}" in forward_map:
+        return forward_map[f"{layer_.name}_{id_node}"]
     else:
         if len(layer_.output_shape) > 1:
             raise NotImplementedError("Decomon cannot handle nodes with a list of output tensors")
@@ -285,16 +285,16 @@ def get_backward_layer(node, layer_map, forward_map, mode, back_bounds, **kwargs
         # return back_bounds, dict of backward bounds associated to inputs
         return get_backward_layer_input(layer_, id_node, forward_map, mode, back_bounds, finetune, convex_domain)
 
-    if "{}_{}".format(layer_.name, id_node) not in layer_map:
+    if f"{layer_.name}_{id_node}" not in layer_map:
         layer_list = [layer_]
     else:
-        layer_list = to_list(layer_map["{}_{}".format(layer_.name, id_node)])
+        layer_list = to_list(layer_map[f"{layer_.name}_{id_node}"])
         layer_list = layer_list[::-1]
 
     for i in range(len(layer_list) - 1):
         # if layer_list has more than one element, then there has been a forward pass
         # hence forward_map contains the related input
-        inputs_i = forward_map["{}_{}".format(layer_list[i + 1].name, id_node)]
+        inputs_i = forward_map[f"{layer_list[i + 1].name}_{id_node}"]
         back_layer_i = get_backward_(
             layer_, previous=(len(back_bounds) > 0), mode=mode, finetune=finetune, convex_domain=convex_domain
         )
@@ -403,21 +403,21 @@ def get_backward_model(
         for node_i in nodes_input:
             layer_i = node_i.outbound_layer
             id_node_i = get_node_by_id(node_i)
-            if "{}_{}".format(layer_i, id_node_i) not in forward_map:
+            if f"{layer_i}_{id_node_i}" not in forward_map:
                 if input_dim == -1:
                     input_dim_i = np.prod(layer_i.input_shape[1:])
                 else:
                     input_dim_i = input_dim
 
-                forward_map["{}_{}".format(layer_i, id_node_i)] = check_input_tensors_sequential(
+                forward_map[f"{layer_i}_{id_node_i}"] = check_input_tensors_sequential(
                     model, None, input_dim_i, input_dim_init, IBP, forward, False, convex_domain
                 )
     else:
         for i, node_i in enumerate(nodes_input):
             layer_i = node_i.outbound_layer
             id_node_i = get_node_by_id(node_i)
-            if "{}_{}".format(layer_i, id_node_i) not in forward_map:
-                forward_map["{}_{}".format(layer_i, id_node_i)] = input_tensors[i]
+            if f"{layer_i}_{id_node_i}" not in forward_map:
+                forward_map[f"{layer_i}_{id_node_i}"] = input_tensors[i]
             else:
                 raise ValueError
 
@@ -442,9 +442,9 @@ def get_backward_model(
             for node_j in nodes_input:
                 layer_name_j = node_j.outbound_layer.name
                 id_j = get_node_by_id(node_j)
-                inputs_tensors_i = forward_map["{}_{}".format(layer_name_j.name, id_j)]
-                if "{}_{}".format(layer_name_j, id_j) in back_bound_i_dict:
-                    output_i = back_bound_i_dict["{}_{}".format(layer_name_j, id_j)]
+                inputs_tensors_i = forward_map[f"{layer_name_j.name}_{id_j}"]
+                if f"{layer_name_j}_{id_j}" in back_bound_i_dict:
+                    output_i = back_bound_i_dict[f"{layer_name_j}_{id_j}"]
                     if mode == F_IBP.name:
                         back_bound_i.append(output_i)
                     else:

--- a/decomon/models/utils.py
+++ b/decomon/models/utils.py
@@ -260,7 +260,7 @@ def get_FORWARD(mode=F_HYBRID.name):
 
 def get_node_by_id_(node):
 
-    return "NODE_{}_{}".format(node.flat_output_ids, node.flat_input_ids)
+    return f"NODE_{node.flat_output_ids}_{node.flat_input_ids}"
 
 
 def get_node_by_id(node, outbound=False, model=None):
@@ -270,16 +270,16 @@ def get_node_by_id(node, outbound=False, model=None):
 
     input_names = str(id(node))
     if outbound:
-        return "{}_NODE_{}".format(layer_.name, input_names)
-    return "NODE_{}".format(input_names)
+        return f"{layer_.name}_NODE_{input_names}"
+    return f"NODE_{input_names}"
 
     if model is None:
         input_names = ""
         for layer_i in layers_i:
             input_names += layer_i.name
         if outbound:
-            return "{}_NODE_{}".format(layer_.name, input_names)
-        return "NODE_{}".format(input_names)
+            return f"{layer_.name}_NODE_{input_names}"
+        return f"NODE_{input_names}"
     else:
         layer_names = [layer.name for layer in model.layers]
         input_names = ""
@@ -288,13 +288,13 @@ def get_node_by_id(node, outbound=False, model=None):
                 input_names += layer_i.name
     input_names = str(id(node))
     if outbound:
-        return "{}_NODE_{}".format(layer_.name, input_names)
-    return "NODE_{}".format(input_names)
+        return f"{layer_.name}_NODE_{input_names}"
+    return f"NODE_{input_names}"
 
 
 def set_name(layer, extra_id):
 
-    layer._name = "{}_{}".format(layer.name, extra_id)
+    layer._name = f"{layer.name}_{extra_id}"
 
 
 def get_inputs(node, tensor_map):

--- a/decomon/models/utils.py
+++ b/decomon/models/utils.py
@@ -420,7 +420,7 @@ def fuse_forward_backward(
 
         return w_out_u_, b_out_u_, w_out_l_, b_out_l_
 
-    lambda_ = Lambda(lambda var: func(var), dtype=w_u.dtype)
+    lambda_ = Lambda(func, dtype=w_u.dtype)
 
     w_out_u_, b_out_u_, w_out_l_, b_out_l_ = lambda_([w_u, b_u, w_l, b_l] + back_bounds)
 

--- a/decomon/models/utils.py
+++ b/decomon/models/utils.py
@@ -495,12 +495,12 @@ def get_depth_dict(model):
 
     nodes_list = []
 
-    dico_depth = dict()
-    dico_nodes = dict()
+    dico_depth = {}
+    dico_nodes = {}
 
     def fill_dico(node, dico_depth=None):
         if dico_depth is None:
-            dico_depth = dict()
+            dico_depth = {}
 
         parents = node.parent_nodes
         if len(parents):

--- a/decomon/numpy/backward/core.py
+++ b/decomon/numpy/backward/core.py
@@ -30,7 +30,7 @@ class BackwardNumpyLayer:
 
         kwargs.pop("update_slope")
         kwargs.pop("reuse_slope")
-        super(BackwardNumpyLayer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if mode != F_FORWARD.name:
             raise NotImplementedError()
         self.keras_layer = keras_layer

--- a/decomon/numpy/backward/core.py
+++ b/decomon/numpy/backward/core.py
@@ -7,7 +7,7 @@ CROWN implementation in numpy (useful for MILP compatibility)
 """
 
 
-class BackwardNumpyLayer(object):
+class BackwardNumpyLayer:
     def __init__(self, keras_layer, convex_domain=None, mode=F_FORWARD.name, rec=1, params=None, **kwargs):
         """
 

--- a/decomon/numpy/backward/layers.py
+++ b/decomon/numpy/backward/layers.py
@@ -203,7 +203,7 @@ def get_backward(keras_layer, previous=True, mode=F_FORWARD.name, convex_domain=
         params = []
     class_name = keras_layer.__class__.__name__
 
-    backward_class_name = "BackwardNumpy{}".format(class_name)
+    backward_class_name = f"BackwardNumpy{class_name}"
     class_ = globals()[backward_class_name]
     try:
         return class_(

--- a/decomon/numpy/backward/layers.py
+++ b/decomon/numpy/backward/layers.py
@@ -26,7 +26,7 @@ class BackwardNumpyActivation(BackwardNumpyLayer):
         :param mode: type of Forward propagation (IBP, Forward or Hybrid)
         :param kwargs: extra parameters
         """
-        super(BackwardNumpyActivation, self).__init__(
+        super().__init__(
             keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, params=params, **kwargs
         )
         if convex_domain is None:
@@ -100,9 +100,7 @@ class BackwardNumpyInputLayer(BackwardNumpyLayer):
         :param mode: type of Forward propagation (IBP, Forward or Hybrid)
         :param kwargs: extra parameters
         """
-        super(BackwardNumpyInputLayer, self).__init__(
-            keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs
-        )
+        super().__init__(keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}
@@ -147,9 +145,7 @@ class BackwardNumpyDense(BackwardNumpyLayer):
         :param mode: type of Forward propagation (IBP, Forward or Hybrid)
         :param kwargs: extra parameters
         """
-        super(BackwardNumpyDense, self).__init__(
-            keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs
-        )
+        super().__init__(keras_layer=keras_layer, convex_domain=convex_domain, mode=mode, rec=rec, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}

--- a/decomon/numpy/backward/utils.py
+++ b/decomon/numpy/backward/utils.py
@@ -35,9 +35,7 @@ def get_lower(x, w, b, convex_domain=None):
     if not len(convex_domain) or convex_domain["name"] in [Box.name, Grid.name]:
         return get_lower_box(x, w, b)
     else:
-        raise NotImplementedError(
-            "get_lower is not implemented yet in numpy for the {} domain".format(convex_domain["name"])
-        )
+        raise NotImplementedError(f"get_lower is not implemented yet in numpy for the {convex_domain['name']} domain")
 
 
 def get_upper(x, w, b, convex_domain=None):
@@ -46,9 +44,7 @@ def get_upper(x, w, b, convex_domain=None):
     if not len(convex_domain) or convex_domain["name"] in [Box.name, Grid.name]:
         return get_upper_box(x, w, b)
     else:
-        raise NotImplementedError(
-            "get_upper is not implemented yet in numpy for the {} domain".format(convex_domain["name"])
-        )
+        raise NotImplementedError(f"get_upper is not implemented yet in numpy for the {convex_domain['name']} domain")
 
 
 def get_linear_hull_relu(inputs, convex_domain, params=None, **kwargs):

--- a/decomon/numpy/milp/activation.py
+++ b/decomon/numpy/milp/activation.py
@@ -82,7 +82,7 @@ def bound_A_ortools(x_min, x_max, m, W_up, b_up, W_low, b_low, mask_A):
     # lambda are binary variables.
 
     lambda_ = [
-        [[solver.IntVar(0, m, "lambda_{}_{}_{}".format(j, i, k)) for i in range(n_dim)] for k in range(n_out)]
+        [[solver.IntVar(0, m, f"lambda_{j}_{i}_{k}") for i in range(n_dim)] for k in range(n_out)]
         for j in range(n_batch)
     ]
 
@@ -155,7 +155,7 @@ def bound_B_ortools(x_min, x_max, m, W_up, b_up, W_low, b_low, mask_B):
     solver = pywraplp.Solver.CreateSolver("SCIP")
     # lambda are binary variables.
     lambda_ = [
-        [[solver.IntVar(0, m, "lambda_{}_{}_{}".format(j, i, k)) for i in range(n_dim)] for k in range(n_out)]
+        [[solver.IntVar(0, m, f"lambda_{j}_{i}_{k}") for i in range(n_dim)] for k in range(n_out)]
         for j in range(n_batch)
     ]
 

--- a/decomon/numpy/models/backward_cloning.py
+++ b/decomon/numpy/models/backward_cloning.py
@@ -40,7 +40,7 @@ def crown_(
         slope_grid = {}
     previous = bool(len(backward_bounds))
 
-    params_key = "{}_{}".format(node.outbound_layer.name, rec)
+    params_key = f"{node.outbound_layer.name}_{rec}"
     if params_key in dico_grid.keys():
         params = dico_grid[params_key]
         if params_key in slope_grid.keys():
@@ -49,9 +49,9 @@ def crown_(
         params = [None, None]
 
     if joint:
-        layer_key = "{}".format(node.outbound_layer.name)
+        layer_key = f"{node.outbound_layer.name}"
     else:
-        layer_key = "{}_{}".format(node.outbound_layer.name, rec)
+        layer_key = f"{node.outbound_layer.name}_{rec}"
 
     if layer_key in log_layers.keys():
         crown_layer = log_layers[layer_key]
@@ -171,7 +171,7 @@ def crown_old(
         slope_grid = {}
     previous = bool(len(backward_bounds))
 
-    params_key = "{}_{}".format(node.outbound_layer.name, rec)
+    params_key = f"{node.outbound_layer.name}_{rec}"
     if params_key in dico_grid.keys():
         params = dico_grid[params_key]
         if params_key in slope_grid.keys():

--- a/decomon/numpy/models/backward_cloning.py
+++ b/decomon/numpy/models/backward_cloning.py
@@ -29,7 +29,7 @@ def crown_(
     if forward_init is None:
         forward_init = []
     if log_bounds is None:
-        log_bounds = dict()
+        log_bounds = {}
     if log_layers is None:
         log_layers = {}
     if convex_domain is None:
@@ -162,7 +162,7 @@ def crown_old(
     if forward_init is None:
         forward_init = []
     if log_bounds is None:
-        log_bounds = dict()
+        log_bounds = {}
     if convex_domain is None:
         convex_domain = {}
     if dico_grid is None:
@@ -280,7 +280,7 @@ def crown(
         outputs_nodes,
         backward_bounds=backward_bounds,
         forward_init=forward_init,
-        log_bounds=dict(),
+        log_bounds={},
         convex_domain=convex_domain,
         dico_grid=dico_grid,
         slope_grid=slope_grid,

--- a/decomon/numpy/models/backward_cloning.py
+++ b/decomon/numpy/models/backward_cloning.py
@@ -291,7 +291,7 @@ def crown(
     return toto[0]
 
 
-class NumpyModel(object):
+class NumpyModel:
     def __init__(
         self,
         model,

--- a/decomon/numpy/models/backward_cloning.py
+++ b/decomon/numpy/models/backward_cloning.py
@@ -342,7 +342,7 @@ class NumpyCROWNModel(NumpyModel):
         joint=False,
         **kwargs,
     ):
-        super(NumpyCROWNModel, self).__init__(
+        super().__init__(
             model,
             ibp=ibp,
             forward=forward,

--- a/decomon/utils.py
+++ b/decomon/utils.py
@@ -857,7 +857,7 @@ def set_mode(x, final_mode, mode, convex_domain=None):
 
 
 def get_AB(model_):
-    dico_AB = dict()
+    dico_AB = {}
     convex_domain = model_.convex_domain
     if not (len(convex_domain) and convex_domain["name"] == "grid" and convex_domain["option"] == "milp"):
         return dico_AB
@@ -873,7 +873,7 @@ def get_AB(model_):
 
 
 def get_AB_finetune(model_):
-    dico_AB = dict()
+    dico_AB = {}
     convex_domain = model_.convex_domain
     if not (len(convex_domain) and convex_domain["name"] == "grid" and convex_domain["option"] == "milp"):
         return dico_AB

--- a/decomon/utils.py
+++ b/decomon/utils.py
@@ -866,7 +866,7 @@ def get_AB(model_):
         name = layer.name
         sub_names = name.split("backward_activation")
         if len(sub_names) > 1:
-            key = "{}_{}".format(layer.layer.name, layer.rec)
+            key = f"{layer.layer.name}_{layer.rec}"
             if key not in dico_AB:
                 dico_AB[key] = layer.grid_finetune
     return dico_AB
@@ -885,7 +885,7 @@ def get_AB_finetune(model_):
         name = layer.name
         sub_names = name.split("backward_activation")
         if len(sub_names) > 1:
-            key = "{}_{}".format(layer.layer.name, layer.rec)
+            key = f"{layer.layer.name}_{layer.rec}"
             if key not in dico_AB:
                 dico_AB[key] = layer.alpha_b_l
     return dico_AB

--- a/decomon/wrapper.py
+++ b/decomon/wrapper.py
@@ -69,7 +69,7 @@ def get_adv_box(
 
     z = np.concatenate([x_min, x_max], 1)
 
-    if isinstance(source_labels, int) or isinstance(source_labels, np.int64):
+    if isinstance(source_labels, (int, np.int64)):
         source_labels = np.zeros((n_batch, 1)) + source_labels
 
     if isinstance(source_labels, list):
@@ -260,7 +260,7 @@ def check_adv_box(model, x_min, x_max, source_labels, target_labels=None, batch_
     x_max = x_max.reshape((-1, 1, input_dim))
 
     z = np.concatenate([x_min, x_max], 1)
-    if isinstance(source_labels, int) or isinstance(source_labels, np.int64):
+    if isinstance(source_labels, (int, np.int64)):
         source_labels = np.zeros((n_batch, 1)) + source_labels
 
     if isinstance(source_labels, list):
@@ -377,7 +377,7 @@ def get_upper_box(model, x_min, x_max, batch_size=-1, n_sub_boxes=1, fast=True):
     fast = True
     # check that the model is a DecomonModel, else do the conversion
     # input_dim = 0
-    if not (isinstance(model, DecomonModel) or isinstance(model, NumpyModel)):
+    if not (isinstance(model, (DecomonModel, NumpyModel))):
         model_ = convert(model, ibp=True, forward=True)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [Box.name, Grid.name]
@@ -489,7 +489,7 @@ def get_lower_box(model, x_min, x_max, batch_size=-1, n_sub_boxes=1, fast=True):
     fast = True
     # check that the model is a DecomonModel, else do the conversion
     # input_dim = 0
-    if not (isinstance(model, DecomonModel) or isinstance(model, NumpyModel)):
+    if not (isinstance(model, (DecomonModel, NumpyModel))):
         model_ = convert(model, ibp=True, forward=True)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [Box.name, Grid.name]
@@ -601,7 +601,7 @@ def get_range_box(model, x_min, x_max, batch_size=-1, n_sub_boxes=1, fast=True):
     fast = True
     # check that the model is a DecomonModel, else do the conversion
     # input_dim = 0
-    if not (isinstance(model, DecomonModel) or isinstance(model, NumpyModel)):
+    if not (isinstance(model, (DecomonModel, NumpyModel))):
         model_ = convert(model, ibp=True, forward=True)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [Box.name, Grid.name]
@@ -1310,7 +1310,7 @@ def get_adv_noise(
     x_ = x + 0 * x
     x_ = x_.reshape([-1] + input_shape)
 
-    if isinstance(source_labels, int) or isinstance(source_labels, np.int64):
+    if isinstance(source_labels, (int, np.int64)):
         source_labels = np.zeros((n_batch, 1)) + source_labels
 
     if isinstance(source_labels, list):

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -566,7 +566,7 @@ from . import (
 )
 def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
 
-    K.set_floatx("float{}".format(floatx))
+    K.set_floatx(f"float{floatx}")
     eps = K.epsilon()
     decimal = 5
     if floatx == 16:
@@ -619,7 +619,7 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             w_l_,
             b_l_,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
 
@@ -640,7 +640,7 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             w_l_,
             b_l_,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
 
@@ -659,7 +659,7 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             None,
             None,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
     if not shared:
@@ -681,7 +681,7 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             w_l_,
             b_l_,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
 
@@ -702,7 +702,7 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             w_l_,
             b_l_,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
 
@@ -721,12 +721,12 @@ def test_DecomonDense_1D_box(n, activation, mode, shared, floatx):
             l_c_,
             None,
             None,
-            "dense_{}".format(n),
+            f"dense_{n}",
             decimal=decimal,
         )
 
     K.set_epsilon(eps)
-    K.set_floatx("float{}".format(32))
+    K.set_floatx("float32")
 
 
 @pytest.mark.parametrize(
@@ -792,7 +792,7 @@ def test_DecomonDense_multiD_box(odd, activation, mode):
             l_c_,
             w_l_,
             b_l_,
-            "dense_multid_{}".format(odd),
+            f"dense_multid_{odd}",
         )
     if mode == "forward":
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
@@ -811,7 +811,7 @@ def test_DecomonDense_multiD_box(odd, activation, mode):
             l_c_,
             w_l_,
             b_l_,
-            "dense_multid_{}".format(odd),
+            f"dense_multid_{odd}",
         )
     if mode == "ibp":
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])


### PR DESCRIPTION
We followed suggestions from https://codereview.doctor/airbus/decomon.

- Use list and dict comprehensions
- Avoid unnecessary inheriting from object
- Use f-string instead of legacy string formatting
- Use literals instead of calling list/set/dict
- Avoid unnecessarily wrapping a function in a `lambda`
- Avoid unnecessary arguments in `super` call
- Avoid multiple isinstance calls

Arguments in favor of these changes can be found at https://codereview.doctor/features/python/best-practice/maintainability.

Fixing `super()` calls highlight missing calls to `super().__init__()` in decomon/layers/utils.py (before only `super()` was called which is doing nothing).

