### PR TITLE
Add index.html and .nojekyll at github pages root

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0; url=main/" />
+        <link rel="canonical" href="main/" />
+    </head>
+
+    <body>
+        <p>
+            The page been moved to <a href="main/">main/</a>
+        </p>
+    </body>
+</html>
+


### PR DESCRIPTION
- .nojekyll: tells github pages that this is not a Jekyll website
- index:html: the documentation versions are available under subdirectories "main/" for default branch, and "x.y.z" for release "x.y.z". So we need an index file at root of https://airbus.github.io/decomon redirecting towards a valid documentation. Here we chose the developper documentation corresponding to code available in "main" branch