### PR TITLE
Generate and deploy dev doc via github actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -59,3 +59,63 @@ jobs:
             tox-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
       - name: Run tox target env for ${{ matrix.python-version }}
         run: python -m tox -e py
+
+  build-doc:
+    runs-on: ubuntu-latest
+    env:
+      python-version: "3.9"
+    steps:
+      - name: Set env variables for github links in doc
+        run: |
+          # notebooks source repo and branch depending if it is a commit push or a PR
+          if [[ $GITHUB_REF == refs/pull* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL="${GITHUB_SERVER_URL}/${{ github.event.pull_request.head.repo.full_name }}"
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_HEAD_REF}
+          elif [[ $GITHUB_REF == refs/heads* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/heads\//}
+          elif [[ $GITHUB_REF == refs/tags* ]];
+          then
+              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}
+          fi
+          # export in GITHUB_ENV for next steps
+          echo "AUTODOC_NOTEBOOKS_REPO_URL=${AUTODOC_NOTEBOOKS_REPO_URL}" >> $GITHUB_ENV
+          echo "AUTODOC_NOTEBOOKS_BRANCH=${AUTODOC_NOTEBOOKS_BRANCH}" >> $GITHUB_ENV
+          # check computed variables
+          echo "Notebooks source: ${AUTODOC_NOTEBOOKS_REPO_URL}/tree/${AUTODOC_NOTEBOOKS_BRANCH}"
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            docs/requirements.txt
+      - name: Install doc dependencies
+        run: |
+          python -m pip install -U pip setuptools
+          pip install .
+          pip install -r docs/requirements.txt
+      - name: generate documentation
+        run: |
+          # move to documentation directory
+          cd docs
+          # generate api doc source files
+          sphinx-apidoc -o source/api -f -T ../src/decomon
+          # generate available notebooks list
+          python generate_nb_index.py
+          # build doc html pages
+          sphinx-build -M html source build
+          # specify it is a nojekyll site
+          touch build/html/.nojekyll
+      - name: upload as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc
+          path: docs/build/html

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -119,3 +119,56 @@ jobs:
         with:
           name: doc
           path: docs/build/html
+
+  deploy-dev-doc:
+    # for default branch (main)
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs: [build-doc, tests, linters]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: doc
+          path: docs/build/html
+      - name: Deploy documentation in a version subfolder on GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/build/html # The folder the action should deploy.
+          target-folder: /${{ github.event.repository.default_branch }} # The folder the action should deploy to.
+          commit-message: publish documentation for ${{ github.event.repository.default_branch }}
+
+  update-doc-versions:
+    # update doc versions index if the doc has been deployed
+    needs: [deploy-dev-doc]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+      - uses: actions/setup-python@v4
+      - name: Generate versions.json
+        shell: python3 {0}
+        run: |
+          import json
+          from pathlib import Path
+
+          cwd = Path.cwd()
+          versions = sorted((item.name for item in cwd.iterdir()
+                             if item.is_dir() and not item.name.startswith('.')),
+                            reverse=True)
+          target_dir = Path('gh-pages')
+          target_dir.mkdir(parents=True)
+          target_file = target_dir / 'versions.json'
+          with target_file.open('w') as f:
+              json.dump(versions, f)
+      - name: Commit versions.json
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: gh-pages # The folder the action should deploy.
+          target-folder: / # The folder the action should deploy to.
+          commit-message: update versions.json
+          clean: false  # do not remove other files (including whole doc versions)


### PR DESCRIPTION
At each push, the doc
- is generated
- is uploaded as an artifact
- is published if on default branch (main) via github pages (available at https://airbus.github.io/decomon/main)

Notes:
- One can have a look to the generated doc, even when not on the default branch by:
  - Downloading it (click on the appropriate "doc" link in the available artifacts link in the github action summary
  - Extracting it to a folder: `mkdir tmp; mv ~/Downloads/doc.zip tmp; cd tmp; unzip doc.zip`
  - Serving it with an html server: `python -m http.server`
- To allow the github pages publication, it is necessary to activate it via repository settings, and to choose gh-pages branch as github-pages source