### PR TITLE
Use "affine" instead of "forward" in code for bounds type

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -9,7 +9,7 @@ from tensorflow.python.ops import array_ops
 
 from decomon.backward_layers.activations import get
 from decomon.backward_layers.core import BackwardLayer
-from decomon.backward_layers.utils import get_FORWARD, get_IBP, get_identity_lirpa
+from decomon.backward_layers.utils import get_affine, get_ibp, get_identity_lirpa
 from decomon.layers.core import DecomonLayer, ForwardMode, Option
 from decomon.layers.decomon_layers import (  # add some layers to module namespace `globals()`
     DecomonActivation,
@@ -65,8 +65,8 @@ class BackwardDense(BackwardLayer):
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,
-                IBP=get_IBP(self.mode),
-                forward=get_FORWARD(self.mode),
+                ibp=get_ibp(self.mode),
+                affine=get_affine(self.mode),
                 shared=True,
                 fast=False,
             )[0]
@@ -248,8 +248,8 @@ class BackwardConv2D(BackwardLayer):
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,
-                IBP=get_IBP(self.mode),
-                forward=get_FORWARD(self.mode),
+                ibp=get_ibp(self.mode),
+                affine=get_affine(self.mode),
                 shared=True,
                 fast=False,
             )[0]

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -6,7 +6,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Layer
 
 from decomon.backward_layers.core import BackwardLayer
-from decomon.backward_layers.utils import get_FORWARD, get_IBP
+from decomon.backward_layers.utils import get_affine, get_ibp
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonLayer, to_decomon
 from decomon.utils import Slope
@@ -51,8 +51,8 @@ class BackwardGroupSort2(BackwardLayer):
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,
-                IBP=get_IBP(self.mode),
-                forward=get_FORWARD(self.mode),
+                ibp=get_ibp(self.mode),
+                affine=get_affine(self.mode),
                 shared=True,
                 fast=False,
             )[0]

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -846,14 +846,14 @@ def get_identity_lirpa(inputs: List[tf.Tensor]) -> List[tf.Tensor]:
     return [w_out_u, b_out_u, w_out_l, b_out_l]
 
 
-def get_IBP(mode: Union[str, ForwardMode] = ForwardMode.HYBRID) -> bool:
+def get_ibp(mode: Union[str, ForwardMode] = ForwardMode.HYBRID) -> bool:
     mode = ForwardMode(mode)
     if mode in [ForwardMode.HYBRID, ForwardMode.IBP]:
         return True
     return False
 
 
-def get_FORWARD(mode: Union[str, ForwardMode] = ForwardMode.HYBRID) -> bool:
+def get_affine(mode: Union[str, ForwardMode] = ForwardMode.HYBRID) -> bool:
     mode = ForwardMode(mode)
     if mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
         return True

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -53,7 +53,7 @@ def relu(
         alpha: see Keras official documentation
         max_value: see Keras official documentation
         threshold: see Keras official documentation
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -91,7 +91,7 @@ def linear_hull_s_shape(
         f_prime: the derivative of the function (sigmoid_prime...)
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
     whether we return a difference of convex decomposition of our layer
 
@@ -169,7 +169,7 @@ def sigmoid(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
 
@@ -201,7 +201,7 @@ def tanh(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -234,7 +234,7 @@ def hard_sigmoid(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -265,7 +265,7 @@ def elu(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -303,7 +303,7 @@ def selu(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -333,7 +333,7 @@ def linear(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -360,7 +360,7 @@ def exponential(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -388,7 +388,7 @@ def softplus(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -418,7 +418,7 @@ def softsign(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer
@@ -452,7 +452,7 @@ def softmax(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: type of convex input domain (None or dict)
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: see Keras official documentation
     whether we return a difference of convex decomposition of our layer

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -35,7 +35,7 @@ class StaticVariables:
         Args:
             dc_decomp: boolean that indicates whether we return a
                 difference of convex decomposition of our layer
-            mode: type of Forward propagation (IBP, Forward or Hybrid)
+            mode: type of Forward propagation (ibp, affine, or hybrid)
         gradient
         """
 
@@ -75,7 +75,7 @@ class DecomonLayer(ABC, Layer):
         Args:
             convex_domain: type of convex input domain (None or dict)
             dc_decomp: boolean that indicates whether we return a
-            mode: type of Forward propagation (IBP, Forward or Hybrid)
+            mode: type of Forward propagation (ibp, affine, or hybrid)
             **kwargs: extra parameters
         difference of convex decomposition of our layer
         """

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -1653,8 +1653,8 @@ def to_decomon(
     dc_decomp: bool = False,
     convex_domain: Optional[Dict[str, Any]] = None,
     finetune: bool = False,
-    IBP: bool = True,
-    forward: bool = True,
+    ibp: bool = True,
+    affine: bool = True,
     shared: bool = True,
     fast: bool = True,
 ) -> List[DecomonLayer]:
@@ -1671,8 +1671,8 @@ def to_decomon(
         dc_decomp: boolean that indicates whether we return a difference
             of convex decomposition of our layer
         convex_domain: the type of convex domain
-        IBP: boolean that indicates whether we propagate constant bounds
-        forward: boolean that indicates whether we propagate affine
+        ibp: boolean that indicates whether we propagate constant bounds
+        affine: boolean that indicates whether we propagate affine
             bounds
 
     Returns:
@@ -1693,7 +1693,7 @@ def to_decomon(
             raise ValueError(f"the layer {layer.name} has not been built yet")
 
     if isinstance(layer, Merge):
-        return to_decomon_merge(layer, input_dim, dc_decomp, convex_domain, finetune, IBP, forward)
+        return to_decomon_merge(layer, input_dim, dc_decomp, convex_domain, finetune, ibp, affine)
 
     # do case by case for optimizing
 
@@ -1711,9 +1711,9 @@ def to_decomon(
             config_layer["convex_domain"] = convex_domain
 
             mode = ForwardMode.HYBRID
-            if IBP and not forward:
+            if ibp and not affine:
                 mode = ForwardMode.IBP
-            if not IBP and forward:
+            if not ibp and affine:
                 mode = ForwardMode.AFFINE
 
             config_layer["mode"] = mode
@@ -1753,8 +1753,8 @@ def to_decomon(
                         dc_decomp=dc_decomp,
                         convex_domain=convex_domain,
                         finetune=finetune,
-                        IBP=IBP,
-                        forward=forward,
+                        ibp=ibp,
+                        affine=affine,
                         shared=shared,
                         fast=fast,
                     )

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -621,8 +621,8 @@ def to_decomon_merge(
     dc_decomp: bool = False,
     convex_domain: Optional[Dict[str, Any]] = None,
     finetune: bool = False,
-    IBP: bool = True,
-    forward: bool = True,
+    ibp: bool = True,
+    affine: bool = True,
 ) -> List[DecomonLayer]:
     """Transform a standard Merge layer into a Decomon layer.
 
@@ -636,8 +636,8 @@ def to_decomon_merge(
         dc_decomp: boolean that indicates whether we return a difference
             of convex decomposition of our layer
         convex_domain: the type of convex domain
-        IBP: boolean that indicates whether we propagate constant bounds
-        forward: boolean that indicates whether we propagate affine
+        ibp: boolean that indicates whether we propagate constant bounds
+        affine: boolean that indicates whether we propagate affine
             bounds
 
     Returns:
@@ -660,9 +660,9 @@ def to_decomon_merge(
     config_layer["convex_domain"] = convex_domain
 
     mode = ForwardMode.HYBRID
-    if IBP and not forward:
+    if ibp and not affine:
         mode = ForwardMode.IBP
-    if not IBP and forward:
+    if not ibp and affine:
         mode = ForwardMode.AFFINE
 
     config_layer["mode"] = mode

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -673,7 +673,7 @@ def multiply(
         inputs_1: list of tensors
         dc_decomp: boolean that indicates
         convex_domain: the type of convex domain
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
     whether we return a difference of convex decomposition of our layer
     whether we propagate upper and lower bounds on the values of the gradient
 
@@ -751,7 +751,7 @@ def permute_dimensions(
     Args:
         x: list of input tensors
         axis: axis on which we apply the permutation
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         axis_perm: see DecomonPermute operator
 
     Returns:
@@ -1226,7 +1226,7 @@ def log(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: the type of convex input domain
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         **kwargs: extra parameters
     whether we return a difference of convex decomposition of our layer
 
@@ -1288,7 +1288,7 @@ def exp(
         x: list of input tensors
         dc_decomp: boolean that indicates
         convex_domain: the type of convex input domain
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
         slope:
         **kwargs: extra parameters
     whether we return a difference of convex decomposition of our layer

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -37,8 +37,8 @@ def include_dim_layer_fn(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     dc_decomp: bool = False,
     convex_domain: Optional[Dict[str, Any]] = None,
-    IBP: bool = True,
-    forward: bool = True,
+    ibp: bool = True,
+    affine: bool = True,
     finetune: bool = False,
     shared: bool = True,
 ) -> Callable[[Layer], List[DecomonLayer]]:
@@ -66,8 +66,8 @@ def include_dim_layer_fn(
                 slope=slope,
                 convex_domain=convex_domain,
                 dc_decomp=dc_decomp,
-                IBP=IBP,
-                forward=forward,
+                ibp=ibp,
+                affine=affine,
                 finetune=finetune,
                 shared=shared,
             )
@@ -92,8 +92,8 @@ def convert_forward(
     input_dim: int = -1,
     dc_decomp: bool = False,
     convex_domain: Optional[Dict[str, Any]] = None,
-    IBP: bool = True,
-    forward: bool = True,
+    ibp: bool = True,
+    affine: bool = True,
     finetune: bool = False,
     shared: bool = True,
     softmax_to_linear: bool = True,
@@ -114,8 +114,8 @@ def convert_forward(
         input_dim=input_dim,
         dc_decomp=dc_decomp,
         convex_domain=convex_domain,
-        IBP=IBP,
-        forward=forward,
+        ibp=ibp,
+        affine=affine,
         finetune=finetune,
         shared=shared,
         softmax_to_linear=softmax_to_linear,
@@ -134,8 +134,8 @@ def convert_forward_functional_model(
     input_dim: int = 1,
     dc_decomp: bool = False,
     convex_domain: Optional[Dict[str, Any]] = None,
-    IBP: bool = True,
-    forward: bool = True,
+    ibp: bool = True,
+    affine: bool = True,
     finetune: bool = False,
     shared: bool = True,
     softmax_to_linear: bool = True,
@@ -162,7 +162,7 @@ def convert_forward_functional_model(
         input_tensors = []
         for i in range(len(model._input_layers)):
 
-            tmp = check_input_tensors_sequential(model, None, input_dim, input_dim, IBP, forward, False, convex_domain)
+            tmp = check_input_tensors_sequential(model, None, input_dim, input_dim, ibp, affine, False, convex_domain)
             input_tensors += tmp
 
     if softmax_to_linear:
@@ -178,8 +178,8 @@ def convert_forward_functional_model(
             input_dim=input_dim,
             slope=slope,
             convex_domain=convex_domain,
-            IBP=IBP,
-            forward=forward,
+            ibp=ibp,
+            affine=affine,
             finetune=finetune,
             shared=shared,
         )  # return a list of Decomon layers
@@ -217,8 +217,8 @@ def convert_forward_functional_model(
                     layer_fn=layer_fn,
                     input_dim=input_dim_init,
                     convex_domain=convex_domain,
-                    IBP=IBP,
-                    forward=forward,
+                    ibp=ibp,
+                    affine=affine,
                     finetune=finetune,
                     shared=shared,
                     softmax_to_linear=softmax_to_linear,

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -17,8 +17,8 @@ class DecomonModel(tf.keras.Model):
         convex_domain: Optional[Dict[str, Any]] = None,
         dc_decomp: bool = False,
         method: Union[str, ConvertMethod] = ConvertMethod.FORWARD_AFFINE,
-        IBP: bool = True,
-        forward: bool = True,
+        ibp: bool = True,
+        affine: bool = True,
         finetune: bool = False,
         shared: bool = True,
         backward_bounds: bool = False,
@@ -31,8 +31,8 @@ class DecomonModel(tf.keras.Model):
         self.nb_tensors = StaticVariables(dc_decomp).nb_tensors
         self.dc_decomp = dc_decomp
         self.method = ConvertMethod(method)
-        self.IBP = IBP
-        self.forward = forward
+        self.ibp = ibp
+        self.affine = affine
         self.finetune = finetune
         self.backward_bounds = backward_bounds
         self.shared = shared

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -41,8 +41,8 @@ def check_input_tensors_sequential(
     input_tensors: Optional[List[tf.Tensor]],
     input_dim: int,
     input_dim_init: int,
-    IBP: bool,
-    forward: bool,
+    ibp: bool,
+    affine: bool,
     dc_decomp: bool,
     convex_domain: Optional[Dict[str, Any]],
 ) -> List[tf.Tensor]:
@@ -69,7 +69,7 @@ def check_input_tensors_sequential(
         if dc_decomp:
             h_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
             g_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
-        if forward:
+        if affine:
             b_u_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
             b_l_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
             if input_dim_init > 0:
@@ -79,10 +79,10 @@ def check_input_tensors_sequential(
                 w_u_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
                 w_l_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
 
-        if IBP:
+        if ibp:
             u_c_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
             l_c_tensor = Input(tuple(input_shape), dtype=model.layers[0].dtype)
-            if forward:  # hybrid mode
+            if affine:  # hybrid mode
                 input_tensors = [
                     z_tensor,
                     u_c_tensor,
@@ -93,13 +93,13 @@ def check_input_tensors_sequential(
                     b_l_tensor,
                 ]
             else:
-                # only IBP
+                # only ibp
                 input_tensors = [
                     u_c_tensor,
                     l_c_tensor,
                 ]
-        elif forward:
-            # forward mode
+        elif affine:
+            # affine mode
             input_tensors = [
                 z_tensor,
                 w_u_tensor,
@@ -108,7 +108,7 @@ def check_input_tensors_sequential(
                 b_l_tensor,
             ]
         else:
-            raise NotImplementedError("not IBP and not forward not implemented")
+            raise NotImplementedError("not ibp and not affine not implemented")
 
         if dc_decomp:
             input_tensors += [h_tensor, g_tensor]
@@ -122,28 +122,28 @@ def check_input_tensors_sequential(
         )
 
         if dc_decomp:
-            if IBP and forward:
+            if ibp and affine:
                 assert len(input_tensors) == 9, "wrong number of inputs, expexted 10 but got {}".format(
                     len(input_tensors)
                 )
-            if IBP and not forward:
+            if ibp and not affine:
                 assert len(input_tensors) == 4, "wrong number of inputs, expexted 6 but got {}".format(
                     len(input_tensors)
                 )
-            if not IBP and forward:
+            if not ibp and affine:
                 assert len(input_tensors) == 5, "wrong number of inputs, expexted 8 but got {}".format(
                     len(input_tensors)
                 )
         else:
-            if IBP and forward:
+            if ibp and affine:
                 assert len(input_tensors) == 7, "wrong number of inputs, expexted 10 but got {}".format(
                     len(input_tensors)
                 )
-            if IBP and not forward:
+            if ibp and not affine:
                 assert len(input_tensors) == 2, "wrong number of inputs, expexted 10 but got {}".format(
                     len(input_tensors)
                 )
-            if not IBP and forward:
+            if not ibp and affine:
                 assert len(input_tensors) == 5, "wrong number of inputs, expexted 10 but got {}".format(
                     len(input_tensors)
                 )
@@ -178,8 +178,8 @@ def check_input_tensors_functionnal(
     input_tensors: Optional[List[tf.Tensor]],
     input_dim: int,
     input_dim_init: int,
-    IBP: bool,
-    forward: bool,
+    ibp: bool,
+    affine: bool,
     dc_decomp: bool,
     convex_domain: Optional[Dict[str, Any]],
 ) -> List[tf.Tensor]:
@@ -187,10 +187,10 @@ def check_input_tensors_functionnal(
     raise NotImplementedError()
 
 
-def get_mode(IBP: bool = True, forward: bool = True) -> ForwardMode:
+def get_mode(ibp: bool = True, affine: bool = True) -> ForwardMode:
 
-    if IBP:
-        if forward:
+    if ibp:
+        if affine:
             return ForwardMode.HYBRID
         else:
             return ForwardMode.IBP

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -1045,7 +1045,7 @@ def get_linear_hull_s_shape(
         func: the function (sigmoid, tanh, softsign...)
         f_prime: the derivative of the function (sigmoid_prime...)
         convex_domain: the type of convex input domain
-        mode: type of Forward propagation (IBP, Forward or Hybrid)
+        mode: type of Forward propagation (ibp, affine, or hybrid)
 
     Returns:
         the updated list of tensors

--- a/tests/lirpa_comparison/test_comparison_lirpa.py
+++ b/tests/lirpa_comparison/test_comparison_lirpa.py
@@ -57,7 +57,7 @@ def test_with_lirpa(path, onnx_filename, method, eps, N):
     onnx_model = onnx.load(onnx_filename)
     k_model = onnx_to_keras(onnx_model, ["0"])
 
-    decomon_model = convert(k_model, method=equ_method[method], ibp=True, affine=False)
+    decomon_model = convert(k_model, method=equ_method[method], final_ibp=True, final_affine=False)
 
     image_ = image.detach().numpy()
     box = np.concatenate([image_[:, None] - eps, image_[:, None] + eps], 1)

--- a/tests/lirpa_comparison/test_comparison_lirpa.py
+++ b/tests/lirpa_comparison/test_comparison_lirpa.py
@@ -57,7 +57,7 @@ def test_with_lirpa(path, onnx_filename, method, eps, N):
     onnx_model = onnx.load(onnx_filename)
     k_model = onnx_to_keras(onnx_model, ["0"])
 
-    decomon_model = convert(k_model, method=equ_method[method], ibp=True, forward=False)
+    decomon_model = convert(k_model, method=equ_method[method], ibp=True, affine=False)
 
     image_ = image.detach().numpy()
     box = np.concatenate([image_[:, None] - eps, image_[:, None] + eps], 1)

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -33,18 +33,18 @@ def test_Backward_Dense_1D_box(n, activation, use_bias, mode, floatx, helpers):
     layer_(inputs[1])
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
-        IBP = True
-        forward = True
+        ibp = True
+        affine = True
     elif mode == ForwardMode.IBP:
-        IBP = True
-        forward = False
+        ibp = True
+        affine = False
     elif mode == ForwardMode.AFFINE:
-        IBP = False
-        forward = True
+        ibp = False
+        affine = True
     else:
         raise ValueError("Unknown mode.")
 
-    layer = to_decomon(layer_, input_dim, dc_decomp=False, IBP=IBP, forward=forward, shared=True)[0]
+    layer = to_decomon(layer_, input_dim, dc_decomp=False, ibp=ibp, affine=affine, shared=True)[0]
 
     if mode == ForwardMode.HYBRID:
         input_mode = inputs[2:]
@@ -159,18 +159,18 @@ def test_Backward_DecomonDense_multiD_box(odd, activation, floatx, mode, helpers
     layer_(inputs[1])
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
-        IBP = True
-        forward = True
+        ibp = True
+        affine = True
     elif mode == ForwardMode.IBP:
-        IBP = True
-        forward = False
+        ibp = True
+        affine = False
     elif mode == ForwardMode.AFFINE:
-        IBP = False
-        forward = True
+        ibp = False
+        affine = True
     else:
         raise ValueError("Unknown mode.")
 
-    layer = to_decomon(layer_, input_dim, dc_decomp=False, IBP=IBP, forward=forward, shared=True)[0]
+    layer = to_decomon(layer_, input_dim, dc_decomp=False, ibp=ibp, affine=affine, shared=True)[0]
 
     if mode == ForwardMode.HYBRID:
         input_mode = inputs[2:]

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -10,7 +10,7 @@ from decomon.models import clone
 
 def test_convert_1D(n, method, mode, floatx, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     K.set_floatx("float{}".format(floatx))
@@ -29,15 +29,15 @@ def test_convert_1D(n, method, mode, floatx, helpers):
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
     ref_nn(inputs[1])
 
-    IBP = True
-    forward = True
+    ibp = True
+    affine = True
     mode = ForwardMode(mode)
     if mode == ForwardMode.AFFINE:
-        IBP = False
+        ibp = False
     if mode == ForwardMode.IBP:
-        forward = False
+        affine = False
 
-    f_dense = clone(ref_nn, method=method, final_ibp=IBP, final_forward=forward)
+    f_dense = clone(ref_nn, method=method, final_ibp=ibp, final_affine=affine)
 
     f_ref = K.function(inputs, ref_nn(inputs[1]))
     y_ref = f_ref(inputs_)

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -27,13 +27,13 @@ def test_convert_backward_1D(n, mode, floatx, helpers):
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
     ref_nn(inputs[1])
 
-    IBP = True
-    forward = True
+    ibp = True
+    affine = True
     mode = ForwardMode(mode)
     if mode == ForwardMode.AFFINE:
-        IBP = False
+        ibp = False
     if mode == ForwardMode.IBP:
-        forward = False
+        affine = False
 
     input_tensors = inputs[2:]
     if mode == ForwardMode.IBP:
@@ -42,17 +42,17 @@ def test_convert_backward_1D(n, mode, floatx, helpers):
         input_tensors = [z, W_u, b_u, W_l, b_l]
 
     _, _, layer_map, forward_map = convert_forward(
-        ref_nn, IBP=IBP, forward=forward, shared=True, input_tensors=input_tensors, final_ibp=IBP, final_forward=forward
+        ref_nn, ibp=ibp, affine=affine, shared=True, input_tensors=input_tensors, final_ibp=ibp, final_affine=affine
     )
     _, output, _, _ = convert_backward(
         ref_nn,
         input_tensors=input_tensors,
-        IBP=IBP,
-        forward=forward,
+        ibp=ibp,
+        affine=affine,
         layer_map=layer_map,
         forward_map=forward_map,
-        final_ibp=IBP,
-        final_forward=forward,
+        final_ibp=ibp,
+        final_affine=affine,
     )
 
     f_dense = K.function(inputs[2:], output)

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -169,13 +169,13 @@ def test_convert_forward_1D(n, mode, floatx, helpers):
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
     ref_nn(inputs[1])
 
-    IBP = True
-    forward = True
+    ibp = True
+    affine = True
     mode = ForwardMode(mode)
     if mode == ForwardMode.AFFINE:
-        IBP = False
+        ibp = False
     if mode == ForwardMode.IBP:
-        forward = False
+        affine = False
 
     input_tensors = inputs[2:]
     if mode == ForwardMode.IBP:
@@ -183,7 +183,7 @@ def test_convert_forward_1D(n, mode, floatx, helpers):
     if mode == ForwardMode.AFFINE:
         input_tensors = [z, W_u, b_u, W_l, b_l]
 
-    _, output, _, _ = convert_forward(ref_nn, IBP=IBP, forward=forward, shared=True, input_tensors=input_tensors)
+    _, output, _, _ = convert_forward(ref_nn, ibp=ibp, affine=affine, shared=True, input_tensors=input_tensors)
 
     f_dense = K.function(inputs[2:], output)
     f_ref = K.function(inputs, ref_nn(inputs[1]))

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -345,19 +345,19 @@ def test_DecomonDense_1D_to_monotonic_box(n, activation, mode, shared, helpers):
     input_dim = x.shape[-1]
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
-        IBP = True
-        forward = True
+        ibp = True
+        affine = True
     elif mode == ForwardMode.AFFINE:
-        IBP = False
-        forward = True
+        ibp = False
+        affine = True
     elif mode == ForwardMode.IBP:
-        IBP = True
-        forward = False
+        ibp = True
+        affine = False
     else:
         raise ValueError("Unknown mode.")
 
     monotonic_dense = to_decomon(
-        dense_ref, input_dim, dc_decomp=True, IBP=IBP, forward=forward, shared=shared
+        dense_ref, input_dim, dc_decomp=True, ibp=ibp, affine=affine, shared=shared
     )  # ATTENTION: it will be a list
 
     W_, bias = monotonic_dense[0].get_weights()
@@ -466,18 +466,18 @@ def test_DecomonDense_multiD_to_monotonic_box(odd, activation, mode, helpers):
 
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
-        IBP = True
-        forward = True
+        ibp = True
+        affine = True
     elif mode == ForwardMode.AFFINE:
-        IBP = False
-        forward = True
+        ibp = False
+        affine = True
     elif mode == ForwardMode.IBP:
-        IBP = True
-        forward = False
+        ibp = True
+        affine = False
     else:
         raise ValueError("Unknown mode.")
 
-    monotonic_dense = to_decomon(dense_ref, input_dim, dc_decomp=True, IBP=IBP, forward=forward)
+    monotonic_dense = to_decomon(dense_ref, input_dim, dc_decomp=True, ibp=ibp, affine=affine)
 
     W_, bias = monotonic_dense[0].get_weights()
     W_0, b_0 = dense_ref.get_weights()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -3,13 +3,13 @@ from tensorflow.keras.layers import Activation, Dense
 from tensorflow.keras.models import Sequential
 
 from decomon import get_lower_box, get_range_box, get_upper_box
-from decomon.backward_layers.utils import get_FORWARD, get_IBP
+from decomon.backward_layers.utils import get_affine, get_ibp
 from decomon.models import clone as convert
 
 
 def test_get_upper_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
@@ -20,9 +20,9 @@ def test_get_upper_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward, mode=mode)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
 
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -36,7 +36,7 @@ def test_get_upper_1d_box(n, method, mode, helpers):
 
 def test_get_lower_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
@@ -47,9 +47,9 @@ def test_get_lower_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward, mode=mode)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
 
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -63,7 +63,7 @@ def test_get_lower_1d_box(n, method, mode, helpers):
 
 def test_get_range_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
@@ -74,9 +74,9 @@ def test_get_range_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward, mode=mode)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
 
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -91,7 +91,7 @@ def test_get_range_1d_box(n, method, mode, helpers):
 
 def test_get_upper_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
@@ -102,9 +102,9 @@ def test_get_upper_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -113,7 +113,7 @@ def test_get_upper_multid_box(odd, method, mode, helpers):
 
 def test_get_lower_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
@@ -124,9 +124,9 @@ def test_get_lower_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -135,7 +135,7 @@ def test_get_lower_multid_box(odd, method, mode, helpers):
 
 def test_get_range_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
-        # skip method=ibp/crown-ibp with mode=forward/hybrid
+        # skip method=ibp/crown-ibp with mode=affine/hybrid
         return
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
@@ -146,9 +146,9 @@ def test_get_range_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
-    ibp = get_IBP(mode)
-    forward = get_FORWARD(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, forward=forward)
+    ibp = get_ibp(mode)
+    affine = get_affine(mode)
+    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -49,7 +49,7 @@ def test_get_lower_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
+    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
 
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -76,7 +76,7 @@ def test_get_range_1d_box(n, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
+    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
 
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
@@ -104,7 +104,7 @@ def test_get_upper_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
+    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -126,7 +126,7 @@ def test_get_lower_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
+    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 
@@ -148,7 +148,7 @@ def test_get_range_multid_box(odd, method, mode, helpers):
     sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = convert(sequential, method=method, ibp=ibp, affine=affine)
+    backward_model = convert(sequential, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
     y_ref = sequential.predict(y)
 


### PR DESCRIPTION
For more consistency, we replace "forward" term by "affine" when it concerns the type of bounds propagated.
We let "forward" when it is about the direction of propagation.

Still to be consistent, we use "ibp" in lower case everywhere (it was sometimes in upper case).

We also fix the use of clone in wrapper.py on the way:
The arguments ibp and affine/forward or mode were passed but not used by clone(), we replace them by "final_ibp" and "final_affine".