### PR TITLE
Add tutorials on colab

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -13,6 +13,20 @@ on:
         required: false
         default: "docs/build/html"
         type: string
+      notebooks-repo-url:
+        description: |
+          Url of the repository containing the notebooks, used to generate github and colab links.
+          By default, the current repository url.
+        required: false
+        default: ""
+        type: string
+      notebooks-branch:
+        description: |
+          Branch containing the notebooks, used to generate github and colab links.
+          By default, the current branch.
+        required: false
+        default: ""
+        type: string
     outputs:
       doc-version:
         description: "Version name of the generated doc. Correspond to the verrsion name used by Sphinx."
@@ -28,19 +42,34 @@ jobs:
     steps:
       - name: Set env variables for github links in doc
         run: |
-          # notebooks source repo and branch depending if it is a commit push or a PR
+          # notebooks source repo and branch. First try to use workflow inputs
+          AUTODOC_NOTEBOOKS_REPO_URL=${{ inputs.notebooks-repo-url }}
+          AUTODOC_NOTEBOOKS_BRANCH=${{ inputs.notebooks-branch }}
+          # use github context if not defined in inputs
           if [[ $GITHUB_REF == refs/pull* ]];
           then
-              AUTODOC_NOTEBOOKS_REPO_URL="${GITHUB_SERVER_URL}/${{ github.event.pull_request.head.repo.full_name }}"
-              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_HEAD_REF}
+              if [ -z "${AUTODOC_NOTEBOOKS_REPO_URL}" ]; then
+                AUTODOC_NOTEBOOKS_REPO_URL="${GITHUB_SERVER_URL}/${{ github.event.pull_request.head.repo.full_name }}"
+              fi
+              if [ -z "${AUTODOC_NOTEBOOKS_BRANCH}" ]; then
+                AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_HEAD_REF}
+              fi
           elif [[ $GITHUB_REF == refs/heads* ]];
           then
-              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
-              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/heads\//}
+              if [ -z "${AUTODOC_NOTEBOOKS_REPO_URL}" ]; then
+                AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              fi
+              if [ -z "${AUTODOC_NOTEBOOKS_BRANCH}" ]; then
+                AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/heads\//}
+              fi
           elif [[ $GITHUB_REF == refs/tags* ]];
           then
-              AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
-              AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}
+              if [ -z "${AUTODOC_NOTEBOOKS_REPO_URL}" ]; then
+                AUTODOC_NOTEBOOKS_REPO_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+              fi
+              if [ -z "${AUTODOC_NOTEBOOKS_BRANCH}" ]; then
+                AUTODOC_NOTEBOOKS_BRANCH=${GITHUB_REF/refs\/tags\//}
+              fi
           fi
           # export in GITHUB_ENV for next steps
           echo "AUTODOC_NOTEBOOKS_REPO_URL=${AUTODOC_NOTEBOOKS_REPO_URL}" >> $GITHUB_ENV

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.get_package_version.outputs.version }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -20,6 +22,13 @@ jobs:
     - name: Build package
       run: |
         python -m build
+    - name: get package version and save it
+      id: get_package_version
+      run: |
+        wheelfile=$(ls ./dist/decomon*.whl)
+        version=$(python -c "print('$wheelfile'.split('-')[1])")
+        echo "version=$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: Upload as build artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -41,8 +50,42 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
+  update-tutorials-for-colab:
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    outputs:
+      tuto-tag-name: ${{ steps.push-tuto-release-tag.outputs.new_tag_name }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: replace decomon version to install in notebooks
+        run: |
+          version=${{ needs.deploy.outputs.package_version }}
+          old_pip_spec_pattern="\(pip.*install.*\)git+https.*egg=decomon"
+          new_pip_spec_pattern="\1decomon==$version"
+          if ${{ github.repository != 'airbus/discrete-optimization' && secrets.TEST_PYPI_API_TOKEN != '' }} == 'true'; then
+            # install from TestPypi if on a fork
+            new_pip_spec_pattern="${new_pip_spec_pattern} --extra-index-url https://test.pypi.org/simple/"
+          fi
+          sed -i -e "s|${old_pip_spec_pattern}|${new_pip_spec_pattern}|" tutorials/*.ipynb
+      - name: push it on a dedicated tag
+        id: push-tuto-release-tag
+        run: |
+          current_tag_name=${GITHUB_REF/refs\/tags\//}  # stripping refs/tags/
+          new_tag_name="tutorials-${current_tag_name}"
+          echo ${new_tag_name}
+          git config user.name "Actions"
+          git config user.email "actions@github.com"
+          git commit tutorials/*.ipynb -m "Install appropriate version of decomon"
+          git tag ${new_tag_name} -m "Release ${current_tag_name} + installation in tutorials updated"
+          git push origin ${new_tag_name}
+          # store new tag name
+          echo "new_tag_name=${new_tag_name}" >> $GITHUB_OUTPUT
+
   build-doc:
     uses: ./.github/workflows/build-doc.yml
+    with:
+      notebooks-branch: ${{ needs.update-tutorials-for-colab.outputs.tuto-tag-name }}
+    needs: ["update-tutorials-for-colab"]
 
   deploy-doc:
     needs: [build-doc, deploy]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,6 @@ repos:
         name: nbqa-pycln
         alias: nbqa-pycln
         additional_dependencies: [pycln]
-        args: ["--all"]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.5.0

--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -98,7 +98,7 @@ pip install -r docs/requirements.txt
 
 #### Define environment variables for notebook github links
 
-In order to define appropriate github links for notebooks,
+In order to define appropriate github and colab links for notebooks,
 we need several environment variables:
 
 - AUTODOC_NOTEBOOKS_REPO_URL: url of the content repository for the notebooks

--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -228,6 +228,7 @@ If you prefer run pre-commit manually, you can remove the hooks with `pre-commit
 
 We try to give some introductory examples via notebooks available in the corresponding `tutorials/` directory.
 
+#### Title and description extraction
 The list of these notebooks is automatically inserted in the documentation with a title and a description.
 These are actually extracted from the first cell. To enable that, each notebook should
 
@@ -236,7 +237,6 @@ These are actually extracted from the first cell. To enable that, each notebook 
 - the remaining lines being used as the description.
 
 For instance:
-
 ```markdown
 # Great notebook title
 
@@ -246,6 +246,23 @@ Can be on several lines.
 Can include a nice thumbnail.
 ![Notebook_thumbnail](https://upload.wikimedia.org/wikipedia/commons/2/27/MnistExamples.png)
 ```
+
+#### Colab specificities
+In order to make it work on colab, you should also adding a cell that, after testing that the notebook is run on colab,
+install decomon and other necessary dependencies:
+```python
+# On Colab: install the library
+on_colab = "google.colab" in str(get_ipython())
+if on_colab:
+    import sys  # noqa: avoid having this import removed by pycln
+
+    # install dev version for dev doc, or release version for release doc
+    !{sys.executable} -m pip install -U pip
+    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@main#egg=decomon
+```
+When deployed in the release doc, the pip spec for decomon will be automatically updated to "decomon==x.y.z",
+"x.y.z" being the appropriate version.
+
 
 ### Adding unit tests
 

--- a/tutorials/tutorial1_sinus-interactive.ipynb
+++ b/tutorials/tutorial1_sinus-interactive.ipynb
@@ -23,6 +23,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "- When running this notebook on Colab, we need to install *decomon* if on Colab. \n",
+    "- If you run this notebook locally, do it inside the environment in which you [installed *decomon*](https://airbus.github.io/decomon/main/install.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Colab: install the library\n",
+    "on_colab = \"google.colab\" in str(get_ipython())\n",
+    "if on_colab:\n",
+    "    import sys  # noqa: avoid having this import removed by pycln\n",
+    "\n",
+    "    # install dev version for dev doc, or release version for release doc\n",
+    "    !{sys.executable} -m pip install -U pip\n",
+    "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@main#egg=decomon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Imports"
    ]
   },
@@ -42,10 +66,7 @@
     "from tensorflow.keras.layers import Activation, Dense\n",
     "from tensorflow.keras.models import Sequential\n",
     "\n",
-    "print(\"Notebook run using keras:\", keras.__version__)\n",
-    "import sys\n",
-    "\n",
-    "sys.path.append(\"..\")"
+    "print(\"Notebook run using keras:\", keras.__version__)"
    ]
   },
   {

--- a/tutorials/tutorial2_noise_sensor.ipynb
+++ b/tutorials/tutorial2_noise_sensor.ipynb
@@ -24,6 +24,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "- When running this notebook on Colab, we need to install *decomon* if on Colab. \n",
+    "- If you run this notebook locally, do it inside the environment in which you [installed *decomon*](https://airbus.github.io/decomon/main/install.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Colab: install the library\n",
+    "on_colab = \"google.colab\" in str(get_ipython())\n",
+    "if on_colab:\n",
+    "    import sys  # noqa: avoid having this import removed by pycln\n",
+    "\n",
+    "    # install dev version for dev doc, or release version for release doc\n",
+    "    !{sys.executable} -m pip install -U pip\n",
+    "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@main#egg=decomon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Toy Example: Electric Motor Temperature\n",
     "\n",
     "We will demonstrate how to perform **Local Robustness to sensoir noise** on a surrogate toy case.\n",
@@ -55,6 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
     "import time\n",
     "\n",
     "import matplotlib.pyplot as plt\n",

--- a/tutorials/tutorial3_adversarial_attack.ipynb
+++ b/tutorials/tutorial3_adversarial_attack.ipynb
@@ -24,6 +24,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "- When running this notebook on Colab, we need to install *decomon* if on Colab. \n",
+    "- If you run this notebook locally, do it inside the environment in which you [installed *decomon*](https://airbus.github.io/decomon/main/install.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Colab: install the library\n",
+    "on_colab = \"google.colab\" in str(get_ipython())\n",
+    "if on_colab:\n",
+    "    import sys  # noqa: avoid having this import removed by pycln\n",
+    "\n",
+    "    # install dev version for dev doc, or release version for release doc\n",
+    "    !{sys.executable} -m pip install -U pip\n",
+    "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@main#egg=decomon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Imports"
    ]
   },
@@ -34,6 +58,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "import matplotlib.patches as patches\n",
     "import matplotlib.pyplot as plt\n",

--- a/tutorials/tutorial4_adversarial_brightness.ipynb
+++ b/tutorials/tutorial4_adversarial_brightness.ipynb
@@ -23,6 +23,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8baef934",
+   "metadata": {},
+   "source": [
+    "- When running this notebook on Colab, we need to install *decomon* if on Colab. \n",
+    "- If you run this notebook locally, do it inside the environment in which you [installed *decomon*](https://airbus.github.io/decomon/main/install.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8226fc13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# On Colab: install the library\n",
+    "on_colab = \"google.colab\" in str(get_ipython())\n",
+    "if on_colab:\n",
+    "    # install dev version for dev doc, or release version for release doc\n",
+    "    import sys  # noqa: avoid having this import removed by pycln\n",
+    "\n",
+    "    !{sys.executable} -m pip install -U pip\n",
+    "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@main#egg=decomon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "musical-commodity",
    "metadata": {},
    "source": [
@@ -37,6 +63,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "import matplotlib.patches as patches\n",
     "import matplotlib.pyplot as plt\n",


### PR DESCRIPTION
- Add links in doc for opening notebooks in colab
- Add a cell in notebooks installing decomon (from main branch) in case they are run from colab
- When deploying a release (tag "vx.y.z") we modify the notebooks to install decomon from pip with the appropriate version number and push them to a dedicated tag ("tutorials-vx.y.z"), and the links in the release doc will point to them