### PR TITLE
Use x.dtype instead of K.floatx() in K.cast()

### DIFF
--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -121,7 +121,7 @@ def linear_hull_s_shape(
             # it happens with the convert function to spare memory footprint
             n_dim = np.prod(w_u.shape[1:])
             M = np.reshape(
-                np.diag([K.cast(1, dtype=K.floatx())] * n_dim), [1, n_dim] + list(w_u.shape[1:])
+                np.diag([K.cast(1, dtype=w_u_0.dtype)] * n_dim), [1, n_dim] + list(w_u.shape[1:])
             )  # usage de numpy pb pour les types
             w_u_ = M * K.concatenate([K.expand_dims(w_u_0, 1)] * n_dim, 1)
             w_l_ = M * K.concatenate([K.expand_dims(w_l_0, 1)] * n_dim, 1)

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -1256,7 +1256,7 @@ def log(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, **kwargs):
             x_0, w_u, b_u, w_l, b_l = x
             u_c = get_upper(x_0, w_u, b_u, convex_domain=convex_domain)
             l_c = get_lower(x_0, w_l, b_l, convex_domain=convex_domain)
-            l_c = K.maximum(K.epsilon(), l_c)
+            l_c = K.maximum(K.cast(K.epsilon(), dtype=l_c.dtype), l_c)
         else:
             x_0, u_c, w_u, b_u, l_c, w_l, b_l = x
 

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -253,7 +253,7 @@ def get_adv_loss(model, sigmoid=False, clip_value=None, softmax=False):
         M = t_tensor * s_tensor
         upper = K.expand_dims(u_c, -1) - K.expand_dims(l_c, 1)
         const = (K.max(upper, (-1, -2)) - K.min(upper, (-1, -2)))[:, None, None]
-        upper = upper - (const + K.cast(1, K.floatx())) * (1 - M)
+        upper = upper - (const + K.cast(1, const.dtype)) * (1 - M)
         return K.max(upper, (-1, -2))
 
     def adv_forward(x, w_u, b_u, w_l, b_l, y_tensor):
@@ -274,7 +274,7 @@ def get_adv_loss(model, sigmoid=False, clip_value=None, softmax=False):
         M = t_tensor * s_tensor
 
         const = (K.max(upper, (-1, -2)) - K.min(upper, (-1, -2)))[:, None, None]
-        upper = upper - (const + K.cast(1, K.floatx())) * (1 - M)
+        upper = upper - (const + K.cast(1, const.dtype)) * (1 - M)
         return K.max(upper, (-1, -2))
 
     def loss_adv(y_true, y_pred):
@@ -383,7 +383,7 @@ class DecomonLossFusion(DecomonLayer):
                 M = t_tensor * s_tensor
                 upper = K.expand_dims(u_c, -1) - K.expand_dims(l_c, 1)
                 const = (K.max(upper, (-1, -2)) - K.min(upper, (-1, -2)))[:, None, None]
-                upper = upper - (const + K.cast(1, K.floatx())) * (1 - M)
+                upper = upper - (const + K.cast(1, const.dtype)) * (1 - M)
                 return K.max(upper, (-1, -2))
 
             source_tensor = tf.linalg.diag(K.ones_like(l_c))

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -246,8 +246,8 @@ def clone(
 
     if len(convex_domain) == 0 or convex_domain["name"] != Ball.name:
 
-        u_c_tensor = Lambda(lambda z: z[:, 1])(z_tensor)
-        l_c_tensor = Lambda(lambda z: z[:, 0])(z_tensor)
+        u_c_tensor = Lambda(lambda z: z[:, 1], dtype=z_tensor.dtype)(z_tensor)
+        l_c_tensor = Lambda(lambda z: z[:, 0], dtype=z_tensor.dtype)(z_tensor)
 
         z_value = K.cast(0.0, z_tensor.dtype)
         o_value = K.cast(1.0, z_tensor.dtype)

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -824,8 +824,8 @@ def relu_(x, dc_decomp=False, convex_domain=None, mode=F_HYBRID.name, slope=V_sl
     if mode not in [F_HYBRID.name, F_IBP.name, F_FORWARD.name]:
         raise ValueError(f"unknown mode {mode}")
 
-    z_value = K.cast(0.0, K.floatx())
-    o_value = K.cast(1.0, K.floatx())
+    z_value = K.cast(0.0, dtype=x[0].dtype)
+    o_value = K.cast(1.0, dtype=x[0].dtype)
 
     nb_tensors = StaticVariables(dc_decomp=False, mode=mode).nb_tensors
     if mode == F_HYBRID.name:
@@ -1043,7 +1043,7 @@ def get_linear_hull_s_shape(x, func=K.sigmoid, f_prime=sigmoid_prime, convex_dom
     s_l = func(l_c_flat)  # (None, n)
 
     # case 0:
-    coeff = (s_u - s_l) / K.maximum(K.cast(K.epsilon(), K.floatx()), u_c_flat - l_c_flat)
+    coeff = (s_u - s_l) / K.maximum(K.cast(K.epsilon(), dtype=x[0].dtype), u_c_flat - l_c_flat)
     alpha_u_0 = K.switch(greater_equal(s_u_prime, coeff), o_value + z_value * u_c_flat, z_value * u_c_flat)  # (None, n)
     alpha_u_1 = (o_value - alpha_u_0) * ((K.sign(l_c_flat) + o_value) / t_value)
 
@@ -1098,7 +1098,7 @@ def get_t_upper(u_c_flat, l_c_flat, s_l, func=K.sigmoid, f_prime=sigmoid_prime):
     # step1: find t
     u_c_flat_ = K.expand_dims(u_c_flat, -1)  # (None, n , 1)
     l_c_flat_ = K.expand_dims(l_c_flat, -1)  # (None, n,  1)
-    t_ = K.cast(np.linspace(0, 1, 100)[None, None, :], K.floatx()) * u_c_flat_  # (None, n , 100)
+    t_ = K.cast(np.linspace(0, 1, 100)[None, None, :], dtype=u_c_flat.dtype) * u_c_flat_  # (None, n , 100)
 
     s_p_t_ = f_prime(t_)  # (None, n, 100)
     s_t_ = func(t_)  # (None, n, 100)
@@ -1113,7 +1113,7 @@ def get_t_upper(u_c_flat, l_c_flat, s_l, func=K.sigmoid, f_prime=sigmoid_prime):
     t_value = K.sum(
         K.switch(
             K.equal(
-                o_value * K.cast(np.arange(0, 100)[None, None, :], K.floatx()) + z_value * u_c_flat_,
+                o_value * K.cast(np.arange(0, 100)[None, None, :], dtype=u_c_flat.dtype) + z_value * u_c_flat_,
                 K.expand_dims(index_t, -1) + z_value * u_c_flat_,
             ),
             t_,
@@ -1149,7 +1149,7 @@ def get_t_lower(u_c_flat, l_c_flat, s_u, func=K.sigmoid, f_prime=sigmoid_prime):
     # step1: find t
     u_c_flat_ = K.expand_dims(u_c_flat, -1)  # (None, n , 1)
     l_c_flat_ = K.expand_dims(l_c_flat, -1)  # (None, n,  1)
-    t_ = K.cast(np.linspace(0, 1.0, 100)[None, None, :], K.floatx()) * l_c_flat_  # (None, n , 100)
+    t_ = K.cast(np.linspace(0, 1.0, 100)[None, None, :], dtype=u_c_flat.dtype) * l_c_flat_  # (None, n , 100)
 
     s_p_t_ = f_prime(t_)  # (None, n, 100)
     s_t_ = func(t_)  # (None, n, 100)
@@ -1164,7 +1164,7 @@ def get_t_lower(u_c_flat, l_c_flat, s_u, func=K.sigmoid, f_prime=sigmoid_prime):
     t_value = K.sum(
         K.switch(
             K.equal(
-                o_value * K.cast(np.arange(0, 100)[None, None, :], K.floatx()) + z_value * u_c_flat_,
+                o_value * K.cast(np.arange(0, 100)[None, None, :], dtype=u_c_flat.dtype) + z_value * u_c_flat_,
                 K.expand_dims(index_t, -1) + z_value * u_c_flat_,
             ),
             t_,


### PR DESCRIPTION
When casting to a float, use rather dtype of current tensor instead of K.floatx() which sometimes does not reference the proper version of float (16, 32, or 64).

At some other places, we needed also to cast to the appropriate dtype and this PR fix them.