### PR TITLE
Add coverage in test suite

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -39,6 +39,9 @@ jobs:
         python-version: ["3.7", "3.9"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -57,10 +60,26 @@ jobs:
           path: .tox
           key:
             tox-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
-      - name: Run tox target env for ${{ matrix.python-version }}
+      - name: Pick proper tox env
+        shell: python
+        run: |
+          import os; import platform; import sys; from pathlib import Path
+          platform_mapping = {
+              "Linux": "linux",
+              "Darwin": "macos",
+              "Windows": "win",
+          }
+          pythonversion = f'py{"" if platform.python_implementation() == "CPython" else "py"}3{sys.version_info.minor}'
+          platformversion=platform_mapping[platform.system()]
+          toxenv = f"{pythonversion}-{platformversion}"
+          set_toxenv_cmd = f"TOXENV={toxenv}"
+          print(f"Picked: {toxenv}")
+          with Path(os.environ["GITHUB_ENV"]).open("ta") as file_handler:
+               file_handler.write(set_toxenv_cmd)
+      - name: Run tox target env for ${{ env.TOXENV }}
         run: |
           python -m tox -e convert-doc-to-test  # extract code blocks from doc to test them
-          python -m tox -e py
+          python -m tox  # launch environment set by TOXENV at previous step
 
   build-doc:
     uses: ./.github/workflows/build-doc.yml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -82,6 +82,24 @@ jobs:
         run: |
           python -m tox -e convert-doc-to-test  # extract code blocks from doc to test them
           python -m tox  # launch environment set by TOXENV at previous step
+      - name: Check if coverage report exists
+        id: check-coverage-report
+        run: |
+          if [ -f coverage.xml ]; then
+            coverage_exists=true
+          else
+            coverage_exists=false
+          fi
+          echo ${coverage_exists}
+          echo "coverage_exists=${coverage_exists}" >> $GITHUB_OUTPUT
+      - name: Export coverage report (if existing)
+        if: steps.check-coverage-report.outputs.coverage_exists == 'true'
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: |
+            coverage.xml
+            coverage_html
 
   build-doc:
     uses: ./.github/workflows/build-doc.yml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           path: .tox
           key:
-            tox-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+            tox-${{ matrix.python-version }}-${{ matrix.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys:
+            tox-${{ matrix.python-version }}-${{ matrix.os }}
       - name: Pick proper tox env
         shell: python
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,29 @@ isolated_build = True
 envlist =
     pre-commit
     convert-doc-to-test
-    py{37,39}
+    py{37,39}-{linux,macos,win}
 
 [testenv]
+platform = linux: linux
+           macos: darwin
+           win: win32
 deps =
     pytest
 commands =
     pytest -v {posargs}
+
+[testenv:py39-linux]
+# coverage in only one env
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest -v \
+      --cov decomon \
+      --cov-report xml:coverage.xml \
+      --cov-report html:coverage_html \
+      --cov-report term \
+      {posargs}
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
- Add coverage only for one tox env (py39-linux) to avoid duplicate report
- Upload the coverage report as an artifact