### PR TITLE
Rename DecomonModel main args "inputs" and "outputs"

### DIFF
--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -79,8 +79,8 @@ def get_model(model: DecomonModel) -> DecomonModel:
         raise ValueError(f"Unknown mode {mode}")
 
     return DecomonModel(
-        input=inputs,
-        output=output_,
+        inputs=inputs,
+        outputs=output_,
         convex_domain=model.convex_domain,
         IBP=IBP,
         forward=forward,
@@ -577,8 +577,8 @@ def build_radius_robust_model(model: DecomonModel) -> DecomonModel:
     output_robust = layer_robust(output)
 
     return DecomonModel(
-        input=inputs,
-        output=output_robust,
+        inputs=inputs,
+        outputs=output_robust,
         convex_domain=model.convex_domain,
         IBP=IBP,
         forward=forward,
@@ -601,8 +601,8 @@ def build_crossentropy_model(model: DecomonModel) -> DecomonModel:
     output_fusion = layer_fusion(output, mode=mode)
 
     return DecomonModel(
-        input=inputs,
-        output=output_fusion,
+        inputs=inputs,
+        outputs=output_fusion,
         convex_domain=model.convex_domain,
         IBP=IBP,
         forward=forward,
@@ -625,8 +625,8 @@ def build_asymptotic_crossentropy_model(model: DecomonModel) -> DecomonModel:
     output_fusion = layer_fusion(output, mode=mode)
 
     return DecomonModel(
-        input=inputs,
-        output=output_fusion,
+        inputs=inputs,
+        outputs=output_fusion,
         convex_domain=model.convex_domain,
         IBP=IBP,
         forward=forward,

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -295,8 +295,8 @@ def clone(
             back_bounds_.append(elem)
 
     return DecomonModel(
-        input=[z_tensor] + back_bounds_ + extra_inputs,
-        output=output,
+        inputs=[z_tensor] + back_bounds_ + extra_inputs,
+        outputs=output,
         convex_domain=convex_domain,
         dc_decomp=False,
         method=method,

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -12,8 +12,8 @@ from decomon.utils import ConvexDomainType
 class DecomonModel(tf.keras.Model):
     def __init__(
         self,
-        input: Union[tf.Tensor, List[tf.Tensor]],
-        output: Union[tf.Tensor, List[tf.Tensor]],
+        inputs: Union[tf.Tensor, List[tf.Tensor]],
+        outputs: Union[tf.Tensor, List[tf.Tensor]],
         convex_domain: Optional[Dict[str, Any]] = None,
         dc_decomp: bool = False,
         method: Union[str, ConvertMethod] = ConvertMethod.FORWARD_AFFINE,
@@ -24,7 +24,7 @@ class DecomonModel(tf.keras.Model):
         backward_bounds: bool = False,
         **kwargs: Any,
     ):
-        super().__init__(input, output, **kwargs)
+        super().__init__(inputs, outputs, **kwargs)
         if convex_domain is None:
             convex_domain = {}
         self.convex_domain = convex_domain


### PR DESCRIPTION
The goal is to stay consistent with Keras models which have "inputs" and "ouputs" as main arguments (when defined as functional models), instead of "input" and "output".