### PR TITLE
Refactor to_decomon(), to_decomon_merge(), and to_backward()

### DIFF
--- a/src/decomon/backward_layers/__init__.py
+++ b/src/decomon/backward_layers/__init__.py
@@ -1,1 +1,1 @@
-from .backward_layers import to_backward
+from .convert import to_backward

--- a/src/decomon/backward_layers/__init__.py
+++ b/src/decomon/backward_layers/__init__.py
@@ -1,1 +1,0 @@
-from .convert import to_backward

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -35,6 +35,7 @@ from decomon.layers.decomon_layers import (  # add some layers to module namespa
     to_decomon,
 )
 from decomon.layers.utils import ClipAlpha, NonNeg, NonPos
+from decomon.models.utils import get_input_dim
 from decomon.utils import ConvexDomainType, Slope
 
 
@@ -64,6 +65,8 @@ class BackwardDense(BackwardLayer):
         if self.layer.use_bias:
             self.bias = self.layer.bias
         if not isinstance(self.layer, DecomonLayer):
+            if input_dim < 0:
+                input_dim = get_input_dim(self.layer)
             self.layer = to_decomon(
                 layer,
                 input_dim,
@@ -145,6 +148,8 @@ class BackwardConv2D(BackwardLayer):
             **kwargs,
         )
         if not isinstance(self.layer, DecomonLayer):
+            if input_dim < 0:
+                input_dim = get_input_dim(self.layer)
             self.layer = to_decomon(
                 layer,
                 input_dim,

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -22,6 +22,7 @@ from decomon.backward_layers.backward_merge import (
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.deel_lip import BackwardGroupSort2
 from decomon.backward_layers.utils import get_affine, get_ibp, get_identity_lirpa
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer, ForwardMode, Option
 from decomon.layers.decomon_layers import (  # add some layers to module namespace `globals()`
     DecomonActivation,
@@ -32,7 +33,6 @@ from decomon.layers.decomon_layers import (  # add some layers to module namespa
     DecomonFlatten,
     DecomonPermute,
     DecomonReshape,
-    to_decomon,
 )
 from decomon.layers.utils import ClipAlpha, NonNeg, NonPos
 from decomon.models.utils import get_input_dim
@@ -68,8 +68,8 @@ class BackwardDense(BackwardLayer):
             if input_dim < 0:
                 input_dim = get_input_dim(self.layer)
             self.layer = to_decomon(
-                layer,
-                input_dim,
+                layer=layer,
+                input_dim=input_dim,
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,
@@ -151,8 +151,8 @@ class BackwardConv2D(BackwardLayer):
             if input_dim < 0:
                 input_dim = get_input_dim(self.layer)
             self.layer = to_decomon(
-                layer,
-                input_dim,
+                layer=layer,
+                input_dim=input_dim,
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,

--- a/src/decomon/backward_layers/convert.py
+++ b/src/decomon/backward_layers/convert.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, Optional, Union
+
+from tensorflow.keras.layers import Layer
+
+import decomon.backward_layers.backward_layers
+import decomon.backward_layers.backward_maxpooling
+import decomon.backward_layers.backward_merge
+import decomon.backward_layers.deel_lip
+from decomon.backward_layers.core import BackwardLayer
+from decomon.layers.core import ForwardMode
+from decomon.utils import Slope
+
+_mapping_name2class: Dict[str, Any] = vars(decomon.backward_layers.backward_layers)
+_mapping_name2class.update(vars(decomon.backward_layers.deel_lip))
+_mapping_name2class.update(vars(decomon.backward_layers.backward_merge))
+_mapping_name2class.update(vars(decomon.backward_layers.backward_maxpooling))
+
+
+def to_backward(
+    layer: Layer,
+    slope: Union[str, Slope] = Slope.V_SLOPE,
+    mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
+    convex_domain: Optional[Dict[str, Any]] = None,
+    finetune: bool = False,
+    **kwargs: Any,
+) -> BackwardLayer:
+    if convex_domain is None:
+        convex_domain = {}
+    class_name = layer.__class__.__name__
+    if class_name.startswith("Decomon"):
+        class_name = "".join(layer.__class__.__name__.split("Decomon")[1:])
+
+    backward_class_name = f"Backward{class_name}"
+    try:
+        class_ = _mapping_name2class[backward_class_name]
+    except KeyError:
+        raise NotImplementedError(f"The backward version of {class_name} is not yet implemented.")
+    backward_layer_name = f"{layer.name}_backward"
+    return class_(
+        layer,
+        slope=slope,
+        mode=mode,
+        convex_domain=convex_domain,
+        finetune=finetune,
+        dtype=layer.dtype,
+        name=backward_layer_name,
+        **kwargs,
+    )

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -1,15 +1,13 @@
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
-import tensorflow as tf
-import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import get_affine, get_ibp
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import DecomonLayer, to_decomon
-from decomon.utils import Slope
+from decomon.layers.decomon_layers import DecomonLayer
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +44,8 @@ class BackwardGroupSort2(BackwardLayer):
 
         if not isinstance(layer, DecomonLayer):
             self.layer = to_decomon(
-                layer,
-                input_dim,
+                layer=layer,
+                input_dim=input_dim,
                 dc_decomp=False,
                 convex_domain=self.convex_domain,
                 finetune=False,

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -1,0 +1,179 @@
+from typing import Any, Dict, List, Optional, Union
+
+import tensorflow as tf
+from tensorflow.keras.layers import Activation, Input, Layer
+
+import decomon.layers.decomon_layers
+import decomon.layers.decomon_merge_layers
+import decomon.layers.decomon_reshape
+import decomon.layers.deel_lip
+import decomon.layers.maxpooling
+from decomon.layers.core import DEEL_LIP, DecomonLayer, ForwardMode, get_mode
+from decomon.utils import ConvexDomainType, Slope
+
+# mapping between decomon class names and actual classes
+_mapping_name2class = vars(decomon.layers.decomon_layers)
+_mapping_name2class.update(vars(decomon.layers.decomon_merge_layers))
+_mapping_name2class.update(vars(decomon.layers.decomon_reshape))
+_mapping_name2class.update(vars(decomon.layers.deel_lip))
+_mapping_name2class.update(vars(decomon.layers.maxpooling))
+
+
+def to_decomon(
+    layer: Layer,
+    input_dim: int,
+    slope: Union[str, Slope] = Slope.V_SLOPE,
+    dc_decomp: bool = False,
+    convex_domain: Optional[Dict[str, Any]] = None,
+    finetune: bool = False,
+    ibp: bool = True,
+    affine: bool = True,
+    shared: bool = True,
+    fast: bool = True,
+) -> DecomonLayer:
+    """Transform a standard keras layer into a Decomon layer.
+
+    Type of layer is tested to know how to transform it into a DecomonLayer of the good type.
+    If type is not treated yet, raises an TypeError
+
+    Args:
+        layer: a Keras Layer
+        input_dim: an integer that represents the dim
+            of the input convex domain
+        slope:
+        dc_decomp: boolean that indicates whether we return a difference
+            of convex decomposition of our layer
+        convex_domain: the type of convex domain
+        ibp: boolean that indicates whether we propagate constant bounds
+        affine: boolean that indicates whether we propagate affine
+            bounds
+
+    Returns:
+        the associated DecomonLayer
+    """
+
+    # get class name
+    if convex_domain is None:
+        convex_domain = {}
+
+    mode = get_mode(ibp=ibp, affine=affine)
+    original_class_name = layer.__class__.__name__
+    layer_decomon: Optional[DecomonLayer] = None
+    for k in range(2):  # two runs before sending a failure
+        try:
+            layer_decomon = _to_decomon_wo_input_init(
+                layer=layer,
+                namespace=_mapping_name2class,
+                slope=slope,
+                dc_decomp=dc_decomp,
+                convex_domain=convex_domain,
+                finetune=finetune,
+                mode=mode,
+                shared=shared,
+                fast=fast,
+            )
+
+            break
+        except NotImplementedError:
+            if hasattr(layer, "vanilla_export"):
+                shared = False  # checking with Deel-LIP
+                layer_ = layer.vanilla_export()
+                layer_(layer.input)
+                layer = layer_
+
+    if layer_decomon is None:
+        raise NotImplementedError(f"The decomon version of {original_class_name} is not yet implemented.")
+
+    input_tensors = _prepare_input_tensors(
+        layer=layer, input_dim=input_dim, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode
+    )
+
+    layer_decomon(input_tensors)
+    layer_decomon.reset_layer(layer)
+
+    # return layer_decomon
+    return layer_decomon
+
+
+def _to_decomon_wo_input_init(
+    layer: Layer,
+    namespace: Dict[str, Any],
+    slope: Union[str, Slope] = Slope.V_SLOPE,
+    dc_decomp: bool = False,
+    convex_domain: Optional[Dict[str, Any]] = None,
+    finetune: bool = False,
+    mode: ForwardMode = ForwardMode.HYBRID,
+    shared: bool = True,
+    fast: bool = True,
+) -> DecomonLayer:
+    if convex_domain is None:
+        convex_domain = {}
+    class_name = layer.__class__.__name__
+    # remove deel-lip dependency
+    if class_name[: len(DEEL_LIP)] == DEEL_LIP:
+        class_name = class_name[len(DEEL_LIP) :]
+    # check if layer has a built argument that built is set to True
+    if hasattr(layer, "built"):
+        if not layer.built:
+            raise ValueError(f"the layer {layer.name} has not been built yet")
+    decomon_class_name = f"Decomon{class_name}"
+    config_layer = layer.get_config()
+    config_layer["name"] = layer.name + "_decomon"
+    config_layer["dc_decomp"] = dc_decomp
+    config_layer["convex_domain"] = convex_domain
+
+    config_layer["mode"] = mode
+    config_layer["finetune"] = finetune
+    config_layer["slope"] = slope
+    config_layer["shared"] = shared
+    config_layer["fast"] = fast
+    if not isinstance(layer, Activation):
+        config_layer.pop("activation", None)  # Hyp: no non-linear activation in dense or conv2d layers
+
+    try:
+        layer_decomon = namespace[decomon_class_name].from_config(config_layer)
+    except:
+        raise NotImplementedError(f"The decomon version of {class_name} is not yet implemented.")
+
+    layer_decomon.share_weights(layer)
+    return layer_decomon
+
+
+def _prepare_input_tensors(
+    layer: Layer, input_dim: int, dc_decomp: bool, convex_domain: Dict[str, Any], mode: ForwardMode
+) -> List[tf.Tensor]:
+    original_input_shapes = layer.input_shape
+    if not isinstance(original_input_shapes, list):
+        original_input_shapes = [original_input_shapes]
+
+    decomon_input_shapes = [list(input_shape[1:]) for input_shape in original_input_shapes]
+    n_input = len(decomon_input_shapes)
+
+    if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BOX:
+        x_input = Input((2, input_dim), dtype=layer.dtype)
+    else:
+        x_input = Input((input_dim,), dtype=layer.dtype)
+
+    w_input = [Input(tuple([input_dim] + decomon_input_shapes[i])) for i in range(n_input)]
+    y_input = [Input(tuple(decomon_input_shapes[i])) for i in range(n_input)]
+
+    if mode == ForwardMode.HYBRID:
+        nested_input_list = [
+            [x_input, y_input[i], w_input[i], y_input[i], y_input[i], w_input[i], y_input[i]] for i in range(n_input)
+        ]
+    elif mode == ForwardMode.IBP:
+        nested_input_list = [[y_input[i], y_input[i]] for i in range(n_input)]
+    elif mode == ForwardMode.AFFINE:
+        nested_input_list = [[x_input, w_input[i], y_input[i], w_input[i], y_input[i]] for i in range(n_input)]
+    else:
+        raise ValueError(f"Unknown mode {mode}")
+
+    flatten_input_list = [tensor for input_list in nested_input_list for tensor in input_list]
+
+    if dc_decomp:
+        if n_input == 1:
+            flatten_input_list += [y_input[0], y_input[0]]
+        else:
+            raise NotImplementedError()
+
+    return flatten_input_list

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -22,6 +22,17 @@ class ForwardMode(Enum):
 DEEL_LIP = "deel-lip>"
 
 
+def get_mode(ibp: bool = True, affine: bool = True) -> ForwardMode:
+
+    if ibp:
+        if affine:
+            return ForwardMode.HYBRID
+        else:
+            return ForwardMode.IBP
+    else:
+        return ForwardMode.AFFINE
+
+
 class Option(Enum):
     lagrangian = "lagrangian"
     milp = "milp"

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -1608,33 +1608,30 @@ def to_decomon(
     if layer_decomon is None:
         raise NotImplementedError(f"The decomon version of {original_class_name} is not yet implemented.")
 
-    try:
-        input_shape = list(layer.input_shape)[1:]
-        if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BOX:
-            x_shape = Input((2, input_dim), dtype=layer.dtype)
-        else:
-            x_shape = Input((input_dim,), dtype=layer.dtype)
+    input_shape = list(layer.input_shape)[1:]
+    if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BOX:
+        x_shape = Input((2, input_dim), dtype=layer.dtype)
+    else:
+        x_shape = Input((input_dim,), dtype=layer.dtype)
 
-        if mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
-            w_shape = Input(tuple([input_dim] + input_shape))
-        y_shape = Input(tuple(input_shape), dtype=layer.dtype)
+    if mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
+        w_shape = Input(tuple([input_dim] + input_shape))
+    y_shape = Input(tuple(input_shape), dtype=layer.dtype)
 
-        if mode == ForwardMode.HYBRID:
-            input_ = [x_shape, y_shape, w_shape, y_shape, y_shape, w_shape, y_shape]
-        elif mode == ForwardMode.IBP:
-            input_ = [y_shape, y_shape]
-        elif mode == ForwardMode.AFFINE:
-            input_ = [x_shape, w_shape, y_shape, w_shape, y_shape]
-        else:
-            raise ValueError(f"Unknown mode {mode}")
+    if mode == ForwardMode.HYBRID:
+        input_ = [x_shape, y_shape, w_shape, y_shape, y_shape, w_shape, y_shape]
+    elif mode == ForwardMode.IBP:
+        input_ = [y_shape, y_shape]
+    elif mode == ForwardMode.AFFINE:
+        input_ = [x_shape, w_shape, y_shape, w_shape, y_shape]
+    else:
+        raise ValueError(f"Unknown mode {mode}")
 
-        if dc_decomp:
-            input_ += [y_shape, y_shape]
+    if dc_decomp:
+        input_ += [y_shape, y_shape]
 
-        layer_decomon(input_)
-        layer_decomon.reset_layer(layer)
-    except:
-        pass
+    layer_decomon(input_)
+    layer_decomon.reset_layer(layer)
 
     # return layer_decomon
     return layer_decomon

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -23,17 +23,7 @@ from tensorflow.python.keras.utils.generic_utils import to_list
 
 from decomon.layers import activations
 from decomon.layers.core import DEEL_LIP, DecomonLayer, ForwardMode
-from decomon.layers.decomon_merge_layers import (  # add some layers to module namespace `globals()`
-    DecomonAdd,
-    DecomonAverage,
-    DecomonConcatenate,
-    DecomonDot,
-    DecomonMaximum,
-    DecomonMinimum,
-    DecomonMultiply,
-    DecomonSubtract,
-    to_decomon_merge,
-)
+from decomon.layers.decomon_merge_layers import to_decomon_merge
 from decomon.layers.decomon_reshape import (  # add some layers to module namespace `globals()`
     DecomonPermute,
     DecomonReshape,
@@ -45,13 +35,9 @@ from decomon.layers.utils import (
     ClipAlphaAndSumtoOne,
     NonPos,
     Project_initializer_pos,
+    is_a_merge_layer,
 )
 from decomon.utils import ConvexDomainType, Slope, get_lower, get_upper
-
-try:
-    from keras.layers.merge import _Merge as Merge
-except ModuleNotFoundError:
-    from tensorflow.python.keras.layers.merge import _Merge as Merge
 
 try:
     # add deel-lip layers to global namespace, if available
@@ -1578,7 +1564,7 @@ def to_decomon(
         if not layer.built:
             raise ValueError(f"the layer {layer.name} has not been built yet")
 
-    if isinstance(layer, Merge):
+    if is_a_merge_layer(layer):
         return to_decomon_merge(layer, input_dim, dc_decomp, convex_domain, finetune, ibp, affine)
 
     # do case by case for optimizing

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -6,6 +6,7 @@ import tensorflow.keras as keras
 from tensorflow.keras import backend as K
 from tensorflow.keras.constraints import Constraint
 from tensorflow.keras.initializers import Initializer
+from tensorflow.keras.layers import Layer
 
 from decomon.layers.core import ForwardMode, StaticVariables
 from decomon.utils import (
@@ -20,6 +21,10 @@ from decomon.utils import (
     minus,
     relu_,
 )
+
+
+def is_a_merge_layer(layer: Layer) -> bool:
+    return hasattr(layer, "_merge_function")
 
 
 #####

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -6,9 +6,8 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Lambda
 
 from decomon.layers.activations import softmax as softmax_
-from decomon.layers.core import DecomonLayer, ForwardMode
+from decomon.layers.core import DecomonLayer, ForwardMode, get_mode
 from decomon.models.models import DecomonModel
-from decomon.models.utils import get_mode
 from decomon.utils import ConvexDomainType, get_lower, get_upper, set_mode
 
 

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -1,13 +1,10 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K
 from keras.engine.node import Node
-from tensorflow.keras.layers import Add, Average, Concatenate
-from tensorflow.keras.layers import Conv2D as Conv
-from tensorflow.keras.layers import Dense, Dropout, Lambda, Layer, Permute, Reshape
+from tensorflow.keras.layers import Average, Concatenate, Lambda, Layer
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.utils.generic_utils import has_arg, to_list
 
@@ -20,11 +17,10 @@ from decomon.backward_layers.crown import (
     Fuse,
     MergeWithPrevious,
 )
-from decomon.backward_layers.utils import merge_with_previous
-from decomon.layers.core import ForwardMode
+from decomon.layers.core import ForwardMode, get_mode
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.forward_cloning import OutputMapDict
-from decomon.models.utils import get_depth_dict, get_mode
+from decomon.models.utils import get_depth_dict
 from decomon.utils import Slope, get_lower, get_upper
 
 

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -8,8 +8,8 @@ from tensorflow.keras.layers import Average, Concatenate, Lambda, Layer
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.utils.generic_utils import has_arg, to_list
 
-from decomon.backward_layers.backward_layers import to_backward
 from decomon.backward_layers.backward_merge import BackwardMerge
+from decomon.backward_layers.convert import to_backward
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.crown import (
     Convert2BackwardMode,

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -9,8 +9,8 @@ from tensorflow.keras.models import Model
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.crown import Convert2Mode
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import get_mode
-from decomon.layers.decomon_layers import to_decomon
 from decomon.models.backward_cloning import convert_backward
 from decomon.models.forward_cloning import (
     LayerMapDict,
@@ -19,12 +19,7 @@ from decomon.models.forward_cloning import (
     convert_forward_functional_model,
 )
 from decomon.models.models import DecomonModel
-from decomon.models.utils import (
-    ConvertMethod,
-    get_input_tensors,
-    get_input_tensors_keras_only,
-    split_activation,
-)
+from decomon.models.utils import ConvertMethod, get_input_tensors, split_activation
 from decomon.utils import ConvexDomainType, Slope, get_lower, get_upper
 
 

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -9,6 +9,7 @@ from tensorflow.keras.models import Model
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.crown import Convert2Mode
+from decomon.layers.core import get_mode
 from decomon.layers.decomon_layers import to_decomon
 from decomon.models.backward_cloning import convert_backward
 from decomon.models.forward_cloning import (
@@ -22,7 +23,6 @@ from decomon.models.utils import (
     ConvertMethod,
     get_input_tensors,
     get_input_tensors_keras_only,
-    get_mode,
     split_activation,
 )
 from decomon.utils import ConvexDomainType, Slope, get_lower, get_upper

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -144,6 +144,8 @@ def convert_forward_functional_model(
     softmax_to_linear: bool = True,
     count: int = 0,
     joint: bool = True,
+    output_map: Optional[OutputMapDict] = None,
+    layer_map: Optional[LayerMapDict] = None,
 ) -> Tuple[List[tf.Tensor], List[tf.Tensor], LayerMapDict, OutputMapDict]:
 
     if softmax_to_linear:
@@ -156,8 +158,10 @@ def convert_forward_functional_model(
     keys = [e for e in dico_nodes.keys()]
     keys.sort(reverse=True)
 
-    output_map: OutputMapDict = {}
-    layer_map: LayerMapDict = {}
+    if output_map is None:
+        output_map = {}
+    if layer_map is None:
+        layer_map = {}
     output: List[tf.Tensor] = input_tensors
     for depth in keys:
         nodes = dico_nodes[depth]

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -7,14 +7,13 @@ import inspect
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import numpy as np
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.utils.generic_utils import to_list
 
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer
-from decomon.layers.decomon_layers import to_decomon
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.utils import (
     get_depth_dict,

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -18,6 +18,7 @@ from tensorflow.keras.layers import (
 from tensorflow.keras.models import Model
 
 from decomon.layers.core import ForwardMode
+from decomon.layers.utils import is_a_merge_layer
 from decomon.utils import (
     ConvexDomainType,
     get_lower,
@@ -35,6 +36,10 @@ class ConvertMethod(Enum):
     FORWARD_IBP = "forward-ibp"
     FORWARD_AFFINE = "forward-affine"
     FORWARD_HYBRID = "forward-hybrid"
+
+
+def has_merge_layers(model: Model) -> bool:
+    return any(is_a_merge_layer(layer) for layer in model.layers)
 
 
 def get_input_tensors(

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -148,11 +148,11 @@ def get_input_tensors_keras_only(
     return input_tensors
 
 
-def get_input_dim(model: Model) -> int:
-    if isinstance(model.input_shape, list):
-        return np.prod(model.input_shape[0][1:])
+def get_input_dim(layer: Layer) -> int:
+    if isinstance(layer.input_shape, list):
+        return np.prod(layer.input_shape[0][1:])
     else:
-        return np.prod(model.input_shape[1:])
+        return np.prod(layer.input_shape[1:])
 
 
 def prepare_inputs_for_layer(

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -144,7 +144,7 @@ def get_input_tensors_keras_only(
 ) -> List[tf.Tensor]:
     input_tensors = []
     for i in range(len(model._input_layers)):
-        input_tensors.append(Input(input_shape, dtype=model.layers[0].dtype))
+        input_tensors.append(Input(input_shape[1:], dtype=model.layers[0].dtype))
     return input_tensors
 
 
@@ -194,7 +194,7 @@ def split_activation(layer: Layer) -> List[Layer]:
         # build the layer
         if not hasattr(layer, "input_shape"):
             raise RuntimeError("The layer should properly initialized so that layer.input_shape is defined.")
-        inputs = Input(layer.input_shape, dtype=layer.dtype)
+        inputs = Input(type_spec=layer.input.type_spec)
         outputs = layer_wo_activation(inputs)
         # use same weights
         layer_wo_activation.set_weights(layer.get_weights())

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -7,7 +7,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Input
 from tensorflow.python.keras.backend import _get_available_gpus
 
-from decomon.backward_layers.backward_layers import to_backward
+from decomon.backward_layers.convert import to_backward
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -8,9 +8,8 @@ from tensorflow.keras.layers import Dense, Input
 from tensorflow.keras.models import Model
 
 from decomon.backward_layers.backward_layers import to_backward
-from decomon.layers.activations import relu
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import DecomonDense, to_decomon
+from decomon.layers.decomon_layers import DecomonDense
 from decomon.utils import Slope
 
 

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -7,7 +7,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Dense, Input
 from tensorflow.keras.models import Model
 
-from decomon.backward_layers.backward_layers import to_backward
+from decomon.backward_layers.convert import to_backward
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonDense
 from decomon.utils import Slope

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -8,7 +8,7 @@ from tensorflow.keras.layers import Input, Layer, Reshape
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.backend import _get_available_gpus
 
-from decomon.backward_layers.backward_layers import to_backward
+from decomon.backward_layers.convert import to_backward
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
 from decomon.layers.decomon_reshape import DecomonReshape

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -8,7 +8,7 @@ from tensorflow.keras.layers import Activation, Flatten, Input, Reshape
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.backend import _get_available_gpus
 
-from decomon.backward_layers.backward_layers import to_backward
+from decomon.backward_layers.convert import to_backward
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
 from decomon.layers.decomon_reshape import DecomonReshape

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -7,8 +7,9 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Conv2D
 from tensorflow.python.keras.backend import _get_available_gpus
 
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import DecomonConv2D, to_decomon
+from decomon.layers.decomon_layers import DecomonConv2D
 
 
 def test_Decomon_conv_box(data_format, mode, floatx, helpers):

--- a/tests/test_decomon_activation_layer.py
+++ b/tests/test_decomon_activation_layer.py
@@ -1,13 +1,7 @@
-import numpy as np
-import pytest
 import tensorflow.python.keras.backend as K
-from tensorflow.keras.layers import Input
-from tensorflow.keras.models import Model
 
-from decomon.backward_layers.backward_layers import to_backward
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
-from decomon.layers.decomon_reshape import DecomonReshape
+from decomon.layers.decomon_layers import DecomonActivation
 from decomon.utils import Slope
 
 

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -7,8 +7,9 @@ import tensorflow.keras.backend as K
 from numpy.testing import assert_almost_equal
 from tensorflow.keras.layers import Dense
 
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import DecomonDense, to_decomon
+from decomon.layers.decomon_layers import DecomonDense
 from decomon.models.utils import split_activation
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -15,8 +15,8 @@ from tensorflow.keras.layers import (
 )
 from tensorflow.keras.models import Model
 
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import to_decomon
 from decomon.layers.decomon_merge_layers import (
     DecomonAdd,
     DecomonAverage,

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -3,8 +3,8 @@ import pytest
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Permute, Reshape
 
+from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
-from decomon.layers.decomon_layers import to_decomon
 from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
 
 

--- a/tests/test_to_decomon.py
+++ b/tests/test_to_decomon.py
@@ -1,7 +1,7 @@
 import pytest
 from tensorflow.keras.layers import Add, Conv2D, Dense, Input, Layer, Reshape
 
-from decomon.layers.decomon_layers import to_decomon
+from decomon.layers.convert import to_decomon
 from decomon.layers.utils import is_a_merge_layer
 
 


### PR DESCRIPTION
- put them in dedicated modules decomon.layers.convert and decomon.backward_layers.convert
- share common code between to_decomon() and to_decomon_merge() => single public function to_decomon()
- Instead of globals() use a mapping constructed from vars() applied to relevant module. It avoids explicitely import each Decomon-/Backward-Layer and make the module imports be used so that it is obvious even for IDE that such imports are not to be removed.
- Remove try...except: pass (relic of a past debugging)
- Add a utility functions to check wether a layer is a merge layer and wether a model contains a merge layer