### PR TITLE
Enable visualization of a decomon model graph with tensorboard

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -78,6 +78,17 @@ class BackwardDense(BackwardLayer):
 
         self.frozen_weights = False
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
+
     def call_previous(self, inputs):
 
         if not len(inputs):
@@ -333,6 +344,17 @@ class BackwardConv2D(BackwardLayer):
 
         self.frozen_weights = False
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
+
     def get_bounds_linear(self, w_out_u, b_out_u, w_out_l, b_out_l):
 
         output_shape_tensor = self.layer.output_shape[-1]
@@ -557,6 +579,17 @@ class BackwardActivation(BackwardLayer):
             self.frozen_alpha = False
         self.grid_finetune = []
         self.frozen_grid = False
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
 
     def build(self, input_shape):
         """
@@ -793,6 +826,15 @@ class BackwardFlatten(BackwardLayer):
             convex_domain = {}
         self.previous = previous
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "previous": self.previous,
+            }
+        )
+        return config
+
     def call(self, inputs, slope=V_slope.name, **kwargs):
         if self.previous:
             return inputs[-4:]
@@ -822,6 +864,15 @@ class BackwardReshape(BackwardLayer):
         if convex_domain is None:
             convex_domain = {}
         self.previous = previous
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "previous": self.previous,
+            }
+        )
+        return config
 
     def call_no_previous(self, inputs):
 
@@ -863,6 +914,15 @@ class BackwardPermute(BackwardLayer):
         self.dims = layer.dims
         self.op = layer.call
         self.previous = previous
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "previous": self.previous,
+            }
+        )
+        return config
 
     def call(self, inputs, slope=V_slope.name, **kwargs):
 
@@ -1001,8 +1061,19 @@ class BackwardInputLayer(BackwardLayer):
         else:
             self.mode = mode
             self.convex_domain = convex_domain
-        self.finetune = False
+        self.finetune = finetune
         self.previous = previous
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
 
     def call_previous(self, inputs):
         w_out_u, b_out_u, w_out_l, b_out_l = inputs[-4:]

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -43,11 +43,10 @@ class BackwardDense(BackwardLayer):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer  # should be removed, not good for config
         self.kernel = self.layer.kernel
         self.use_bias = self.layer.use_bias
         if self.layer.use_bias:
@@ -296,11 +295,10 @@ class BackwardConv2D(BackwardLayer):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.activation = get(layer.get_config()["activation"])
         self.activation_name = layer.get_config()["activation"]
         self.slope = slope
@@ -539,11 +537,10 @@ class BackwardActivation(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.activation = get(layer.get_config()["activation"])
         self.activation_name = layer.get_config()["activation"]
         self.slope = slope
@@ -791,7 +788,7 @@ class BackwardFlatten(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.previous = previous
@@ -821,7 +818,7 @@ class BackwardReshape(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.previous = previous
@@ -860,7 +857,7 @@ class BackwardPermute(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.dims = layer.dims
@@ -915,7 +912,7 @@ class BackwardDropout(BackwardLayer):
         rec=1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
 
@@ -943,12 +940,11 @@ class BackwardBatchNormalization(BackwardLayer):
     """Backward  LiRPA of Batch Normalization"""
 
     def __init__(self, layer, slope=V_slope.name, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         if not isinstance(layer, DecomonBatchNormalization):
             raise NotImplementedError()
-        self.layer = layer
         self.mode = self.layer.mode
         self.axis = self.layer.axis
         self.op_flat = Flatten()
@@ -995,10 +991,9 @@ class BackwardInputLayer(BackwardLayer):
     def __init__(
         self, layer, slope=V_slope.name, previous=True, mode=F_HYBRID.name, convex_domain=None, finetune=False, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):
             self.mode = self.layer.mode

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -1,14 +1,14 @@
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import Flatten, Layer
+from tensorflow.keras.layers import Flatten, Wrapper
 
 from decomon.backward_layers.utils import backward_max_
 from decomon.layers.core import F_FORWARD, F_HYBRID, F_IBP
 from decomon.utils import V_slope, get_lower, get_upper
 
 
-class BackwardMaxPooling2D(Layer):
+class BackwardMaxPooling2D(Wrapper):
     """Backward  LiRPA of MaxPooling2D"""
 
     def __init__(
@@ -22,7 +22,7 @@ class BackwardMaxPooling2D(Layer):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         raise NotImplementedError()

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -61,6 +61,17 @@ class BackwardAdd(BackwardMerge):
 
         self.op = DecomonAdd(mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp).call
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
+
     def call_previous(self, inputs):
 
         x_ = inputs[:-4]
@@ -136,6 +147,17 @@ class BackwardAverage(BackwardMerge):
         self.finetune = False
         self.previous = previous
         self.op = DecomonAdd(mode=self.mode, convex_domain=self.convex_domain, dc_decomp=False).call
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "previous": self.previous,
+                "finetune": self.finetune,
+            }
+        )
+        return config
 
     def call_previous(self, inputs):
 
@@ -216,6 +238,15 @@ class BackwardSubtract(BackwardMerge):
         self.slope = slope
         self.mode = self.layer.mode
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
+
     def call(self, inputs, **kwargs):
 
         x_ = inputs[:-4]
@@ -255,6 +286,15 @@ class BackwardMaximum(BackwardMerge):
         self.slope = slope
         self.mode = self.layer.mode
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
+
     def call(self, inputs, **kwargs):
 
         x_ = inputs[:-4]
@@ -293,6 +333,15 @@ class BackwardMinimum(BackwardMerge):
 
         self.slope = slope
         self.mode = self.layer.mode
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
 
     def call(self, inputs, **kwargs):
 
@@ -334,6 +383,15 @@ class BackwardConcatenate(BackwardMerge):
         self.mode = self.layer.mode
         self.axis = self.layer.axis
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
+
     def call(self, inputs, **kwargs):
         x_ = inputs[:-4]
         w_out_u, b_out_u, w_out_l, b_out_l = inputs[-4:]
@@ -369,6 +427,15 @@ class BackwardMultiply(BackwardMerge):
 
         self.slope = slope
         self.mode = self.layer.mode
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
 
     def call(self, inputs, **kwargs):
 
@@ -413,6 +480,15 @@ class BackwardDot(BackwardMerge):
         self.convex_domain = self.layer.convex_domain
 
         raise NotImplementedError()
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+            }
+        )
+        return config
 
     def call(self, inputs, **kwargs):
 

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -26,8 +26,8 @@ from decomon.layers.utils import broadcast, multiply, permute_dimensions, split
 
 
 class BackwardMerge(BackwardLayer):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, layer, **kwargs):
+        super().__init__(layer, **kwargs)
 
 
 class BackwardAdd(BackwardMerge):
@@ -44,10 +44,9 @@ class BackwardAdd(BackwardMerge):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):
             self.mode = self.layer.mode
@@ -123,11 +122,10 @@ class BackwardAverage(BackwardMerge):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
 
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.slope = slope
         if hasattr(self.layer, "mode"):
             self.mode = self.layer.mode
@@ -211,11 +209,10 @@ class BackwardSubtract(BackwardMerge):
     """Backward  LiRPA of Subtract"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonSubtract):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
 
@@ -251,11 +248,10 @@ class BackwardMaximum(BackwardMerge):
     """Backward  LiRPA of Maximum"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonMaximum):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
 
@@ -291,11 +287,10 @@ class BackwardMinimum(BackwardMerge):
     """Backward  LiRPA of Minimum"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonMinimum):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
 
@@ -331,11 +326,10 @@ class BackwardConcatenate(BackwardMerge):
     """Backward  LiRPA of Concatenate"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonConcatenate):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
         self.axis = self.layer.axis
@@ -369,11 +363,10 @@ class BackwardMultiply(BackwardMerge):
     """Backward  LiRPA of Multiply"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonMultiply):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
 
@@ -409,11 +402,10 @@ class BackwardDot(BackwardMerge):
     """Backward  LiRPA of Dot"""
 
     def __init__(self, layer, slope=V_slope.name, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(layer, **kwargs)
         if not isinstance(layer, DecomonDot):
             raise KeyError()
 
-        self.layer = layer
         self.slope = slope
         self.mode = self.layer.mode
         self.axes = [i for i in self.layer.axes]

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -1,9 +1,9 @@
-from tensorflow.keras.layers import Layer
+from tensorflow.keras.layers import Wrapper
 
 
-class BackwardLayer(Layer):
-    def __init__(self, rec=1, **kwargs):
-        super().__init__(**kwargs)
+class BackwardLayer(Wrapper):
+    def __init__(self, layer, rec=1, **kwargs):
+        super().__init__(layer, **kwargs)
         self.rec = rec
 
     def set_previous(self, previous):

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -6,5 +6,10 @@ class BackwardLayer(Wrapper):
         super().__init__(layer, **kwargs)
         self.rec = rec
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({"rec": self.rec})
+        return config
+
     def set_previous(self, previous):
         raise NotImplementedError()

--- a/src/decomon/backward_layers/crown.py
+++ b/src/decomon/backward_layers/crown.py
@@ -26,8 +26,7 @@ class Fuse(Layer):
         return merge_with_previous([w_f_u, b_f_u, w_f_l, b_f_l] + backward_bounds)
 
     def get_config(self):
-
-        config = super(Fuse, self).get_config()
+        config = super().get_config()
         config.update({"mode": self.mode})
         return config
 
@@ -63,7 +62,7 @@ class Convert_2_backward_mode(Layer):
             return [x_0, u_c_, w_out_u, b_out_u, l_c_, w_out_l, b_out_l]
 
     def get_config(self):
-        config = super(Convert_2_backward_mode, self).get_config()
+        config = super().get_config()
         config.update({"mode": self.mode, "convex_domain": self.convex_domain})
         return config
 
@@ -71,7 +70,8 @@ class Convert_2_backward_mode(Layer):
 class MergeWithPrevious(Layer):
     def __init__(self, input_shape_layer=None, backward_shape_layer=None, **kwargs):
         super(MergeWithPrevious, self).__init__(**kwargs)
-
+        self.input_shape_layer = input_shape_layer
+        self.backward_shape_layer = backward_shape_layer
         if not (input_shape_layer is None) and not (backward_shape_layer is None):
             _, n_in, n_h = input_shape_layer
             _, n_h, n_out = backward_shape_layer
@@ -84,6 +84,16 @@ class MergeWithPrevious(Layer):
 
     def call(self, inputs):
         return merge_with_previous(inputs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "input_shape_layer": self.input_shape_layer,
+                "backward_shape_layer": self.backward_shape_layer,
+            }
+        )
+        return config
 
 
 class Convert_2_mode(Layer):
@@ -134,7 +144,6 @@ class Convert_2_mode(Layer):
             return [x_0, u_c, w_u, b_u, l_c, w_l, b_l]
 
     def get_config(self):
-
-        config = super(Convert_2_mode, self).get_config()
+        config = super().get_config()
         config.update({"mode_from": self.mode_from, "mode_to": self.mode_to, "convex_domain": self.convex_domain})
         return config

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -106,6 +106,16 @@ class BackwardGroupSort2(Wrapper):
 
         self.frozen_weights = False
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "slope": self.slope,
+                "finetune": self.finetune,
+            }
+        )
+        return config
+
     def call_previous(self, inputs):
 
         w_out_u, b_out_u, w_out_l, b_out_l = inputs[-4:]

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -1,7 +1,7 @@
 import logging
 
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import Layer
+from tensorflow.keras.layers import Wrapper
 
 from decomon.backward_layers.activations import get
 from decomon.backward_layers.utils import V_slope, get_FORWARD, get_IBP, get_input_dim
@@ -19,7 +19,7 @@ except ImportError:
     )
 
 
-class BackwardDense(Layer):
+class BackwardDense(Wrapper):
     """Backward  LiRPA of Dense"""
 
     def __init__(
@@ -65,7 +65,7 @@ class BackwardDense(Layer):
         self.frozen_weights = False
 
 
-class BackwardGroupSort2(Layer):
+class BackwardGroupSort2(Wrapper):
     """Backward LiRPA of GroupSort2"""
 
     def __init__(
@@ -79,10 +79,9 @@ class BackwardGroupSort2(Layer):
         input_dim=-1,
         **kwargs,
     ):
-        super().__init__(kwargs)
+        super().__init__(layer, kwargs)
         if convex_domain is None:
             convex_domain = {}
-        self.layer = layer
         self.slope = slope
         self.finetune = finetune
 

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -429,7 +429,7 @@ def deserialize(name):
     elif name == TANH:
         return tanh
     elif name == RELU:
-        return relu_
+        return relu
     elif name == EXPONENTIAL:
         return exponential
     elif name == LINEAR:

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -115,6 +115,20 @@ class DecomonLayer(ABC, Layer):
         self.linear_layer = False
         self.has_backward_bounds = False  # optimizing Forward LiRPA for adversarial perturbation
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "dc_decomp": self.dc_decomp,
+                "shared": self.shared,
+                "fast": self.fast,
+                "finetune": self.finetune,
+                "mode": self.mode,
+                "convex_domain": self.convex_domain,
+            }
+        )
+        return config
+
     def build(self, input_shape):
         """
         Args:

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -66,7 +66,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
 
     def __init__(self, filters, kernel_size, mode=F_HYBRID.name, **kwargs):
 
-        activation = kwargs["activation"]
+        activation = kwargs.get("activation", None)
         if "activation" in kwargs:
             kwargs["activation"] = None
         super().__init__(filters=filters, kernel_size=kernel_size, mode=mode, **kwargs)

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -20,7 +20,7 @@ class DecomonGroupSort(DecomonLayer):
     def __init__(self, n=None, data_format="channels_last", k_coef_lip=1.0, mode=F_HYBRID.name, **kwargs):
         super().__init__(**kwargs)
         self.mode = mode
-
+        self.data_format = data_format
         if data_format == "channels_last":
             self.channel_axis = -1
         elif data_format == "channels_first":
@@ -34,6 +34,17 @@ class DecomonGroupSort(DecomonLayer):
         self.concat = DecomonConcatenate(
             mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
         ).call
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "data_format": self.data_format,
+                "mode": self.mode,
+                "n": self.n,
+            }
+        )
+        return config
 
     def call(self, input, **kwargs):
 
@@ -84,6 +95,16 @@ class DecomonGroupSort2(DecomonLayer):
         self.op_concat = DecomonConcatenate(self.axis, mode=self.mode, convex_domain=self.convex_domain)
         self.op_reshape_in = None
         self.op_reshape_out = None
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "data_format": self.data_format,
+                "mode": self.mode,
+            }
+        )
+        return config
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -26,10 +26,9 @@ class DecomonMaxPooling2D(MaxPooling2D, DecomonLayer):
             padding=padding,
             data_format=data_format,
             mode=mode,
+            fast=fast,
             **kwargs,
         )
-
-        self.fast = fast
 
         if self.mode == F_IBP.name:
             self.input_spec = [
@@ -59,8 +58,6 @@ class DecomonMaxPooling2D(MaxPooling2D, DecomonLayer):
 
         if self.dc_decomp:
             self.input_spec += [InputSpec(ndim=4), InputSpec(ndim=4)]
-
-        self.pool_size = pool_size
 
         # express maxpooling with convolutions
         if not self.fast or self.fast:

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -361,6 +361,16 @@ class DecomonLossFusion(DecomonLayer):
         self.asymptotic = asymptotic
         self.backward = backward
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "asymptotic": self.asymptotic,
+                "backward": self.backward,
+            }
+        )
+        return config
+
     def call_no_backward(self, inputs, **kwargs):
 
         if not self.asymptotic:
@@ -424,6 +434,15 @@ class DecomonRadiusRobust(DecomonLayer):
             raise NotImplementedError()
 
         self.backward = backward
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "backward": self.backward,
+            }
+        )
+        return config
 
     def call_no_backward(self, inputs, **kwargs):
 

--- a/src/decomon/metrics/metric.py
+++ b/src/decomon/metrics/metric.py
@@ -28,6 +28,18 @@ class Adversarial_score(Layer):
         self.mode = mode
         self.convex_domain = convex_domain
 
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "ibp": self.ibp,
+                "forward": self.forward,
+                "mode": self.mode,
+                "convex_domain": self.convex_domain,
+            }
+        )
+        return config
+
     def linear_adv(self, z_tensor, y_tensor, w_u, b_u, w_l, b_l):
 
         t_tensor = 1 - y_tensor
@@ -139,6 +151,18 @@ class Adversarial_check(Layer):
         self.forward = forward
         self.mode = mode
         self.convex_domain = convex_domain
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "ibp": self.ibp,
+                "forward": self.forward,
+                "mode": self.mode,
+                "convex_domain": self.convex_domain,
+            }
+        )
+        return config
 
     def linear_adv(self, z_tensor, y_tensor, w_u, b_u, w_l, b_l):
         w_upper = w_u * (1 - y_tensor[:, None]) - K.expand_dims(K.sum(w_l * y_tensor[:, None], -1), -1)
@@ -287,6 +311,18 @@ class Upper_score(Layer):
         self.forward = forward
         self.mode = mode
         self.convex_domain = convex_domain
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "ibp": self.ibp,
+                "forward": self.forward,
+                "mode": self.mode,
+                "convex_domain": self.convex_domain,
+            }
+        )
+        return config
 
     def linear_upper(self, z_tensor, y_tensor, w_u, b_u):
         w_upper = w_u * y_tensor[:, None]

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -1,4 +1,7 @@
+import copy
+
 import tensorflow as tf
+from keras.engine.functional import get_network_config
 
 from decomon.layers.core import Box, StaticVariables
 
@@ -72,6 +75,11 @@ class DecomonModel(tf.keras.Model):
         for layer in self.layers:
             if hasattr(layer, "reset_finetuning"):
                 layer.reset_finetuning()
+
+    def get_config(self):
+        # Continue adding configs into what the super class has added.
+        config = super().get_config()
+        return copy.deepcopy(get_network_config(self, config=config))
 
 
 def set_domain_priv(convex_domain_prev, convex_domain):

--- a/tests/test_backward_layers_get_config.py
+++ b/tests/test_backward_layers_get_config.py
@@ -1,0 +1,160 @@
+import pytest
+from keras.layers import Layer
+
+from decomon.backward_layers.backward_layers import (
+    BackwardActivation,
+    BackwardBatchNormalization,
+    BackwardConv2D,
+    BackwardDense,
+    BackwardDropout,
+    BackwardFlatten,
+    BackwardInputLayer,
+    BackwardPermute,
+    BackwardReshape,
+)
+from decomon.backward_layers.backward_maxpooling import BackwardMaxPooling2D
+from decomon.backward_layers.backward_merge import (
+    BackwardAdd,
+    BackwardAverage,
+    BackwardConcatenate,
+    BackwardDot,
+    BackwardMaximum,
+    BackwardMinimum,
+    BackwardMultiply,
+    BackwardSubtract,
+)
+from decomon.backward_layers.crown import (
+    Convert_2_backward_mode,
+    Convert_2_mode,
+    Fuse,
+    MergeWithPrevious,
+)
+from decomon.backward_layers.deel_lip import BackwardGroupSort2
+from decomon.layers.core import F_FORWARD
+from decomon.layers.decomon_layers import (
+    DecomonActivation,
+    DecomonBatchNormalization,
+    DecomonConv2D,
+    DecomonDense,
+    DecomonDropout,
+)
+from decomon.layers.decomon_merge_layers import (
+    DecomonAdd,
+    DecomonAverage,
+    DecomonConcatenate,
+    DecomonDot,
+    DecomonMaximum,
+    DecomonMinimum,
+    DecomonMultiply,
+    DecomonSubtract,
+)
+from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
+from decomon.layers.deel_lip import DecomonGroupSort2
+from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+
+def test_backward_layers():
+    activation = "linear"
+    sublayer = DecomonActivation(activation)
+    layer = BackwardActivation(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    units = 2
+    sublayer = DecomonDense(units=units, use_bias=False)
+    layer = BackwardDense(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    filters = 2
+    kernel_size = 3, 3
+    sublayer = DecomonConv2D(filters=filters, kernel_size=kernel_size)
+    layer = BackwardConv2D(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    rate = 0.9
+    sublayer = DecomonDropout(rate=rate)
+    layer = BackwardDropout(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    dims = (1, 2, 3)
+    sublayer = DecomonPermute(dims=dims)
+    layer = BackwardPermute(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    shape = (1, 2, 3)
+    sublayer = DecomonReshape(target_shape=shape)
+    layer = BackwardReshape(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    sublayer = DecomonBatchNormalization()
+    layer = BackwardBatchNormalization(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+    sublayer = Layer()
+    for cls in [BackwardFlatten, BackwardInputLayer]:
+        layer = cls(layer=sublayer)
+        config = layer.get_config()
+        assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+
+backward2decomon = {
+    BackwardAdd: DecomonAdd,
+    BackwardAverage: DecomonAverage,
+    BackwardConcatenate: DecomonConcatenate,
+    # BackwardDot: DecomonDot,  # not yet implemented
+    BackwardMaximum: DecomonMaximum,
+    BackwardMinimum: DecomonMinimum,
+    BackwardMultiply: DecomonMultiply,
+    BackwardSubtract: DecomonSubtract,
+}
+
+
+def test_backward_merge():
+    for backwardlayer_cls, decomonlayer_cls in backward2decomon.items():
+        sublayer = decomonlayer_cls()
+        layer = backwardlayer_cls(layer=sublayer)
+        config = layer.get_config()
+        assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+
+@pytest.mark.skip("Not yet implemented.")
+def test_backward_maxpooling():
+    sublayer = DecomonMaxPooling2D()
+    layer = BackwardMaxPooling2D(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+
+@pytest.mark.skip("Not yet implemented.")
+def test_deel_lip():
+    sublayer = DecomonGroupSort2()
+    layer = BackwardGroupSort2(layer=sublayer)
+    config = layer.get_config()
+    assert config["layer"]["class_name"] == sublayer.__class__.__name__
+
+
+def test_crown():
+    mode = F_FORWARD
+    convex_domain = {}
+    input_shape_layer = (1, 2, 4)
+    backward_shape_layer = (2, 5, 10)
+
+    layer = Fuse(mode=mode)
+    config = layer.get_config()
+    assert config["mode"] == mode
+
+    layer = Convert_2_backward_mode(mode=mode, convex_domain=convex_domain)
+    config = layer.get_config()
+    assert config["mode"] == mode
+    assert "convex_domain" in config
+
+    layer = MergeWithPrevious(input_shape_layer=input_shape_layer, backward_shape_layer=backward_shape_layer)
+    config = layer.get_config()
+    assert config["input_shape_layer"] == input_shape_layer
+    assert config["backward_shape_layer"] == backward_shape_layer

--- a/tests/test_layers_get_config.py
+++ b/tests/test_layers_get_config.py
@@ -1,0 +1,109 @@
+from decomon.layers.core import F_FORWARD
+from decomon.layers.decomon_layers import (
+    DecomonActivation,
+    DecomonBatchNormalization,
+    DecomonConv2D,
+    DecomonDense,
+    DecomonDropout,
+    DecomonFlatten,
+    DecomonInputLayer,
+)
+from decomon.layers.decomon_merge_layers import (
+    DecomonAdd,
+    DecomonAverage,
+    DecomonConcatenate,
+    DecomonDot,
+    DecomonMaximum,
+    DecomonMinimum,
+    DecomonMultiply,
+    DecomonSubtract,
+)
+from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
+from decomon.layers.deel_lip import DecomonGroupSort, DecomonGroupSort2
+from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+
+def test_decomon_reshape():
+    dims = (1, 2, 3)
+    mode = F_FORWARD.name
+    layer = DecomonPermute(dims=dims, mode=mode)
+    config = layer.get_config()
+    assert config["dims"] == dims
+    assert config["mode"] == mode
+
+    shape = (1, 2, 3)
+    layer = DecomonReshape(target_shape=shape, mode=mode)
+    config = layer.get_config()
+    assert config["target_shape"] == shape
+    assert config["mode"] == mode
+
+
+def test_deel_lip():
+    layer = DecomonGroupSort()
+    config = layer.get_config()
+
+    layer = DecomonGroupSort2()
+    config = layer.get_config()
+
+
+def test_maxpooling():
+    layer = DecomonMaxPooling2D()
+    config = layer.get_config()
+    assert "pool_size" in config
+
+
+def test_decomon_merge_layers():
+    for cls in [
+        DecomonAdd,
+        DecomonAverage,
+        DecomonConcatenate,
+        DecomonDot,
+        DecomonMaximum,
+        DecomonMinimum,
+        DecomonMultiply,
+        DecomonSubtract,
+    ]:
+        layer = cls()
+        config = layer.get_config()
+        assert "mode" in config
+        if layer == DecomonConcatenate:
+            assert "axis" in config
+        elif layer == DecomonDot:
+            assert "axes" in config
+
+
+def test_decomon_layers():
+    for activation in ["relu", "softmax"]:
+        layer = DecomonActivation(activation=activation)
+        config = layer.get_config()
+        print(config)
+        print(layer.activation)
+        assert config["activation"] == activation
+
+    units = 2
+    layer = DecomonDense(units=units)
+    config = layer.get_config()
+    assert config["units"] == units
+
+    filters = 2
+    kernel_size = 3, 3
+    layer = DecomonConv2D(filters=filters, kernel_size=kernel_size)
+    config = layer.get_config()
+    assert config["filters"] == filters
+    assert config["kernel_size"] == kernel_size
+
+    rate = 0.9
+    layer = DecomonDropout(rate=rate)
+    config = layer.get_config()
+    assert config["rate"] == rate
+
+    for cls in [DecomonBatchNormalization, DecomonInputLayer, DecomonFlatten]:
+        layer = cls()
+        config = layer.get_config()
+        assert "mode" in config
+        if layer == DecomonBatchNormalization:
+            assert "axis" in config
+        elif layer == DecomonInputLayer:
+            assert "input_shape" in config
+        elif layer == DecomonFlatten:
+            assert "data_format" in config

--- a/tests/test_metrics_get_config.py
+++ b/tests/test_metrics_get_config.py
@@ -1,0 +1,29 @@
+from decomon.layers.core import F_FORWARD
+from decomon.metrics.loss import DecomonLossFusion, DecomonRadiusRobust
+from decomon.metrics.metric import Adversarial_check, Adversarial_score, Upper_score
+
+
+def test_decomon_loss():
+    backward = True
+    mode = F_FORWARD.name
+
+    layer = DecomonLossFusion(mode=mode, backward=backward)
+    config = layer.get_config()
+    assert config["backward"] == backward
+    assert config["mode"] == mode
+
+    layer = DecomonRadiusRobust(backward=backward, mode=mode)
+    config = layer.get_config()
+    assert config["backward"] == backward
+    assert config["mode"] == mode
+
+
+def test_metric():
+    ibp, forward, mode, convex_domain = True, False, F_FORWARD, {}
+    for cls in [Adversarial_check, Adversarial_score, Upper_score]:
+        layer = cls(ibp=ibp, forward=forward, mode=mode, convex_domain=convex_domain)
+        config = layer.get_config()
+        assert config["ibp"] == ibp
+        assert config["forward"] == forward
+        assert config["mode"] == mode
+        assert "convex_domain" in config

--- a/tutorials/Advanced/tensorboard-and-decomon.ipynb
+++ b/tutorials/Advanced/tensorboard-and-decomon.ipynb
@@ -1,0 +1,388 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tensorboard with decomon\n",
+    "\n",
+    "\n",
+    "In this notebook, we show how to have a look to the graph of a decomon model.\n",
+    "\n",
+    "We use here the same model as in [tutorial 1](../tutorial1_sinus-interactive.ipynb) and you should refer to it for any details about how it works.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "Because decomon models have specificities, visualizing them with tensorboard reveal some bug in the library and we need to get the last version of tensorboard available on master to make the notebook work. (The bug fix should be included in future 2.13.0)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### On local Jupyter\n",
+    "\n",
+    "Here is a way to install decomon with the nightly version of tensorflow (including the nighly version of tensorboard) available as package \"tf-nightly\". We need to install the dependencies of decomon manually and then to use --no-deps option to install decomon, because tf-nightly is not recognized as tensorflow by pip.\n",
+    "\n",
+    "\n",
+    "```shell\n",
+    "# create and activate a new environment\n",
+    "python -m venv decomon-tf-nightly-venv \n",
+    ". decomon-tf-nightly-venv/bin/activate\n",
+    "\n",
+    "# update pip\n",
+    "pip install -U pip\n",
+    "\n",
+    "# install tensorflow nightly and matplotlib (dependencies of decomon)\n",
+    "pip install tf-nightly matplotlib\n",
+    "\n",
+    "# install decomon without dependencies\n",
+    "# pip install --no-deps decomon  # from pypi\n",
+    "pip install --no-deps -e .  # from source in developer mode, from root directory of decomon repository\n",
+    "\n",
+    "# install jupyter to run this notebook!\n",
+    "pip install jupyter\n",
+    "jupyter notebook tutorials/Advanced/tensorboard-and-decomon.ipynb &\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### On Binder or Colab\n",
+    "\n",
+    "**Disclaimer:**\n",
+    "As the environment on binder or colab are using released version of tensorflow (and thus tensorboard), we cannot ensure that the notebook will work as it is for now. (Up to the moment where 2.13.0 will be released)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import socket\n",
+    "\n",
+    "on_colab = \"google.colab\" in str(get_ipython())  # running on colab?\n",
+    "on_binder = socket.gethostname().startswith(\"jupyter-\")  # running on binder? (not 100% sure but rather robust)\n",
+    "\n",
+    "if on_colab or on_binder:\n",
+    "    raise RuntimeError(\n",
+    "        \"Do not run this notebook on Binder or Colab. \"\n",
+    "        \"Please test it locally for now, until tensorflow 2.13.0 is released.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext tensorboard\n",
+    "\n",
+    "from datetime import datetime\n",
+    "\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "import tensorflow.keras as keras\n",
+    "from tensorflow.keras.layers import Activation, Dense\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "\n",
+    "from decomon.models import clone\n",
+    "from decomon.wrapper import get_lower_box, get_upper_box\n",
+    "\n",
+    "print(\"Notebook run using keras:\", keras.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initial Keras model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build model\n",
+    "\n",
+    "The sinusoide funtion is defined on a $[-1 ; 1 ]$ interval. We put a factor in the sinusoide to have several periods of oscillations. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(-1, 1, 1000)\n",
+    "y = np.sin(10 * x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We approximate this function by a fully connected network composed of 4 hidden layers of size 100, 100, 20 and 20 respectively. Rectified Linear Units (ReLU) are chosen as activation functions for all the neurons. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layers = []\n",
+    "layers.append(Dense(100, activation=\"linear\", input_dim=1, name=\"dense1\"))  # specify the dimension of the input space\n",
+    "layers.append(Activation(\"relu\", name=\"relu1\"))\n",
+    "layers.append(Dense(100, activation=\"linear\", name=\"dense2\"))\n",
+    "layers.append(Activation(\"relu\", name=\"relu2\"))\n",
+    "layers.append(Dense(20, activation=\"linear\", name=\"dense3\"))\n",
+    "layers.append(Activation(\"relu\", name=\"relu3\"))\n",
+    "layers.append(Dense(20, activation=\"linear\", name=\"dense4\"))\n",
+    "layers.append(Activation(\"relu\", name=\"relu4\"))\n",
+    "layers.append(Dense(1, activation=\"linear\", name=\"dense5\"))\n",
+    "model = Sequential(layers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fit model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Uncomment the cell below if you want to see the op graph generated during model fit, later in [tensorboard](#Tensorboard)."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "model.compile(\"adam\", \"mse\")\n",
+    "\n",
+    "# Define the Keras TensorBoard callback.\n",
+    "logdir=\"logs/fit/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "tensorboard_callback = keras.callbacks.TensorBoard(log_dir=logdir)\n",
+    "\n",
+    "model.fit(x, y, batch_size=32, shuffle=True, epochs=10, verbose=1, callbacks=[tensorboard_callback])\n",
+    "# verbose=0 removes the printing along the training, *but* it prevent op graph in tensorboard (?!)\n",
+    "# verbose=2 does not allow neither op graph in tensorboard, beware !"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conversion to decomon model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert our model into a decomon model:\n",
+    "decomon_model = clone(model, method=\"crown\")  # method is optionnal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Serialization to json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(model.to_json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(decomon_model.to_json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualization with Graphviz and pydot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You need to install pydot and graphviz to make it work. If available, uncomment the 2 next cells."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "tf.keras.utils.plot_model(\n",
+    "    model,\n",
+    "    to_file=\"model.png\",\n",
+    "    show_shapes=False,\n",
+    "    show_dtype=False,\n",
+    "    show_layer_names=True,\n",
+    "    rankdir=\"TB\",\n",
+    "    expand_nested=False,\n",
+    "    dpi=96,\n",
+    "    layer_range=None,\n",
+    "    show_layer_activations=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "tf.keras.utils.plot_model(\n",
+    "    decomon_model,\n",
+    "    to_file=\"decomon_model.png\",\n",
+    "    show_shapes=False,\n",
+    "    show_dtype=False,\n",
+    "    show_layer_names=True,\n",
+    "    rankdir=\"TB\",\n",
+    "    expand_nested=False,\n",
+    "    dpi=96,\n",
+    "    layer_range=None,\n",
+    "    show_layer_activations=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tensorboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We create a log file by setting respectively the Keras and Decomon models to a tensorboard callback."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logdir = \"logs/keras-graph/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "tensorboard_callback = keras.callbacks.TensorBoard(log_dir=logdir, write_graph=True)\n",
+    "tensorboard_callback.set_model(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logdir = \"logs/decomon-graph/\" + datetime.now().strftime(\"%Y%m%d-%H%M%S\")\n",
+    "tensorboard_callback = keras.callbacks.TensorBoard(log_dir=logdir, write_graph=True)\n",
+    "tensorboard_callback.set_model(decomon_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We launch tensorboard to visualize the graph. \n",
+    "As the op graph is not available without fit, you need to select tag \"keras\" and graph type \"Conceptual graph\" on  the right to make it work. \n",
+    "In \"Run\" drop-down menu, select \"decomon-graph\" and then double click on the big node to develop the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%tensorboard --logdir logs"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "512px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
- define get_config() in layers/models specific to Decomon
- define BackwardLayer as a child of keras.layers.Wrapper in order to get the proper get_config() with the referenced layer
- fix the use of relu in DecomonActivation to get the proper get_config (and use the proper activation function by the same way)
- add the related unit tests
- add a notebook (in an "advanced" subsection) demonstrating the visualization with tensorboard