### PR TITLE
Use `pytest.skip` when skipping a test because some condition is not met

### DIFF
--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -25,7 +25,7 @@ def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_fun
     # softmax: test only n=0,3
     if funcname == "softmax":
         if n not in {0, 3}:
-            return
+            pytest.skip("softmax activation only possible for n=0 or 3")
 
     mode = ForwardMode(mode)
     K.set_floatx("float{}".format(floatx))

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -15,7 +15,7 @@ from decomon.layers.decomon_layers import DecomonConv2D
 def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
 

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -188,7 +188,7 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, mode, helpers):
 def test_Backward_Flatten_multiD_box(odd, floatx, mode, data_format, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
@@ -252,7 +252,7 @@ def test_Backward_Flatten_multiD_box(odd, floatx, mode, data_format, helpers):
 
 def test_Backward_Reshape_multiD_box(odd, floatx, mode, data_format, helpers):
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -134,7 +134,7 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, hel
 
 def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, data_format, helpers):
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
@@ -198,7 +198,7 @@ def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, data_format, helpe
 
 def test_Backward_NativeReshape_multiD_box(odd, floatx, mode, data_format, helpers):
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -15,7 +15,7 @@ from decomon.utils import Slope
 def test_convert_1D(n, method, mode, floatx, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -15,7 +15,7 @@ from decomon.layers.decomon_layers import DecomonConv2D
 def test_Decomon_conv_box(data_format, mode, floatx, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
 
@@ -115,7 +115,7 @@ def test_Decomon_conv_box(data_format, mode, floatx, helpers):
 def test_Decomon_conv_box_nodc(data_format, floatx, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
-        return
+        pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
 

--- a/tests/test_utils_pooling.py
+++ b/tests/test_utils_pooling.py
@@ -24,7 +24,7 @@ def test_get_lower_upper_linear_hull_max(
 
     if finetune_odd is not None and name == "upper":
         # skip test with finetune if not get_lower
-        return
+        pytest.skip("finetune_odd is only intended for get_lower_linear_hull_max()")
 
     odd, m_0, m_1 = 0, 0, 1
     data_format = "channels_last"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -12,7 +12,7 @@ from decomon.models import clone
 def test_get_upper_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
@@ -39,7 +39,7 @@ def test_get_upper_1d_box(n, method, mode, helpers):
 def test_get_lower_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
@@ -66,7 +66,7 @@ def test_get_lower_1d_box(n, method, mode, helpers):
 def test_get_range_1d_box(n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
@@ -94,7 +94,7 @@ def test_get_range_1d_box(n, method, mode, helpers):
 def test_get_upper_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
@@ -116,7 +116,7 @@ def test_get_upper_multid_box(odd, method, mode, helpers):
 def test_get_lower_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
@@ -138,7 +138,7 @@ def test_get_lower_multid_box(odd, method, mode, helpers):
 def test_get_range_multid_box(odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
-        return
+        pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_


### PR DESCRIPTION
We were using `return` statement but this is cleaner and clearer as it allows to state the reason and it appears as skipped in pytest report.