### PR TITLE
Fix issues in decomon layers build()

### DIFF
--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -31,11 +31,13 @@ from decomon.layers.utils import (
 from decomon.utils import ConvexDomainType, Slope, get_lower, get_upper
 
 
-class DecomonConv2D(Conv2D, DecomonLayer):
+class DecomonConv2D(DecomonLayer, Conv2D):
     """Forward LiRPA implementation of Conv2d layers.
     See Keras official documentation for further details on the Conv2d operator
 
     """
+
+    original_keras_layer_class = Conv2D
 
     def __init__(
         self,
@@ -589,10 +591,12 @@ class DecomonConv2D(Conv2D, DecomonLayer):
             K.set_value(self.gamma_out, np.ones_like(self.gamma_pos_out.value()))
 
 
-class DecomonDense(Dense, DecomonLayer):
+class DecomonDense(DecomonLayer, Dense):
     """Forward LiRPA implementation of Dense layers.
     See Keras official documentation for further details on the Dense operator
     """
+
+    original_keras_layer_class = Dense
 
     def __init__(
         self,
@@ -998,10 +1002,12 @@ class DecomonDense(Dense, DecomonLayer):
             K.set_value(self.gamma_, np.ones_like(self.gamma_.value()))
 
 
-class DecomonActivation(Activation, DecomonLayer):
+class DecomonActivation(DecomonLayer, Activation):
     """Forward LiRPA implementation of Activation layers.
     See Keras official documentation for further details on the Activation operator
     """
+
+    original_keras_layer_class = Activation
 
     def __init__(
         self,
@@ -1108,10 +1114,12 @@ class DecomonActivation(Activation, DecomonLayer):
             self.frozen_alpha = False
 
 
-class DecomonFlatten(Flatten, DecomonLayer):
+class DecomonFlatten(DecomonLayer, Flatten):
     """Forward LiRPA implementation of Flatten layers.
     See Keras official documentation for further details on the Flatten operator
     """
+
+    original_keras_layer_class = Flatten
 
     def __init__(
         self,
@@ -1223,10 +1231,12 @@ class DecomonFlatten(Flatten, DecomonLayer):
         return output
 
 
-class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
+class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
     """Forward LiRPA implementation of Batch Normalization layers.
     See Keras official documentation for further details on the BatchNormalization operator
     """
+
+    original_keras_layer_class = BatchNormalization
 
     def __init__(
         self,
@@ -1275,8 +1285,7 @@ class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
         )
 
     def build(self, input_shape: List[tf.TensorShape]) -> None:
-        BatchNormalization.build(self, input_shape[0])
-
+        super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
     def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
@@ -1383,10 +1392,12 @@ class DecomonBatchNormalization(BatchNormalization, DecomonLayer):
         self.set_weights(params)
 
 
-class DecomonDropout(Dropout, DecomonLayer):
+class DecomonDropout(DecomonLayer, Dropout):
     """Forward LiRPA implementation of Dropout layers.
     See Keras official documentation for further details on the Dropout operator
     """
+
+    original_keras_layer_class = Dropout
 
     def __init__(
         self,
@@ -1418,7 +1429,7 @@ class DecomonDropout(Dropout, DecomonLayer):
         return input_shape
 
     def build(self, input_shape: List[tf.TensorShape]) -> None:
-        super().build(input_shape[0])
+        super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
     def call(self, inputs: List[tf.Tensor], training: Optional[bool] = None, **kwargs: Any) -> List[tf.Tensor]:
@@ -1436,6 +1447,8 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
     """Forward LiRPA implementation of Dropout layers.
     See Keras official documentation for further details on the Dropout operator
     """
+
+    original_keras_layer_class = InputLayer
 
     def __init__(
         self,

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -1,16 +1,18 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import InputSpec, Permute, Reshape
+from tensorflow.keras.layers import InputSpec, Layer, Permute, Reshape
 
 from decomon.layers.core import DecomonLayer, ForwardMode
 
 
-class DecomonReshape(Reshape, DecomonLayer):
+class DecomonReshape(DecomonLayer, Reshape):
     """Forward LiRPA implementation of Reshape layers.
     See Keras official documentation for further details on the Reshape operator
     """
+
+    original_keras_layer_class = Reshape
 
     def __init__(
         self,
@@ -65,19 +67,6 @@ class DecomonReshape(Reshape, DecomonLayer):
 
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
-
-    def build(self, input_shape: List[tf.TensorShape]) -> None:
-        """
-        Args:
-            self
-            input_shape
-
-        Returns:
-
-        """
-
-        y_input_shape = input_shape[0]
-        Reshape.build(self, y_input_shape)
 
     def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
         def op(x: tf.Tensor) -> tf.Tensor:
@@ -134,10 +123,12 @@ class DecomonReshape(Reshape, DecomonLayer):
         return output
 
 
-class DecomonPermute(Permute, DecomonLayer):
+class DecomonPermute(DecomonLayer, Permute):
     """Forward LiRPA implementation of Reshape layers.
     See Keras official documentation for further details on the Reshape operator
     """
+
+    original_keras_layer_class = Permute
 
     def __init__(
         self,
@@ -194,19 +185,6 @@ class DecomonPermute(Permute, DecomonLayer):
 
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
-
-    def build(self, input_shape: List[tf.TensorShape]) -> None:
-        """
-        Args:
-            self
-            input_shape
-
-        Returns:
-
-        """
-
-        y_input_shape = input_shape[-1]
-        super().build(y_input_shape)
 
     def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
         def op(x: tf.Tensor) -> tf.Tensor:

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -18,201 +18,208 @@ except ImportError:
         "Could not import GroupSort or GroupSort2 from deel.lip.activations. "
         "Please install deel-lip for being compatible with 1 Lipschitz network (see https://github.com/deel-ai/deel-lip)"
     )
+else:
 
+    class DecomonGroupSort(DecomonLayer):
 
-class DecomonGroupSort(DecomonLayer):
-    def __init__(
-        self,
-        n: Optional[int] = None,
-        data_format: str = "channels_last",
-        k_coef_lip: float = 1.0,
-        convex_domain: Optional[Dict[str, Any]] = None,
-        dc_decomp: bool = False,
-        mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-        finetune: bool = False,
-        shared: bool = False,
-        fast: bool = True,
-        **kwargs: Any,
-    ):
-        super().__init__(
-            convex_domain=convex_domain,
-            dc_decomp=dc_decomp,
-            mode=mode,
-            finetune=finetune,
-            shared=shared,
-            fast=fast,
-            **kwargs,
-        )
-        self.data_format = data_format
-        if data_format == "channels_last":
-            self.channel_axis = -1
-        elif data_format == "channels_first":
-            raise RuntimeError("channels_first not implemented for GroupSort activation")
-        else:
-            raise RuntimeError("data format not understood")
-        self.n = n
-        self.concat = DecomonConcatenate(
-            mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
-        ).call
+        original_keras_layer_class = GroupSort
 
-    def get_config(self) -> Dict[str, Any]:
-        config = super().get_config()
-        config.update(
-            {
-                "data_format": self.data_format,
-                "mode": self.mode,
-                "n": self.n,
-            }
-        )
-        return config
-
-    def build(self, input_shape: List[tf.TensorShape]) -> None:
-        if (self.n is None) or (self.n > input_shape[-1][self.channel_axis]):
-            self.n = input_shape[-1][self.channel_axis]
-            if self.n is None:  # for mypy
-                raise RuntimeError("self.n cannot be None at this point.")
-        self.reshape = DecomonReshape(
-            (-1, self.n), mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
-        ).call
-
-    def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
-
-        shape_in = tuple(inputs[-1].shape[1:])
-        input_ = self.reshape(inputs)
-        if self.n == 2:
-
-            output_max = expand_dims(
-                max_(input_, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode, axis=-1),
-                dc_decomp=self.dc_decomp,
-                mode=self.mode,
-                axis=-1,
+        def __init__(
+            self,
+            n: Optional[int] = None,
+            data_format: str = "channels_last",
+            k_coef_lip: float = 1.0,
+            convex_domain: Optional[Dict[str, Any]] = None,
+            dc_decomp: bool = False,
+            mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
+            finetune: bool = False,
+            shared: bool = False,
+            fast: bool = True,
+            **kwargs: Any,
+        ):
+            super().__init__(
+                convex_domain=convex_domain,
+                dc_decomp=dc_decomp,
+                mode=mode,
+                finetune=finetune,
+                shared=shared,
+                fast=fast,
+                **kwargs,
             )
-            output_min = expand_dims(
-                min_(input_, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode, axis=-1),
-                dc_decomp=self.dc_decomp,
-                mode=self.mode,
-                axis=-1,
+            self.data_format = data_format
+            if data_format == "channels_last":
+                self.channel_axis = -1
+            elif data_format == "channels_first":
+                raise RuntimeError("channels_first not implemented for GroupSort activation")
+            else:
+                raise RuntimeError("data format not understood")
+            self.n = n
+            self.concat = DecomonConcatenate(
+                mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
+            ).call
+
+        def get_config(self) -> Dict[str, Any]:
+            config = super().get_config()
+            config.update(
+                {
+                    "data_format": self.data_format,
+                    "mode": self.mode,
+                    "n": self.n,
+                }
             )
-            output_ = self.concat(output_min + output_max)
+            return config
 
-        else:
+        def build(self, input_shape: List[tf.TensorShape]) -> None:
+            if (self.n is None) or (self.n > input_shape[-1][self.channel_axis]):
+                self.n = input_shape[-1][self.channel_axis]
+                if self.n is None:  # for mypy
+                    raise RuntimeError("self.n cannot be None at this point.")
+            self.reshape = DecomonReshape(
+                (-1, self.n), mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
+            ).call
 
-            output_ = sort(input_, axis=-1, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode)
+        def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
 
-        return DecomonReshape(
-            shape_in, mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
-        ).call(output_)
+            shape_in = tuple(inputs[-1].shape[1:])
+            input_ = self.reshape(inputs)
+            if self.n == 2:
 
-    def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
-        return input_shape
+                output_max = expand_dims(
+                    max_(input_, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode, axis=-1),
+                    dc_decomp=self.dc_decomp,
+                    mode=self.mode,
+                    axis=-1,
+                )
+                output_min = expand_dims(
+                    min_(input_, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode, axis=-1),
+                    dc_decomp=self.dc_decomp,
+                    mode=self.mode,
+                    axis=-1,
+                )
+                output_ = self.concat(output_min + output_max)
 
+            else:
 
-class DecomonGroupSort2(DecomonLayer):
-    def __init__(
-        self,
-        n: int = 2,
-        data_format: str = "channels_last",
-        k_coef_lip: float = 1.0,
-        convex_domain: Optional[Dict[str, Any]] = None,
-        dc_decomp: bool = False,
-        mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-        finetune: bool = False,
-        shared: bool = False,
-        fast: bool = True,
-        **kwargs: Any,
-    ):
-        super().__init__(
-            convex_domain=convex_domain,
-            dc_decomp=dc_decomp,
-            mode=mode,
-            finetune=finetune,
-            shared=shared,
-            fast=fast,
-            **kwargs,
-        )
-        self.data_format = data_format
+                output_ = sort(
+                    input_, axis=-1, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+                )
 
-        if self.data_format == "channels_last":
-            self.axis = -1
-        else:
-            self.axis = 1
+            return DecomonReshape(
+                shape_in, mode=self.mode, convex_domain=self.convex_domain, dc_decomp=self.dc_decomp
+            ).call(output_)
 
-        if self.dc_decomp:
-            raise NotImplementedError()
+        def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
+            return input_shape
 
-        self.op_concat = DecomonConcatenate(self.axis, mode=self.mode, convex_domain=self.convex_domain)
+    class DecomonGroupSort2(DecomonLayer):
 
-    def get_config(self) -> Dict[str, Any]:
-        config = super().get_config()
-        config.update(
-            {
-                "data_format": self.data_format,
-                "mode": self.mode,
-            }
-        )
-        return config
+        original_keras_layer_class = GroupSort2
 
-    def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
-        return input_shape
+        def __init__(
+            self,
+            n: int = 2,
+            data_format: str = "channels_last",
+            k_coef_lip: float = 1.0,
+            convex_domain: Optional[Dict[str, Any]] = None,
+            dc_decomp: bool = False,
+            mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
+            finetune: bool = False,
+            shared: bool = False,
+            fast: bool = True,
+            **kwargs: Any,
+        ):
+            super().__init__(
+                convex_domain=convex_domain,
+                dc_decomp=dc_decomp,
+                mode=mode,
+                finetune=finetune,
+                shared=shared,
+                fast=fast,
+                **kwargs,
+            )
+            self.data_format = data_format
 
-    def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
+            if self.data_format == "channels_last":
+                self.axis = -1
+            else:
+                self.axis = 1
 
-        inputs_ = self.op_reshape_in(inputs)
-        inputs_max = expand_dims(
-            max_(
-                inputs_,
+            if self.dc_decomp:
+                raise NotImplementedError()
+
+            self.op_concat = DecomonConcatenate(self.axis, mode=self.mode, convex_domain=self.convex_domain)
+
+        def get_config(self) -> Dict[str, Any]:
+            config = super().get_config()
+            config.update(
+                {
+                    "data_format": self.data_format,
+                    "mode": self.mode,
+                }
+            )
+            return config
+
+        def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> List[tf.TensorShape]:
+            return input_shape
+
+        def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
+
+            inputs_ = self.op_reshape_in(inputs)
+            inputs_max = expand_dims(
+                max_(
+                    inputs_,
+                    mode=self.mode,
+                    convex_domain=self.convex_domain,
+                    axis=self.axis,
+                    finetune=self.finetune,
+                    finetune_params=self.params_max,
+                ),
                 mode=self.mode,
-                convex_domain=self.convex_domain,
                 axis=self.axis,
-                finetune=self.finetune,
-                finetune_params=self.params_max,
-            ),
-            mode=self.mode,
-            axis=self.axis,
-        )
-        inputs_min = expand_dims(
-            min_(
-                inputs_,
+            )
+            inputs_min = expand_dims(
+                min_(
+                    inputs_,
+                    mode=self.mode,
+                    convex_domain=self.convex_domain,
+                    axis=self.axis,
+                    finetune=self.finetune,
+                    finetune_params=self.params_min,
+                ),
                 mode=self.mode,
-                convex_domain=self.convex_domain,
                 axis=self.axis,
-                finetune=self.finetune,
-                finetune_params=self.params_min,
-            ),
-            mode=self.mode,
-            axis=self.axis,
-        )
-        output = self.op_concat(inputs_min + inputs_max)
-        output_ = self.op_reshape_out(output)
-        return output_
-
-    def build(self, input_shape: List[tf.TensorShape]) -> None:
-        input_shape = input_shape[-1]
-
-        if self.data_format == "channels_last":
-            if input_shape[-1] % 2 != 0:
-                raise ValueError()
-            target_shape = list(input_shape[1:-2]) + [int(input_shape[-1] / 2), 2]
-        else:
-            if input_shape[1] % 2 != 0:
-                raise ValueError()
-            target_shape = [2, int(input_shape[1] / 2)] + list(input_shape[2:])
-
-        self.params_max = []
-        self.params_min = []
-
-        if self.finetune and self.mode in [ForwardMode.AFFINE, ForwardMode.HYBRID]:
-            self.beta_max_ = self.add_weight(
-                shape=target_shape, initializer="ones", name="beta_max", regularizer=None, constraint=ClipAlpha()
             )
-            self.beta_min_ = self.add_weight(
-                shape=target_shape, initializer="ones", name="beta_max", regularizer=None, constraint=ClipAlpha()
-            )
-            self.params_max = [self.beta_max_]
-            self.params_min = [self.beta_min_]
+            output = self.op_concat(inputs_min + inputs_max)
+            output_ = self.op_reshape_out(output)
+            return output_
 
-        self.op_reshape_in = DecomonReshape(tuple(target_shape), mode=self.mode)
-        self.op_reshape_out = DecomonReshape(tuple(input_shape[1:]), mode=self.mode)
+        def build(self, input_shape: List[tf.TensorShape]) -> None:
+            input_shape = input_shape[-1]
 
-    def reset_layer(self, layer: Layer) -> None:
-        pass
+            if self.data_format == "channels_last":
+                if input_shape[-1] % 2 != 0:
+                    raise ValueError()
+                target_shape = list(input_shape[1:-2]) + [int(input_shape[-1] / 2), 2]
+            else:
+                if input_shape[1] % 2 != 0:
+                    raise ValueError()
+                target_shape = [2, int(input_shape[1] / 2)] + list(input_shape[2:])
+
+            self.params_max = []
+            self.params_min = []
+
+            if self.finetune and self.mode in [ForwardMode.AFFINE, ForwardMode.HYBRID]:
+                self.beta_max_ = self.add_weight(
+                    shape=target_shape, initializer="ones", name="beta_max", regularizer=None, constraint=ClipAlpha()
+                )
+                self.beta_min_ = self.add_weight(
+                    shape=target_shape, initializer="ones", name="beta_max", regularizer=None, constraint=ClipAlpha()
+                )
+                self.params_max = [self.beta_max_]
+                self.params_min = [self.beta_min_]
+
+            self.op_reshape_in = DecomonReshape(tuple(target_shape), mode=self.mode)
+            self.op_reshape_out = DecomonReshape(tuple(input_shape[1:]), mode=self.mode)
+
+        def reset_layer(self, layer: Layer) -> None:
+            pass

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -12,11 +12,13 @@ from decomon.utils import get_lower, get_upper
 
 
 # step 1: compute the maximum
-class DecomonMaxPooling2D(MaxPooling2D, DecomonLayer):
+class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
     """LiRPA implementation of MaxPooling2D layers.
     See Keras official documentation for further details on the MaxPooling2D operator
 
     """
+
+    original_keras_layer_class = MaxPooling2D
 
     pool_size: Tuple[int, int]
     strides: Tuple[int, int]

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import Lambda
+from tensorflow.keras.layers import Lambda, Layer
 
 from decomon.layers.activations import softmax as softmax_
 from decomon.layers.core import DecomonLayer, ForwardMode, get_mode
@@ -361,6 +361,9 @@ def get_adv_loss(
 
 # create a layer
 class DecomonLossFusion(DecomonLayer):
+
+    original_keras_layer_class = Layer
+
     def __init__(
         self,
         asymptotic: bool = False,
@@ -446,9 +449,15 @@ class DecomonLossFusion(DecomonLayer):
     def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> tf.TensorShape:
         return input_shape[-1]
 
+    def build(self, input_shape: List[tf.TensorShape]) -> None:
+        return None
+
 
 # new layer for new loss functions
 class DecomonRadiusRobust(DecomonLayer):
+
+    original_keras_layer_class = Layer
+
     def __init__(
         self,
         backward: bool = False,
@@ -560,6 +569,9 @@ class DecomonRadiusRobust(DecomonLayer):
 
     def compute_output_shape(self, input_shape: List[tf.TensorShape]) -> tf.TensorShape:
         return input_shape[-1]
+
+    def build(self, input_shape: List[tf.TensorShape]) -> None:
+        return None
 
 
 def build_radius_robust_model(model: DecomonModel) -> DecomonModel:

--- a/tests/test_backward_layers_get_config.py
+++ b/tests/test_backward_layers_get_config.py
@@ -49,8 +49,17 @@ from decomon.layers.decomon_merge_layers import (
     DecomonSubtract,
 )
 from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
-from decomon.layers.deel_lip import DecomonGroupSort2
 from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+try:
+    from decomon.layers.deel_lip import DecomonGroupSort2
+except ImportError:
+    deel_lip_available = False
+else:
+    deel_lip_available = True
+
+
+deel_lip_skip_reason = "deel-lip is not available"
 
 
 def test_backward_layers():
@@ -132,6 +141,7 @@ def test_backward_maxpooling():
 
 
 @pytest.mark.skip("Not yet implemented.")
+@pytest.mark.skipif(not (deel_lip_available), reason=deel_lip_skip_reason)
 def test_deel_lip():
     sublayer = DecomonGroupSort2()
     layer = BackwardGroupSort2(layer=sublayer)

--- a/tests/test_layers_get_config.py
+++ b/tests/test_layers_get_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import (
     DecomonActivation,
@@ -19,8 +21,16 @@ from decomon.layers.decomon_merge_layers import (
     DecomonSubtract,
 )
 from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
-from decomon.layers.deel_lip import DecomonGroupSort, DecomonGroupSort2
 from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+try:
+    from decomon.layers.deel_lip import DecomonGroupSort, DecomonGroupSort2
+except ImportError:
+    deel_lip_available = False
+else:
+    deel_lip_available = True
+
+deel_lip_skip_reason = "deel-lip is not available"
 
 
 def test_decomon_reshape():
@@ -38,6 +48,7 @@ def test_decomon_reshape():
     assert config["mode"] == mode
 
 
+@pytest.mark.skipif(not (deel_lip_available), reason=deel_lip_skip_reason)
 def test_deel_lip():
     layer = DecomonGroupSort()
     config = layer.get_config()


### PR DESCRIPTION
- It is the last tensor which has always the proper shape for underlying original Keras layer in inputs for decomon layers => thus in general, we should call the original keras layer's build() on input_shape[-1]
- For merging layers we introduce a base layer DecomonMerge to harmonize build() and also compute_output_shape(). We need to derive first from DecomonMerge to be sure to pass through the proper build().   
- We implement a default version of build in DecomonLayer.
- To avoid issues to know which build is called when using super().call(), we introduce a new attribute `original_keras_layer_class`, to be overriden in each subclass of  DecomonLayer. This is the keras layer from which this decomon layer is the decomon equivalent.
- We use this new attribute to get also a default version of compute_output_shape(). This is needed if we want to derive first from DecomonLayer and still have DecomonReshape working as the underlying Reshape.call() (used by in DecomonReshape.call()) use self.compute_output_shape()
- We define DecomonGroupSort and DecomonGroupSort2 only if deel-lip is available as we need to define original_keras_layer_class = GroupSort