### PR TITLE
Add a binder environment to launch notebooks on binderhub

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -17,7 +17,27 @@ on:
         required: false
         default: "docs/build/html"
         type: string
+      binder-env-fullref:
+        description: "Full ref of the binder env to build. The build is triggered only if not empty."
+        required: false
+        default: ""
+        type: string
 jobs:
+  trigger-binder-build:
+    runs-on: ubuntu-latest
+    if: inputs.binder-env-fullref != ''
+    steps:
+      - uses: actions/checkout@v3  # checkout triggering branch to get scripts/trigger_binder.sh
+      - name: Trigger a build for default binder env ref on each BinderHub deployments in the mybinder.org federation
+        run: |
+          binder_env_full_ref=${{ inputs.binder-env-fullref }}
+          echo Triggering binder environment build for ${binder_env_full_ref}
+          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${binder_env_full_ref}
+          bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${binder_env_full_ref}
+          bash scripts/trigger_binder.sh https://ovh2.mybinder.org/build/gh/${binder_env_full_ref}
+          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${binder_env_full_ref}
+          bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${binder_env_full_ref}
+
   deploy-doc:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -104,7 +104,8 @@ jobs:
     needs: ["update-tutorials-for-colab-and-binder"]
 
   deploy-doc:
-    needs: [build-doc, deploy]
+    needs: [build-doc, deploy, update-tutorials-for-colab-and-binder]
     uses: ./.github/workflows/deploy-doc.yml
     with:
       doc-version: ${{ needs.build-doc.outputs.doc-version }}
+      binder-env-fullref: ${{ github.repository }}/${{ needs.update-tutorials-for-colab-and-binder.outputs.tuto-tag-name }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -53,14 +53,14 @@ jobs:
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
-  update-tutorials-for-colab:
+  update-tutorials-for-colab-and-binder:
     needs: [deploy]
     runs-on: ubuntu-latest
     outputs:
       tuto-tag-name: ${{ steps.push-tuto-release-tag.outputs.new_tag_name }}
     steps:
       - uses: actions/checkout@v3
-      - name: replace decomon version to install in notebooks
+      - name: replace decomon version to install in colab notebooks
         run: |
           version=${{ needs.deploy.outputs.package_version }}
           old_pip_spec_pattern="\(pip.*install.*\)git+https.*egg=decomon"
@@ -70,7 +70,20 @@ jobs:
             new_pip_spec_pattern="${new_pip_spec_pattern} --extra-index-url https://test.pypi.org/simple/"
           fi
           sed -i -e "s|${old_pip_spec_pattern}|${new_pip_spec_pattern}|" tutorials/*.ipynb
-      - name: push it on a dedicated tag
+      - name: replace decomon version to install in binder environment
+        run: |
+          version=${{ needs.deploy.outputs.package_version }}
+          linefilter="/^name/!"
+          old_pip_spec_pattern="\(\s*\)-.*decomon.*$"
+          new_pip_spec_pattern="\1- decomon==$version"
+          if ${{ github.repository != env.MAIN_REPO_NAME && secrets.TEST_PYPI_API_TOKEN != '' }} == 'true'; then
+            # install from TestPypi if on a fork
+            new_pip_spec_pattern="${new_pip_spec_pattern}\n\1- --extra-index-url https://test.pypi.org/simple/"
+          fi
+          sed_command="${linefilter}s|${old_pip_spec_pattern}|${new_pip_spec_pattern}|"
+          echo sed -i -e ${sed_command} binder/environment.yml
+          sed -i -e "${sed_command}" binder/environment.yml
+      - name: push modifications on a dedicated tag
         id: push-tuto-release-tag
         run: |
           current_tag_name=${GITHUB_REF/refs\/tags\//}  # stripping refs/tags/
@@ -78,7 +91,7 @@ jobs:
           echo ${new_tag_name}
           git config user.name "Actions"
           git config user.email "actions@github.com"
-          git commit tutorials/*.ipynb -m "Install appropriate version of decomon"
+          git commit binder/environment.yml tutorials/*.ipynb -m "Install appropriate version of decomon"
           git tag ${new_tag_name} -m "Release ${current_tag_name} + installation in tutorials updated"
           git push origin ${new_tag_name}
           # store new tag name
@@ -87,8 +100,8 @@ jobs:
   build-doc:
     uses: ./.github/workflows/build-doc.yml
     with:
-      notebooks-branch: ${{ needs.update-tutorials-for-colab.outputs.tuto-tag-name }}
-    needs: ["update-tutorials-for-colab"]
+      notebooks-branch: ${{ needs.update-tutorials-for-colab-and-binder.outputs.tuto-tag-name }}
+    needs: ["update-tutorials-for-colab-and-binder"]
 
   deploy-doc:
     needs: [build-doc, deploy]

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,8 @@
 name: pypi
 
+env:
+  MAIN_REPO_NAME: 'airbus/decomon'
+
 on:
   release:
     types: [published]
@@ -37,7 +40,7 @@ jobs:
     - name: Publish package to TestPyPI (only for forks)
       env:
         TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      if: github.repository != 'airbus/decomon' && env.TEST_PYPI_API_TOKEN != ''
+      if: github.repository != env.MAIN_REPO_NAME && env.TEST_PYPI_API_TOKEN != ''
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -45,7 +48,7 @@ jobs:
     - name: Publish package to PyPI (main repo)
       env:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      if: github.repository == 'airbus/decomon' && env.PYPI_API_TOKEN != ''
+      if: github.repository == env.MAIN_REPO_NAME && env.PYPI_API_TOKEN != ''
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
@@ -62,7 +65,7 @@ jobs:
           version=${{ needs.deploy.outputs.package_version }}
           old_pip_spec_pattern="\(pip.*install.*\)git+https.*egg=decomon"
           new_pip_spec_pattern="\1decomon==$version"
-          if ${{ github.repository != 'airbus/discrete-optimization' && secrets.TEST_PYPI_API_TOKEN != '' }} == 'true'; then
+          if ${{ github.repository != env.MAIN_REPO_NAME && secrets.TEST_PYPI_API_TOKEN != '' }} == 'true'; then
             # install from TestPypi if on a fork
             new_pip_spec_pattern="${new_pip_spec_pattern} --extra-index-url https://test.pypi.org/simple/"
           fi

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -111,3 +111,4 @@ jobs:
     uses: ./.github/workflows/deploy-doc.yml
     with:
       doc-version: ${{ needs.build-doc.outputs.doc-version }}
+      binder-env-fullref: ${{ github.repository }}/${{ github.ref_name}}

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,8 @@
+name: nb-decomon-py3.7
+channels:
+  - defaults
+dependencies:
+  - python=3.7
+  - pip
+  - pip:
+      - ..  # decomon

--- a/scripts/trigger_binder.sh
+++ b/scripts/trigger_binder.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# from https://github.com/scikit-hep/pyhf/blob/master/binder/trigger_binder.sh
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl -L --connect-timeout 10 --max-time 12 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
- Add the environment settings in binder/ directory
- Add the appropriate links to tutorials page of the doc to launch the notebooks
- Update the binder environment when publishing a release to use the decomon library published on PyPi (using the same tag "tutorials_vx.y.z" already created for colab)
- Trigger a build of binder environment at each release and each push on main branch (e.g. when merging PRs) to avoid long waiting time for users following the binder links