### PR TITLE
Fix convex_domain use by converting fields to proper enumeration type

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -11,11 +11,11 @@ from decomon.backward_layers.activations import get
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import get_affine, get_ibp, get_identity_lirpa
 from decomon.layers.convert import to_decomon
-from decomon.layers.core import DecomonLayer, ForwardMode, Option
+from decomon.layers.core import DecomonLayer, ForwardMode
 from decomon.layers.decomon_layers import DecomonBatchNormalization
 from decomon.layers.utils import ClipAlpha, NonNeg, NonPos
 from decomon.models.utils import get_input_dim
-from decomon.utils import ConvexDomainType, Slope
+from decomon.utils import ConvexDomainType, Option, Slope
 
 
 class BackwardDense(BackwardLayer):
@@ -301,7 +301,7 @@ class BackwardActivation(BackwardLayer):
 
         if self.finetune and self.activation_name != "linear":
 
-            if len(self.convex_domain) and self.convex_domain["name"] == ConvexDomainType.GRID:
+            if len(self.convex_domain) and ConvexDomainType(self.convex_domain["name"]) == ConvexDomainType.GRID:
                 if self.activation_name[:4] == "relu":
                     self.alpha_b_l = self.add_weight(
                         shape=(
@@ -348,8 +348,8 @@ class BackwardActivation(BackwardLayer):
         if self.activation_name[:4] == "relu":
             if (
                 len(self.convex_domain)
-                and self.convex_domain["name"] == ConvexDomainType.GRID
-                and self.convex_domain["option"] == Option.lagrangian
+                and ConvexDomainType(self.convex_domain["name"]) == ConvexDomainType.GRID
+                and Option(self.convex_domain["option"]) == Option.lagrangian
                 and self.mode != ForwardMode.IBP
             ):
 
@@ -373,8 +373,8 @@ class BackwardActivation(BackwardLayer):
 
         if (
             len(self.convex_domain)
-            and self.convex_domain["name"] == ConvexDomainType.GRID
-            and self.convex_domain["option"] == Option.milp
+            and ConvexDomainType(self.convex_domain["name"]) == ConvexDomainType.GRID
+            and Option(self.convex_domain["option"]) == Option.milp
             and self.mode != ForwardMode.IBP
         ):
 

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -189,7 +189,11 @@ def backward_relu_(
     else:
         raise ValueError(f"Unknown mode {mode}")
 
-    if len(convex_domain) and convex_domain["name"] == ConvexDomainType.GRID and mode != ForwardMode.IBP:
+    if (
+        len(convex_domain)
+        and ConvexDomainType(convex_domain["name"] == ConvexDomainType.GRID)
+        and mode != ForwardMode.IBP
+    ):
 
         raise NotImplementedError()
 

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -149,7 +149,7 @@ def _prepare_input_tensors(
     decomon_input_shapes = [list(input_shape[1:]) for input_shape in original_input_shapes]
     n_input = len(decomon_input_shapes)
 
-    if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BOX:
+    if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) == ConvexDomainType.BOX:
         x_input = Input((2, input_dim), dtype=layer.dtype)
     else:
         x_input = Input((input_dim,), dtype=layer.dtype)

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -33,11 +33,6 @@ def get_mode(ibp: bool = True, affine: bool = True) -> ForwardMode:
         return ForwardMode.AFFINE
 
 
-class Option(Enum):
-    lagrangian = "lagrangian"
-    milp = "milp"
-
-
 class StaticVariables:
     """Storing static values on the number of input tensors for our layers"""
 

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -807,7 +807,7 @@ class DecomonDense(Dense, DecomonLayer):
             else:
 
                 # check convex_domain
-                if len(self.convex_domain) and self.convex_domain["name"] == ConvexDomainType.BALL:
+                if len(self.convex_domain) and ConvexDomainType(self.convex_domain["name"]) == ConvexDomainType.BALL:
 
                     if self.mode == ForwardMode.IBP:
                         x_0 = (u_c + l_c) / 2.0

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -83,14 +83,16 @@ def compute_R(z: tf.Tensor, convex_domain: Dict[str, Any]) -> tf.Tensor:
     if len(convex_domain) == 0:
         # compute the L2 distance z[:, 0], z[:, 1]
         dist_ = K.sqrt(K.sum(K.pow((z[:, 1] - z[:, 0]) / 2.0, 2), -1))
-    elif convex_domain["name"] == ConvexDomainType.BOX:
-        dist_ = K.sqrt(K.sum(K.pow((z[:, 1] - z[:, 0]) / 2.0, 2), -1))
-    elif convex_domain["name"] == ConvexDomainType.BALL and convex_domain["p"] == np.inf:
-        dist_ = K.sqrt(K.sum(K.pow(z - z + convex_domain["eps"], 2), -1))
-    elif convex_domain["name"] == ConvexDomainType.BALL and convex_domain["p"] == 2:
-        dist_ = convex_domain["eps"] * (0 * z + 1.0)
     else:
-        raise NotImplementedError()
+        convex_domain_type = ConvexDomainType(convex_domain["name"])
+        if convex_domain_type == ConvexDomainType.BOX:
+            dist_ = K.sqrt(K.sum(K.pow((z[:, 1] - z[:, 0]) / 2.0, 2), -1))
+        elif convex_domain_type == ConvexDomainType.BALL and convex_domain["p"] == np.inf:
+            dist_ = K.sqrt(K.sum(K.pow(z - z + convex_domain["eps"], 2), -1))
+        elif convex_domain_type == ConvexDomainType.BALL and convex_domain["p"] == 2:
+            dist_ = convex_domain["eps"] * (0 * z + 1.0)
+        else:
+            raise NotImplementedError()
 
     return dist_
 
@@ -109,14 +111,16 @@ def get_start_point(z: tf.Tensor, convex_domain: Dict[str, Any]) -> tf.Tensor:
 
     if len(convex_domain) == 0:
         return z[:, 0]
-    elif convex_domain["name"] == ConvexDomainType.BOX:
-        return (z[:, 0] + z[:, 1]) / 2.0
-    elif convex_domain["name"] == ConvexDomainType.BALL and convex_domain["p"] == np.inf:
-        return z
-    elif convex_domain["name"] == ConvexDomainType.BALL and convex_domain["p"] == 2:
-        return z
     else:
-        raise NotImplementedError()
+        convex_domain_type = ConvexDomainType(convex_domain["name"])
+        if convex_domain_type == ConvexDomainType.BOX:
+            return (z[:, 0] + z[:, 1]) / 2.0
+        elif convex_domain_type and convex_domain["p"] == np.inf:
+            return z
+        elif convex_domain_type and convex_domain["p"] == 2:
+            return z
+        else:
+            raise NotImplementedError()
 
 
 def get_coeff_grad(R: tf.Tensor, k: int, g: tf.Tensor) -> tf.Tensor:

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -96,7 +96,7 @@ def get_upper_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
     convex_domain = model.convex_domain
 
     if affine:
-        if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BALL:
+        if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) == ConvexDomainType.BALL:
             n_comp = 2
         else:
             n_comp = 1
@@ -167,7 +167,7 @@ def get_lower_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
     convex_domain = model.convex_domain
 
     if affine:
-        if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BALL:
+        if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) == ConvexDomainType.BALL:
             n_comp = 2
         else:
             n_comp = 1
@@ -240,7 +240,7 @@ def get_adv_loss(
     convex_domain = model.convex_domain
 
     if affine:
-        if len(convex_domain) == 0 or convex_domain["name"] == ConvexDomainType.BALL:
+        if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) == ConvexDomainType.BALL:
             n_comp = 2
         else:
             n_comp = 1

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -6,7 +6,7 @@ from keras.engine.functional import get_network_config
 
 from decomon.layers.core import StaticVariables
 from decomon.models.utils import ConvertMethod
-from decomon.utils import ConvexDomainType
+from decomon.utils import ConvexDomainType, Option
 
 
 class DecomonModel(tf.keras.Model):
@@ -82,12 +82,12 @@ def _check_domain(convex_domain_prev: Dict[str, Any], convex_domain: Dict[str, A
     if convex_domain == {}:
         convex_domain = {"name": ConvexDomainType.BOX}
 
-    if len(convex_domain_prev) == 0 or convex_domain_prev["name"] == ConvexDomainType.BOX:
+    if len(convex_domain_prev) == 0 or ConvexDomainType(convex_domain_prev["name"]) == ConvexDomainType.BOX:
         # Box
-        if convex_domain["name"] != ConvexDomainType.BOX:
+        if ConvexDomainType(convex_domain["name"]) != ConvexDomainType.BOX:
             raise NotImplementedError(msg)
 
-    if convex_domain_prev["name"] != convex_domain["name"]:
+    if ConvexDomainType(convex_domain_prev["name"]) != ConvexDomainType(convex_domain["name"]):
         raise NotImplementedError(msg)
 
     return convex_domain_
@@ -97,7 +97,9 @@ def get_AB(model_: DecomonModel) -> Dict[str, List[tf.Variable]]:
     dico_AB: Dict[str, List[tf.Variable]] = {}
     convex_domain = model_.convex_domain
     if not (
-        len(convex_domain) and convex_domain["name"] == ConvexDomainType.GRID and convex_domain["option"] == "milp"
+        len(convex_domain)
+        and ConvexDomainType(convex_domain["name"]) == ConvexDomainType.GRID
+        and Option(convex_domain["option"]) == Option.milp
     ):
         return dico_AB
 
@@ -115,7 +117,9 @@ def get_AB_finetune(model_: DecomonModel) -> Dict[str, tf.Variable]:
     dico_AB: Dict[str, tf.Variable] = {}
     convex_domain = model_.convex_domain
     if not (
-        len(convex_domain) and convex_domain["name"] == ConvexDomainType.GRID and convex_domain["option"] == "milp"
+        len(convex_domain)
+        and ConvexDomainType(convex_domain["name"]) == ConvexDomainType.GRID
+        and Option(convex_domain["option"]) == Option.milp
     ):
         return dico_AB
 

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -67,14 +67,14 @@ def get_input_tensors(
                 raise ValueError("Expected that every input layers use the same input_tensor")
 
     input_shape_x: Tuple[int, ...]
-    if len(convex_domain) == 0 or convex_domain["name"] != ConvexDomainType.BALL:
+    if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) != ConvexDomainType.BALL:
         input_shape_x = (2, input_dim)
     else:
         input_shape_x = (input_dim,)
 
     z_tensor = Input(shape=input_shape_x, dtype=model.layers[0].dtype)
 
-    if len(convex_domain) == 0 or convex_domain["name"] != ConvexDomainType.BALL:
+    if len(convex_domain) == 0 or ConvexDomainType(convex_domain["name"]) != ConvexDomainType.BALL:
 
         if ibp:
             u_c_tensor = Lambda(lambda z: z[:, 1], dtype=z_tensor.dtype)(z_tensor)
@@ -221,7 +221,7 @@ def get_input_tensor_x(
     if len(convex_domain) == 0 and not isinstance(input_dim, tuple):
         input_dim_ = (2, input_dim)
         z_tensor = Input(input_dim_, dtype=model.layers[0].dtype)
-    elif convex_domain["name"] == ConvexDomainType.BOX and not isinstance(input_dim, tuple):
+    elif ConvexDomainType(convex_domain["name"]) == ConvexDomainType.BOX and not isinstance(input_dim, tuple):
         input_dim_ = (2, input_dim)
         z_tensor = Input(input_dim_, dtype=model.layers[0].dtype)
     else:

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -19,6 +19,11 @@ class ConvexDomainType(Enum):
     # (no verification is proceeded to assess that the set is convex)
 
 
+class Option(Enum):
+    lagrangian = "lagrangian"
+    milp = "milp"
+
+
 class Slope(Enum):
     V_SLOPE = "volume-slope"
     A_SLOPE = "adaptative-slope"
@@ -376,22 +381,25 @@ def get_upper(
         x_max = x[:, 1]
         return get_upper_box(x_min, x_max, w, b, **kwargs)
 
-    elif convex_domain["name"] in {ConvexDomainType.BOX, ConvexDomainType.GRID}:
-        x_min = x[:, 0]
-        x_max = x[:, 1]
-        return get_upper_box(x_min, x_max, w, b, **kwargs)
-
-    elif convex_domain["name"] == ConvexDomainType.BALL:
-
-        eps = convex_domain["eps"]
-        p = convex_domain["p"]
-        return get_upper_ball(x, eps, p, w, b, **kwargs)
-
-    elif convex_domain["name"] == ConvexDomainType.VERTEX:
-        raise NotImplementedError()
-
     else:
-        raise NotImplementedError()
+
+        convex_domain_type = ConvexDomainType(convex_domain["name"])
+        if convex_domain_type in {ConvexDomainType.BOX, ConvexDomainType.GRID}:
+            x_min = x[:, 0]
+            x_max = x[:, 1]
+            return get_upper_box(x_min, x_max, w, b, **kwargs)
+
+        elif convex_domain_type == ConvexDomainType.BALL:
+
+            eps = convex_domain["eps"]
+            p = convex_domain["p"]
+            return get_upper_ball(x, eps, p, w, b, **kwargs)
+
+        elif convex_domain_type == ConvexDomainType.VERTEX:
+            raise NotImplementedError()
+
+        else:
+            raise NotImplementedError()
 
 
 def get_lower(
@@ -411,21 +419,23 @@ def get_lower(
         x_max = x[:, 1]
         return get_lower_box(x_min, x_max, w, b, **kwargs)
 
-    elif convex_domain["name"] in {ConvexDomainType.BOX, ConvexDomainType.GRID}:
-        x_min = x[:, 0]
-        x_max = x[:, 1]
-        return get_lower_box(x_min, x_max, w, b, **kwargs)
-
-    elif convex_domain["name"] == ConvexDomainType.BALL:
-        eps = convex_domain["eps"]
-        p = convex_domain["p"]
-        return get_lower_ball(x, eps, p, w, b, **kwargs)
-
-    elif convex_domain["name"] == ConvexDomainType.VERTEX:
-        raise NotImplementedError()
-
     else:
-        raise NotImplementedError()
+        convex_domain_type = ConvexDomainType(convex_domain["name"])
+        if convex_domain_type in {ConvexDomainType.BOX, ConvexDomainType.GRID}:
+            x_min = x[:, 0]
+            x_max = x[:, 1]
+            return get_lower_box(x_min, x_max, w, b, **kwargs)
+
+        elif convex_domain_type == ConvexDomainType.BALL:
+            eps = convex_domain["eps"]
+            p = convex_domain["p"]
+            return get_lower_ball(x, eps, p, w, b, **kwargs)
+
+        elif convex_domain_type == ConvexDomainType.VERTEX:
+            raise NotImplementedError()
+
+        else:
+            raise NotImplementedError()
 
 
 def get_lower_layer(convex_domain: Optional[Dict[str, Any]] = None) -> Layer:
@@ -875,7 +885,7 @@ def relu_(
 
     if mode in [ForwardMode.AFFINE, ForwardMode.HYBRID]:
 
-        if len(convex_domain) and convex_domain["name"] == ConvexDomainType.GRID:
+        if len(convex_domain) and ConvexDomainType(convex_domain["name"]) == ConvexDomainType.GRID:
             upper_g, lower_g = get_bound_grid(x_0, w_u, b_u, w_l, b_l, 1)
             kwargs.update({"upper_grid": upper_g, "lower_grid": lower_g})
 

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -72,7 +72,7 @@ def get_adv_box(
     if not isinstance(model, DecomonModel):
         model_ = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
+        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
             ConvexDomainType.BOX,
             ConvexDomainType.GRID,
         ]
@@ -287,7 +287,7 @@ def check_adv_box(
     if not isinstance(model, DecomonModel):
         model_ = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
+        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
             ConvexDomainType.BOX,
             ConvexDomainType.GRID,
         ]
@@ -483,7 +483,7 @@ def get_range_box(
     if not (isinstance(model, DecomonModel)):
         model_ = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
+        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
             ConvexDomainType.BOX,
             ConvexDomainType.GRID,
         ]
@@ -819,7 +819,7 @@ def refine_box(
     if not isinstance(model, DecomonModel):
         model_ = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or model.convex_domain["name"] in [
+        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
             ConvexDomainType.BOX,
             ConvexDomainType.GRID,
         ]


### PR DESCRIPTION
- put Option enumeration besides ConvexDomainType enumeration
- when testing convex_domain["name"], first convert it to ConvexDomainType
- when testing convex_domain["option"], first convert it to Option

This PR fix issues in some notebooks which were defining convex domain type by a string. This will be now ok as we convert on-the-fly when checking this convex domain type.