### PR TITLE
Unify decomon syntax throughout the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="https://raw.githubusercontent.com/airbus/decomon/main/docs/source/_static/banner.jpg" width="55%" alt="Decomon" align="center" />
+    <img src="https://raw.githubusercontent.com/airbus/decomon/main/docs/source/_static/banner.jpg" width="55%" alt="decomon" align="center" />
 </div>
 <br>
 
@@ -19,15 +19,15 @@
 </div>
 <br>
 
-# DecoMon: Automatic Certified Perturbation Analysis of Neural Networks
+# Decomon: Automatic Certified Perturbation Analysis of Neural Networks
 
 ## Introduction
 
-**What is DecoMon?** `DecoMon` is a library that allows the derivation of upper and lower bounds
+**What is decomon?** `decomon` is a library that allows the derivation of upper and lower bounds
 for the predictions of a Tensorflow/Keras neural network with perturbed inputs.
 In the current release, these bounds are represented as affine functions with respect to some variable under perturbation.
 
-Previous works that tackled certified robustness with backward propagation relied on forward upper and lower bounds. In `DecoMon`,
+Previous works that tackled certified robustness with backward propagation relied on forward upper and lower bounds. In `decomon`,
 we explored various ways to tighten forward upper and lower bounds, while remaining backpropagation-compatible
  thanks to symbolic optimization.
 
@@ -35,10 +35,10 @@ Our algorithm improves existing forward linear relaxation algorithms for general
 without manual derivation. Our implementation is also automatically **differentiable**.
 So far we support interval bound propagation, forward mode perturbation, backward mode perturbation as well as hybrid approaches.
 
-`DecoMon` is compatible with a wider range of perturbation: boxes, $L_{\inf, 1, 2}$ norms or general
+`decomon` is compatible with a wider range of perturbation: boxes, $L_{\inf, 1, 2}$ norms or general
 convex sets described by their vertices.
 
-We believe that DecoMon is a complementary tool to existing libraries for the certification of neural networks.
+We believe that decomon is a complementary tool to existing libraries for the certification of neural networks.
 
 Since we rely on Tensorflow and not Pytorch, we are opening up the possibility for a new community
 to formally assess the robustness of their networks, without worrying about the technicality of

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ import decomon
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-project = "DecoMon"
+project = "decomon"
 copyright = "2022, Airbus"
 author = "Airbus"
 

--- a/docs/source/contribute.md
+++ b/docs/source/contribute.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We welcome all contributions to DecoMon.
+We welcome all contributions to decomon.
 
 You can help by:
 

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,7 +1,7 @@
 # Getting started
 
 
-First define your Keras Neural Network and convert it into its `DecoMon` version
+First define your Keras Neural Network and convert it into its `decomon` version
 using the `clone` method. You can then call `get_upper_box` and `get_lower_box` to
 respectively obtain certified upper and lower bounds for the network's outputs
 within a box domain.
@@ -22,7 +22,7 @@ model = Sequential([Dense(10, activation="relu", input_dim=2)])
 x_min = np.zeros((1, 2))
 x_max = np.ones((1, 2))
 
-# Convert into a DecoMon neural network
+# Convert into a decomon neural network
 decomon_model = clone(model)
 
 # Get lower and upper bounds

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,14 +1,14 @@
-# DecoMon: Automatic Certified Perturbation Analysis of Neural Networks
+# Decomon: Automatic Certified Perturbation Analysis of Neural Networks
 
 <div align="center">
-    <img src="_static/banner.jpg" width="55%" alt="Decomon" align="center" />
+    <img src="_static/banner.jpg" width="55%" alt="decomon" align="center" />
 </div>
 
-`DecoMon` is a library that allows the derivation of upper and lower bounds
+`decomon` is a library that allows the derivation of upper and lower bounds
 for the predictions of a Tensorflow/Keras neural network with perturbed inputs.
 In the current release, these bounds are represented as affine functions with respect to some variable under perturbation.
 
-Previous works that tackled certified robustness with backward propagation relied on forward upper and lower bounds. In `DecoMon`,
+Previous works that tackled certified robustness with backward propagation relied on forward upper and lower bounds. In `decomon`,
 we explored various ways to tighten forward upper and lower bounds, while remaining backpropagation-compatible
  thanks to symbolic optimization.
 
@@ -16,10 +16,10 @@ Our algorithm improves existing forward linear relaxation algorithms for general
 without manual derivation. Our implementation is also automatically **differentiable**.
 So far we support interval bound propagation, forward mode perturbation, backward mode perturbation as well as hybrid approaches.
 
-`DecoMon` is compatible with a wider range of perturbation: boxes, $L_{\inf, 1, 2}$ norms or general
+`decomon` is compatible with a wider range of perturbation: boxes, $L_{\inf, 1, 2}$ norms or general
 convex sets described by their vertices.
 
-We believe that DecoMon is a complementary tool to existing libraries for the certification of neural networks.
+We believe that decomon is a complementary tool to existing libraries for the certification of neural networks.
 
 Since we rely on Tensorflow and not Pytorch, we are opening up the possibility for a new community
 to formally assess the robustness of their networks, without worrying about the technicality of

--- a/tutorials/tutorial3_adversarial_attack.ipynb
+++ b/tutorials/tutorial3_adversarial_attack.ipynb
@@ -173,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Applying Decomon for Local Robustness to misclassification\n",
+    "## Applying decomon for local robustness to misclassification\n",
     "\n",
     "In this section, we detail how to prove local robustness to misclassification. Misclassification can be studied with the global optimisation of a function f:\n",
     "\n",
@@ -477,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/tutorials/tutorial4_adversarial_brightness.ipynb
+++ b/tutorials/tutorial4_adversarial_brightness.ipynb
@@ -183,7 +183,7 @@
    "id": "northern-invalid",
    "metadata": {},
    "source": [
-    "## Applying Decomon for Local Robustness to misclassification\n",
+    "## Applying decomon for local robustness to misclassification\n",
     "\n",
     "In this section, we detail how to prove local robustness to misclassification due to some environmental condition: **Brightness (Luminosity)**. Misclassification can be studied with the global optimisation of a function f:\n",
     "\n",
@@ -358,7 +358,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Sometimes "DecoMon" and sometimes "decomon" were used. The convention is now to always use lowercase for the library name.