### PR TITLE
Add tests for slope argument

### DIFF
--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -94,7 +94,7 @@ class DecomonConv2D(Conv2D, DecomonLayer):
             fast=fast,
             **kwargs,
         )
-        self.slope = slope
+        self.slope = Slope(slope)
         self.kernel_constraint_pos_ = NonNeg()
         self.kernel_constraint_neg_ = NonPos()
 
@@ -675,7 +675,7 @@ class DecomonDense(Dense, DecomonLayer):
             fast=fast,
             **kwargs,
         )
-        self.slope = slope
+        self.slope = Slope(slope)
         self.kernel_constraint_pos_ = NonNeg()
         self.kernel_constraint_neg_ = NonPos()
         self.input_spec = [InputSpec(min_ndim=2) for _ in range(self.nb_tensors)]
@@ -1172,7 +1172,7 @@ class DecomonActivation(Activation, DecomonLayer):
             **kwargs,
         )
 
-        self.slope = slope
+        self.slope = Slope(slope)
         self.supports_masking = True
         self.activation = activations.get(activation)
         self.activation_name = activation

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 import tensorflow as tf
 
-from decomon.models.convert import clone as convert
+from decomon.models.convert import clone
 from decomon.models.models import DecomonModel
 from decomon.models.utils import ConvertMethod
 from decomon.utils import ConvexDomainType
@@ -70,7 +70,7 @@ def get_adv_box(
     # check that the model is a DecomonModel, else do the conversion
     model_: DecomonModel
     if not isinstance(model, DecomonModel):
-        model_ = convert(model)
+        model_ = clone(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -285,7 +285,7 @@ def check_adv_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model)
+        model_ = clone(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -481,7 +481,7 @@ def get_range_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not (isinstance(model, DecomonModel)):
-        model_ = convert(model)
+        model_ = clone(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -666,7 +666,7 @@ def get_range_noise(
     convex_domain = {"name": ConvexDomainType.BALL, "p": p, "eps": max(0, eps)}
 
     if not isinstance(model, DecomonModel):
-        model_ = convert(
+        model_ = clone(
             model,
             method=ConvertMethod.CROWN_FORWARD_HYBRID,
             convex_domain=convex_domain,
@@ -817,7 +817,7 @@ def refine_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model)
+        model_ = clone(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -944,7 +944,7 @@ def get_adv_noise(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model, convex_domain=convex_domain)
+        model_ = clone(model, convex_domain=convex_domain)
     else:
         model_ = model
         if eps >= 0:

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from decomon.models.convert import clone as convert
 from decomon.models.models import DecomonModel
 from decomon.models.utils import ConvertMethod
-from decomon.utils import ConvexDomainType, Slope
+from decomon.utils import ConvexDomainType
 
 IntegerType = Union[int, np.int_]
 """Alias for integers types."""
@@ -45,7 +45,6 @@ def get_adv_box(
     target_labels: Optional[LabelType] = None,
     batch_size: int = -1,
     n_sub_boxes: int = 1,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> npt.NDArray[np.float_]:
     """if the output is negative, then it is a formal guarantee that there is no adversarial examples
 
@@ -62,7 +61,6 @@ def get_adv_box(
         batch_size: for computational efficiency, one can split the
             calls to minibatches
         n_sub_boxes:
-        slope:
     Returns:
         numpy array, vector with upper bounds for adversarial attacks
     """
@@ -72,7 +70,7 @@ def get_adv_box(
     # check that the model is a DecomonModel, else do the conversion
     model_: DecomonModel
     if not isinstance(model, DecomonModel):
-        model_ = convert(model, slope=slope)
+        model_ = convert(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -263,7 +261,6 @@ def check_adv_box(
     source_labels: npt.NDArray[np.int_],
     target_labels: Optional[npt.NDArray[np.int_]] = None,
     batch_size: int = -1,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> npt.NDArray[np.float_]:
     """if the output is negative, then it is a formal guarantee that there is no adversarial examples
 
@@ -279,7 +276,6 @@ def check_adv_box(
             contain multiple target labels for each sample)
         batch_size: for computational efficiency, one can split the
             calls to minibatches
-        slope:
 
     Returns:
         numpy array, vector with upper bounds for adversarial attacks
@@ -289,7 +285,7 @@ def check_adv_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model, slope=slope)
+        model_ = convert(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -465,7 +461,6 @@ def get_range_box(
     x_max: npt.NDArray[np.float_],
     batch_size: int = -1,
     n_sub_boxes: int = 1,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
     """bounding the outputs of a model in a given box
     if the constant is negative, then it is a formal guarantee that there is no adversarial examples
@@ -476,7 +471,6 @@ def get_range_box(
         x_max: numpy array for the extremal upper corner of the boxes
         batch_size: for computational efficiency, one can split the
             calls to minibatches
-        slope:
 
     Returns:
         2 numpy array, vector with upper bounds and vector with lower
@@ -487,7 +481,7 @@ def get_range_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not (isinstance(model, DecomonModel)):
-        model_ = convert(model, slope=slope)
+        model_ = convert(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -652,7 +646,6 @@ def get_range_noise(
     eps: float,
     p: float = np.inf,
     batch_size: int = -1,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
     """Bounds the output of a model in an Lp Ball
 
@@ -663,7 +656,6 @@ def get_range_noise(
         p: the type of Lp norm (p=2, 1, np.inf)
         batch_size: for computational efficiency, one can split the
             calls to minibatches
-        slope:
 
     Returns:
         2 numpy arrays, vector with upper andlower bounds
@@ -678,7 +670,6 @@ def get_range_noise(
             model,
             method=ConvertMethod.CROWN_FORWARD_HYBRID,
             convex_domain=convex_domain,
-            slope=slope,
         )
     else:
         model_ = model
@@ -817,7 +808,6 @@ def refine_box(
     target_labels: Optional[npt.NDArray[np.int_]] = None,
     batch_size: int = -1,
     random: bool = True,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> npt.NDArray[np.float_]:
 
     if func.__name__ not in [
@@ -827,7 +817,7 @@ def refine_box(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model, slope=slope)
+        model_ = convert(model)
     else:
         assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
             ConvexDomainType.BOX,
@@ -930,7 +920,6 @@ def get_adv_noise(
     p: float = np.inf,
     target_labels: Optional[LabelType] = None,
     batch_size: int = -1,
-    slope: Union[str, Slope] = Slope.V_SLOPE,
 ) -> npt.NDArray[np.float_]:
     """if the output is negative, then it is a formal guarantee that there is no adversarial examples
 
@@ -946,7 +935,6 @@ def get_adv_noise(
             contain multiple target labels for each sample)
         batch_size: for computational efficiency, one can split the
             calls to minibatches
-        slope:
 
     Returns:
         numpy array, vector with upper bounds for adversarial attacks
@@ -956,7 +944,7 @@ def get_adv_noise(
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        model_ = convert(model, convex_domain=convex_domain, slope=slope)
+        model_ = convert(model, convex_domain=convex_domain)
     else:
         model_ = model
         if eps >= 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,16 @@ from tensorflow.keras.models import Model, Sequential
 
 from decomon.layers.core import ForwardMode
 from decomon.models.utils import ConvertMethod
+from decomon.utils import Slope
 
 
 @pytest.fixture(params=[m.value for m in ForwardMode])
 def mode(request):
+    return request.param
+
+
+@pytest.fixture(params=[s.value for s in Slope])
+def slope(request):
     return request.param
 
 

--- a/tests/lirpa_comparison/test_comparison_lirpa.py
+++ b/tests/lirpa_comparison/test_comparison_lirpa.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_almost_equal
 from onnx2keras import onnx_to_keras
 from onnx2torch import convert
 
-from decomon.models.convert import clone as convert
+from decomon.models.convert import clone
 from decomon.models.utils import ConvertMethod
 
 
@@ -34,7 +34,7 @@ def test_with_lirpa(path, onnx_filename, method, eps, N):
 
     # use use onnx2torch to load the network in torch
     onnx_model = onnx.load(onnx_filename)
-    torch_model = convert(onnx_model)
+    torch_model = clone(onnx_model)
 
     ## Step 2: Prepare dataset as usual
     test_data = torchvision.datasets.MNIST(
@@ -57,7 +57,7 @@ def test_with_lirpa(path, onnx_filename, method, eps, N):
     onnx_model = onnx.load(onnx_filename)
     k_model = onnx_to_keras(onnx_model, ["0"])
 
-    decomon_model = convert(k_model, method=equ_method[method], final_ibp=True, final_affine=False)
+    decomon_model = clone(k_model, method=equ_method[method], final_ibp=True, final_affine=False)
 
     image_ = image.detach().numpy()
     box = np.concatenate([image_[:, None] - eps, image_[:, None] + eps], 1)

--- a/tests/test_decomon_activation_layer.py
+++ b/tests/test_decomon_activation_layer.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+import tensorflow.python.keras.backend as K
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+
+from decomon.backward_layers.backward_layers import to_backward
+from decomon.layers.core import ForwardMode
+from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
+from decomon.layers.decomon_reshape import DecomonReshape
+from decomon.utils import Slope
+
+
+def test_decomon_activation_slope(helpers):
+    mode = ForwardMode.AFFINE
+    activation = "relu"
+    n = 2
+
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
+    (
+        x_0,
+        y_0,
+        z_0,
+        u_c_0,
+        W_u_0,
+        b_u_0,
+        l_c_0,
+        W_l_0,
+        b_l_0,
+    ) = inputs_  # numpy values
+
+    outputs_by_slope = {}
+    for slope in Slope:
+        layer = DecomonActivation(activation, dc_decomp=False, mode=mode, slope=slope)
+        assert layer.slope == slope
+        inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
+        x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs  # tensors
+        inputs_for_mode = [z, W_u, b_u, W_l, b_l]
+        output = layer(inputs_for_mode)
+        f_func = K.function(inputs[2:], output)
+        outputs_by_slope[slope] = f_func(inputs_[2:])
+
+    # check results
+    # O_Slope != Z_Slope
+    same_outputs_O_n_Z = [
+        (a == b).all() for a, b in zip(outputs_by_slope[Slope.O_SLOPE], outputs_by_slope[Slope.Z_SLOPE])
+    ]
+    assert not all(same_outputs_O_n_Z)
+
+    # V_Slope == Z_Slope
+    for a, b in zip(outputs_by_slope[Slope.V_SLOPE], outputs_by_slope[Slope.Z_SLOPE]):
+        assert (a == b).all()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pytest
+from numpy.testing import assert_almost_equal
 from tensorflow.keras.layers import Activation, Dense
 from tensorflow.keras.models import Sequential
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -4,7 +4,7 @@ from tensorflow.keras.models import Sequential
 
 from decomon import get_lower_box, get_range_box, get_upper_box
 from decomon.backward_layers.utils import get_affine, get_ibp
-from decomon.models import clone as convert
+from decomon.models import clone
 
 
 def test_get_upper_1d_box(n, method, mode, helpers):
@@ -22,7 +22,7 @@ def test_get_upper_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
+    backward_model = clone(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
 
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -49,7 +49,7 @@ def test_get_lower_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
 
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -76,7 +76,7 @@ def test_get_range_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
 
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -104,7 +104,7 @@ def test_get_upper_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -126,7 +126,7 @@ def test_get_lower_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -148,7 +148,7 @@ def test_get_range_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 


### PR DESCRIPTION
- add a fixture slope in conftest with all possible values that slope can take
- test wrapper: compare call on a preconverted model with slope to a a direct call on a keras model with a given slope arg
- test clone: check that converted layers get the proper slope attribute
- test layers with activation: check that modifying slope modifies result
- test activation functions (only relu for now): check affine bounds found for each slope