### PR TITLE
Remove `previous` attribute from backward layers

### DIFF
--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -23,7 +23,6 @@ class BackwardMaxPooling2D(BackwardLayer):
     def __init__(
         self,
         layer: Layer,
-        previous: bool = True,
         rec: int = 1,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         convex_domain: Optional[Dict[str, Any]] = None,
@@ -36,7 +35,6 @@ class BackwardMaxPooling2D(BackwardLayer):
             mode=mode,
             convex_domain=convex_domain,
             dc_decomp=dc_decomp,
-            previous=previous,
             **kwargs,
         )
         raise NotImplementedError()

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -19,14 +19,12 @@ class BackwardLayer(ABC, Wrapper):
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         convex_domain: Optional[Dict[str, Any]] = None,
         dc_decomp: bool = False,
-        previous: bool = True,
         **kwargs: Any,
     ):
         kwargs.pop("slope", None)
         kwargs.pop("finetune", None)
         super().__init__(layer, **kwargs)
         self.rec = rec
-        self.previous = previous
         if isinstance(self.layer, DecomonLayer):
             self.mode = self.layer.mode
             self.convex_domain = self.layer.convex_domain
@@ -47,7 +45,6 @@ class BackwardLayer(ABC, Wrapper):
                 "mode": self.mode,
                 "convex_domain": self.convex_domain,
                 "dc_decomp": self.dc_decomp,
-                "previous": self.previous,
             }
         )
         return config

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -28,7 +28,6 @@ class BackwardGroupSort2(BackwardLayer):
     def __init__(
         self,
         layer: Layer,
-        previous: bool = True,
         input_dim: int = -1,
         rec: int = 1,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -42,7 +41,6 @@ class BackwardGroupSort2(BackwardLayer):
             mode=mode,
             convex_domain=convex_domain,
             dc_decomp=dc_decomp,
-            previous=previous,
             **kwargs,
         )
 
@@ -60,14 +58,3 @@ class BackwardGroupSort2(BackwardLayer):
             )[0]
 
         self.frozen_weights = False
-
-    def call_previous(self, inputs: List[tf.Tensor]) -> List[tf.Tensor]:
-
-        w_out_u, b_out_u, w_out_l, b_out_l = inputs[-4:]
-
-        if self.layer.data_format == "channels_last":
-            shape = int(w_out_u.shape[1] / 2)
-            n_out = w_out_u.shape[-1]
-            w_out_u_ = K.reshape(w_out_u, [-1, shape, self.layer.n, n_out])
-
-        raise NotImplementedError()

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -67,17 +67,16 @@ def get_disconnected_input(
 
 def retrieve_layer(
     node: Node,
-    previous: int,
     layer_fn: Callable[[Layer], BackwardLayer],
-    backward_map: Dict[Tuple[int, bool], BackwardLayer],
+    backward_map: Dict[int, BackwardLayer],
     joint: bool = True,
 ) -> BackwardLayer:
-    if (id(node), bool(previous)) in backward_map:
-        backward_layer = backward_map[id(node), bool(previous)]
+    if id(node) in backward_map:
+        backward_layer = backward_map[id(node)]
     else:
         backward_layer = layer_fn(node.outbound_layer)
         if joint:
-            backward_map[id(node), bool(previous)] = backward_layer
+            backward_map[id(node)] = backward_layer
     return backward_layer
 
 
@@ -89,7 +88,7 @@ def crown_(
     input_map: Dict[int, List[tf.Tensor]],
     layer_fn: Callable[[Layer], BackwardLayer],
     backward_bounds: List[tf.Tensor],
-    backward_map: Optional[Dict[Tuple[int, bool], BackwardLayer]] = None,
+    backward_map: Optional[Dict[int, BackwardLayer]] = None,
     joint: bool = True,
     fuse: bool = True,
     output_map: Optional[Dict[int, List[tf.Tensor]]] = None,
@@ -139,7 +138,7 @@ def crown_(
         )
 
     else:
-        backward_layer = retrieve_layer(node, len(backward_bounds), layer_fn, backward_map, joint)
+        backward_layer = retrieve_layer(node=node, layer_fn=layer_fn, backward_map=backward_map, joint=joint)
 
         if id(node) not in output_map:
             backward_bounds_ = backward_layer(inputs)
@@ -239,13 +238,13 @@ def get_input_nodes(
     set_mode_layer: Layer,
     convex_domain: Optional[Dict[str, Any]] = None,
     **kwargs: Any,
-) -> Tuple[Dict[int, List[tf.Tensor]], Dict[Tuple[int, bool], BackwardLayer], Dict[int, List[tf.Tensor]]]:
+) -> Tuple[Dict[int, List[tf.Tensor]], Dict[int, BackwardLayer], Dict[int, List[tf.Tensor]]]:
 
     keys = [e for e in dico_nodes.keys()]
     keys.sort(reverse=True)
     fuse_layer = None
     input_map: Dict[int, List[tf.Tensor]] = {}
-    backward_map: Dict[Tuple[int, bool], BackwardLayer] = {}
+    backward_map: Dict[int, BackwardLayer] = {}
     if convex_domain is None:
         convex_domain = {}
     crown_map: Dict[int, List[tf.Tensor]] = {}
@@ -313,7 +312,7 @@ def crown_model(
     layer_fn: Callable[..., BackwardLayer] = to_backward,
     fuse: bool = True,
     **kwargs: Any,
-) -> Tuple[List[tf.Tensor], List[tf.Tensor], Dict[Tuple[int, bool], BackwardLayer], None]:
+) -> Tuple[List[tf.Tensor], List[tf.Tensor], Dict[int, BackwardLayer], None]:
     if back_bounds is None:
         back_bounds = []
     if forward_map is None:
@@ -436,7 +435,7 @@ def convert_backward(
     final_ibp: bool = True,
     final_forward: bool = False,
     **kwargs: Any,
-) -> Tuple[List[tf.Tensor], List[tf.Tensor], Dict[Tuple[int, bool], BackwardLayer], None]:
+) -> Tuple[List[tf.Tensor], List[tf.Tensor], Dict[int, BackwardLayer], None]:
     if back_bounds is None:
         back_bounds = []
     if forward_map is None:

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -76,7 +76,6 @@ def retrieve_layer(
         backward_layer = backward_map[id(node), bool(previous)]
     else:
         backward_layer = layer_fn(node.outbound_layer)
-        backward_layer.previous = bool(previous)
         if joint:
             backward_map[id(node), bool(previous)] = backward_layer
     return backward_layer
@@ -143,8 +142,6 @@ def crown_(
         backward_layer = retrieve_layer(node, len(backward_bounds), layer_fn, backward_map, joint)
 
         if id(node) not in output_map:
-            if backward_layer.previous:
-                backward_layer.previous = False
             backward_bounds_ = backward_layer(inputs)
             output_map[id(node)] = backward_bounds_
         else:
@@ -158,13 +155,6 @@ def crown_(
                 merge_layers = MergeWithPrevious(backward_bounds_[0].shape, backward_bounds[0].shape)
             backward_tmp = merge_layers(backward_bounds_ + backward_bounds)
             backward_bounds_ = backward_tmp
-
-            # backward_bounds_ = \
-            #    backward_layer(inputs+backward_bounds)
-            # debugging
-
-            # backward_layer.previous = False
-            # tmp = backward_layer.call_no_previous(inputs)
 
     if not isinstance(backward_bounds_, list):
         backward_bounds = [e for e in backward_bounds_]
@@ -356,7 +346,7 @@ def crown_model(
         has_iter = True
 
     if not has_iter:
-        # layer, slope = V_slope.name, previous = True, mode = ForwardMode.F_HYBRID, convex_domain = {}, finetune = False, rec = 1, ** kwargs
+
         def func(layer: Layer) -> Layer:
             return to_backward(layer, mode=get_mode(IBP, forward), finetune=finetune)
 

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -67,12 +67,7 @@ def convert(
     final_ibp: bool = False,
     final_forward: bool = False,
     **kwargs: Any,
-) -> Tuple[
-    List[tf.Tensor],
-    List[tf.Tensor],
-    Union[LayerMapDict, Dict[Tuple[int, bool], BackwardLayer]],
-    Optional[OutputMapDict],
-]:
+) -> Tuple[List[tf.Tensor], List[tf.Tensor], Union[LayerMapDict, Dict[int, BackwardLayer]], Optional[OutputMapDict],]:
 
     if back_bounds is None:
         back_bounds = []
@@ -85,7 +80,7 @@ def convert(
     if isinstance(method, str):
         method = ConvertMethod(method.lower())
 
-    layer_map: Union[LayerMapDict, Dict[Tuple[int, bool], BackwardLayer]]
+    layer_map: Union[LayerMapDict, Dict[int, BackwardLayer]]
 
     if method != ConvertMethod.CROWN:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,11 +34,6 @@ def floatx(request):
 
 
 @pytest.fixture(params=[True, False])
-def previous(request):
-    return request.param
-
-
-@pytest.fixture(params=[True, False])
 def use_bias(request):
     return request.param
 

--- a/tests/test_backward_activation.py
+++ b/tests/test_backward_activation.py
@@ -16,7 +16,7 @@ from decomon.utils import relu_
         (softsign, backward_softsign, "softsign"),
     ],
 )
-def test_activation_backward_1D_box(n, mode, previous, floatx, activation_func, tensor_func, funcname, helpers):
+def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_func, funcname, helpers):
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
@@ -52,16 +52,9 @@ def test_activation_backward_1D_box(n, mode, previous, floatx, activation_func, 
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1), dtype=K.floatx())
 
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = tensor_func(
-            input_mode + [w_out, b_out, w_out, b_out], mode=mode, previous=previous
-        )
-        f_func = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_func(inputs_ + [np.ones((len(x_), 1, 1)), np.zeros((len(x_), 1))])
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = tensor_func(input_mode, mode=mode, previous=previous)
-        f_func = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_func(inputs_)
+    w_out_u, b_out_u, w_out_l, b_out_l = tensor_func(input_mode, mode=mode)
+    f_func = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    output_ = f_func(inputs_)
 
     w_u_, b_u_, w_l_, b_l_ = output_
     w_u_b = np.sum(np.maximum(w_u_, 0) * W_u_ + np.minimum(w_u_, 0) * W_l_, 1)[:, :, None]

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -11,7 +11,7 @@ from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 
 
-def test_Decomon_conv_box(data_format, activation, padding, use_bias, mode, floatx, previous, helpers):
+def test_Decomon_conv_box(data_format, activation, padding, use_bias, mode, floatx, helpers):
 
     if data_format == "channels_first" and not len(K._get_available_gpus()):
         return
@@ -61,25 +61,11 @@ def test_Decomon_conv_box(data_format, activation, padding, use_bias, mode, floa
     w_out = Input((output_shape, output_shape))
     b_out = Input((output_shape,))
     # get backward layer
-    layer_backward = to_backward(layer, previous=previous)
+    layer_backward = to_backward(layer)
 
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        f_conv = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        w_init = np.concatenate([np.diag([1.0] * output_shape)[None]] * len(x)).reshape(
-            (-1, output_shape, output_shape)
-        )
-        b_init = np.zeros((len(x), output_shape))
-        output_ = f_conv(inputs_ + [w_init, b_init])
-
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_conv = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_conv(inputs_)
-
-    # import pdb; pdb.set_trace()
-
-    # import pdb; pdb.set_trace()
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_conv = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    output_ = f_conv(inputs_)
 
     w_u_, b_u_, w_l_, b_l_ = output_
 

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -13,7 +13,7 @@ from decomon.layers.decomon_layers import DecomonDense, to_decomon
 from decomon.utils import Slope
 
 
-def test_Backward_Dense_1D_box(n, activation, use_bias, previous, mode, floatx, helpers):
+def test_Backward_Dense_1D_box(n, activation, use_bias, mode, floatx, helpers):
 
     slope = Slope.V_SLOPE
 
@@ -64,21 +64,11 @@ def test_Backward_Dense_1D_box(n, activation, use_bias, previous, mode, floatx, 
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
-    layer_backward = to_backward(
-        layer_, input_dim=input_dim, slope=slope, previous=previous, mode=mode, convex_domain={}
-    )
+    layer_backward = to_backward(layer_, input_dim=input_dim, slope=slope, mode=mode, convex_domain={})
 
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-
-        f_dense = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-
-        output_ = f_dense(inputs_ + [np.ones((len(x), 1, 1)), np.zeros((len(x), 1))])
-    else:
-
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_dense(inputs_)
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
     if use_bias:
@@ -153,7 +143,7 @@ def test_Backward_Dense_1D_box(n, activation, use_bias, previous, mode, floatx, 
     K.set_floatx("float32")
 
 
-def test_Backward_DecomonDense_multiD_box(odd, activation, floatx, mode, previous, helpers):
+def test_Backward_DecomonDense_multiD_box(odd, activation, floatx, mode, helpers):
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
     decimal = 5
@@ -203,27 +193,11 @@ def test_Backward_DecomonDense_multiD_box(odd, activation, floatx, mode, previou
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
-    layer_backward = to_backward(layer_, input_dim=input_dim, previous=previous, mode=mode, convex_domain={})
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        f_dense = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_dense(
-            inputs_
-            + [
-                np.ones((len(x), 1, 1)),
-                np.zeros(
-                    (
-                        len(x),
-                        1,
-                    )
-                ),
-            ]
-        )
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        # import pdb; pdb.set_trace()
-        output_ = f_dense(inputs_)
+    layer_backward = to_backward(layer_, input_dim=input_dim, mode=mode, convex_domain={})
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    # import pdb; pdb.set_trace()
+    output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
     helpers.assert_output_properties_box_linear(

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -13,7 +13,7 @@ from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
 from decomon.layers.decomon_reshape import DecomonReshape
 
 
-def test_Backward_NativeActivation_1D_box_model(n, activation, mode, previous, floatx, helpers):
+def test_Backward_NativeActivation_1D_box_model(n, activation, mode, floatx, helpers):
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
     decimal = 5
@@ -46,26 +46,10 @@ def test_Backward_NativeActivation_1D_box_model(n, activation, mode, previous, f
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
-    layer_backward = to_backward(Activation(activation, dtype=K.floatx()), previous=previous, mode=mode)
-    if previous:
-        w_out_u_, b_out_u_, w_out_l_, b_out_l_ = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        model = Model(inputs[2:] + [w_out, b_out], [w_out_u_, b_out_u_, w_out_l_, b_out_l_])
-        w_u_, b_u_, w_l_, b_l_ = model.predict(
-            inputs_[2:]
-            + [
-                np.ones((len(x), 1, 1)),
-                np.zeros(
-                    (
-                        len(x),
-                        1,
-                    )
-                ),
-            ]
-        )
-    else:
-        w_out_u_, b_out_u_, w_out_l_, b_out_l_ = layer_backward(input_mode)
-        model = Model(inputs[2:], [w_out_u_, b_out_u_, w_out_l_, b_out_l_])
-        w_u_, b_u_, w_l_, b_l_ = model.predict(inputs_[2:])
+    layer_backward = to_backward(Activation(activation, dtype=K.floatx()), mode=mode)
+    w_out_u_, b_out_u_, w_out_l_, b_out_l_ = layer_backward(input_mode)
+    model = Model(inputs[2:], [w_out_u_, b_out_u_, w_out_l_, b_out_l_])
+    w_u_, b_u_, w_l_, b_l_ = model.predict(inputs_[2:])
 
     helpers.assert_output_properties_box_linear(
         x,
@@ -86,7 +70,7 @@ def test_Backward_NativeActivation_1D_box_model(n, activation, mode, previous, f
     K.set_epsilon(eps)
 
 
-def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, previous, helpers):
+def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, helpers):
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
     decimal = 5
@@ -122,27 +106,11 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, pre
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
-    layer_backward = to_backward(Activation(activation, dtype=K.floatx()), previous=previous, mode=mode)
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        f_dense = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_dense(
-            inputs_
-            + [
-                np.ones((len(x), 1, 1)),
-                np.zeros(
-                    (
-                        len(x),
-                        1,
-                    )
-                ),
-            ]
-        )
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        # import pdb; pdb.set_trace()
-        output_ = f_dense(inputs_)
+    layer_backward = to_backward(Activation(activation, dtype=K.floatx()), mode=mode)
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    # import pdb; pdb.set_trace()
+    output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
     helpers.assert_output_properties_box_linear(
@@ -163,7 +131,7 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, pre
     K.set_epsilon(eps)
 
 
-def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, previous, data_format, helpers):
+def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, data_format, helpers):
     if data_format == "channels_first" and not len(K._get_available_gpus()):
         return
 
@@ -202,27 +170,11 @@ def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, previous, data_for
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
-    layer_backward = to_backward(Flatten("channels_last", dtype=K.floatx()), previous=previous, mode=mode)
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        f_dense = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_dense(
-            inputs_
-            + [
-                np.ones((len(x), 1, 1)),
-                np.zeros(
-                    (
-                        len(x),
-                        1,
-                    )
-                ),
-            ]
-        )
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        # import pdb; pdb.set_trace()
-        output_ = f_dense(inputs_)
+    layer_backward = to_backward(Flatten("channels_last", dtype=K.floatx()), mode=mode)
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    # import pdb; pdb.set_trace()
+    output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
     helpers.assert_output_properties_box_linear(
@@ -243,7 +195,7 @@ def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, previous, data_for
     K.set_epsilon(eps)
 
 
-def test_Backward_NativeReshape_multiD_box(odd, floatx, mode, previous, data_format, helpers):
+def test_Backward_NativeReshape_multiD_box(odd, floatx, mode, data_format, helpers):
     if data_format == "channels_first" and not len(K._get_available_gpus()):
         return
 
@@ -281,27 +233,10 @@ def test_Backward_NativeReshape_multiD_box(odd, floatx, mode, previous, data_for
     w_out = Input((1, 1))
     b_out = Input((1,))
     # get backward layer
-    layer_backward = to_backward(Reshape((-1,)), previous=previous, mode=mode)
-    if previous:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode + [w_out, b_out, w_out, b_out])
-        f_dense = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-        output_ = f_dense(
-            inputs_
-            + [
-                np.ones((len(x), 1, 1)),
-                np.zeros(
-                    (
-                        len(x),
-                        1,
-                    )
-                ),
-            ]
-        )
-    else:
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        # import pdb; pdb.set_trace()
-        output_ = f_dense(inputs_)
+    layer_backward = to_backward(Reshape((-1,)), mode=mode)
+    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
+    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
+    output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
     helpers.assert_output_properties_box_linear(


### PR DESCRIPTION
This attribute was forced to `False` in `convert_backward` so we remove it by assuming it `False`.