### PR TITLE
Remove references to self.linear_layer and self.init_layer

### DIFF
--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -99,8 +99,6 @@ class DecomonLayer(ABC, Layer):
         self.frozen_alpha = False
         self.shared = shared
         self.fast = fast
-        self.init_layer = False
-        self.linear_layer = False
         self.has_backward_bounds = False  # optimizing Forward LiRPA for adversarial perturbation
 
     def get_config(self) -> Dict[str, Any]:

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -796,34 +796,12 @@ class DecomonDense(Dense, DecomonLayer):
             raise ValueError(f"Unknown mode {self.mode}")
 
         if self.mode in [ForwardMode.HYBRID, ForwardMode.IBP]:
-            if not self.linear_layer:
-                if not self.has_backward_bounds:
-                    u_c_ = self.op_dot(u_c, kernel_pos) + self.op_dot(l_c, kernel_neg)
-                    l_c_ = self.op_dot(l_c, kernel_pos) + self.op_dot(u_c, kernel_neg)
-                else:
-                    u_c_ = self.op_dot(u_c, kernel_pos_back) + self.op_dot(l_c, kernel_neg_back)
-                    l_c_ = self.op_dot(l_c, kernel_pos_back) + self.op_dot(u_c, kernel_neg_back)
-
+            if not self.has_backward_bounds:
+                u_c_ = self.op_dot(u_c, kernel_pos) + self.op_dot(l_c, kernel_neg)
+                l_c_ = self.op_dot(l_c, kernel_pos) + self.op_dot(u_c, kernel_neg)
             else:
-
-                # check convex_domain
-                if len(self.convex_domain) and ConvexDomainType(self.convex_domain["name"]) == ConvexDomainType.BALL:
-
-                    if self.mode == ForwardMode.IBP:
-                        x_0 = (u_c + l_c) / 2.0
-                    b_ = (0 * self.kernel[0])[None]
-                    if self.has_backward_bounds:
-                        raise NotImplementedError()
-                    u_c_ = get_upper(x_0, self.kernel[None], b_, convex_domain=self.convex_domain)
-                    l_c_ = get_lower(x_0, self.kernel[None], b_, convex_domain=self.convex_domain)
-
-                else:
-                    if not self.has_backward_bounds:
-                        u_c_ = self.op_dot(u_c, kernel_pos) + self.op_dot(l_c, kernel_neg)
-                        l_c_ = self.op_dot(l_c, kernel_pos) + self.op_dot(u_c, kernel_neg)
-                    else:
-                        u_c_ = self.op_dot(u_c, kernel_pos_back) + self.op_dot(l_c, kernel_neg_back)
-                        l_c_ = self.op_dot(l_c, kernel_pos_back) + self.op_dot(u_c, kernel_neg_back)
+                u_c_ = self.op_dot(u_c, kernel_pos_back) + self.op_dot(l_c, kernel_neg_back)
+                l_c_ = self.op_dot(l_c, kernel_pos_back) + self.op_dot(u_c, kernel_neg_back)
 
         if self.mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
 
@@ -1492,6 +1470,3 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
 
     def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
         return input_shape
-
-    def get_linear(self) -> bool:
-        return self.linear_layer


### PR DESCRIPTION
- self.init_layer is never used
- now that activation in decomon dense or conv2d is assumed to be linear, we never change self.linear_layer which is set to False by default in DecomonLayer. So we skip the part corresponding to if self.linear_layer in DecomonDense.call()