### PR TITLE
Fix typo on subtract

### DIFF
--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -11,7 +11,7 @@ from decomon.backward_layers.utils import (
     backward_maximum,
     backward_minimum,
     backward_multiply,
-    backward_substract,
+    backward_subtract,
     get_identity_lirpa,
 )
 from decomon.layers.core import DecomonLayer, ForwardMode
@@ -281,7 +281,7 @@ class BackwardSubtract(BackwardMerge):
         if n_elem != 2:
             raise ValueError()
 
-        return backward_substract(
+        return backward_subtract(
             inputs_list[0],
             inputs_list[1],
             w_out_u,

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -18,7 +18,7 @@ from decomon.utils import (
     maximum,
     minus,
     relu_,
-    substract,
+    subtract,
 )
 
 
@@ -363,7 +363,7 @@ def backward_maximum(
 
     if convex_domain is None:
         convex_domain = {}
-    input_step_a_0 = substract(inputs_0, inputs_1, dc_decomp=False, convex_domain=convex_domain, mode=mode)
+    input_step_a_0 = subtract(inputs_0, inputs_1, dc_decomp=False, convex_domain=convex_domain, mode=mode)
 
     input_step_0_ = relu_(input_step_a_0, dc_decomp=False, convex_domain=convex_domain, mode=mode, **kwargs)
 
@@ -371,7 +371,7 @@ def backward_maximum(
         input_step_0_, inputs_1, w_out_u, b_out_u, w_out_l, b_out_l, convex_domain=convex_domain, mode=mode
     )
 
-    input_step_a_1 = substract(inputs_1, inputs_0, dc_decomp=False, convex_domain=convex_domain, mode=mode)
+    input_step_a_1 = subtract(inputs_1, inputs_0, dc_decomp=False, convex_domain=convex_domain, mode=mode)
     input_step_1_ = relu_(input_step_a_1, dc_decomp=False, convex_domain=convex_domain, mode=mode, **kwargs)
 
     _, bounds_0_ = backward_add(
@@ -627,7 +627,7 @@ def backward_scale(
     return output
 
 
-def backward_substract(
+def backward_subtract(
     inputs_0: List[tf.Tensor],
     inputs_1: List[tf.Tensor],
     w_out_u_: tf.Tensor,

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -15,7 +15,7 @@ from tensorflow.keras.layers import (
 
 from decomon.layers.core import DecomonLayer, ForwardMode
 from decomon.layers.utils import broadcast, multiply, permute_dimensions
-from decomon.utils import maximum, minus, substract
+from decomon.utils import maximum, minus, subtract
 
 ##### Merge Layer ####
 
@@ -231,7 +231,7 @@ class DecomonSubtract(DecomonLayer):
         n_comp = self.nb_tensors
         inputs_list = [inputs[n_comp * i : n_comp * (i + 1)] for i in range(len(inputs) // n_comp)]
 
-        output = substract(
+        output = subtract(
             inputs_list[0], inputs_list[1], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
         )
         return output

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -732,7 +732,7 @@ def get_linear_softplus_hull(
     return [w_u_, b_u_, w_l_, b_l_]
 
 
-def substract(
+def subtract(
     inputs_0: List[tf.Tensor],
     inputs_1: List[tf.Tensor],
     dc_decomp: bool = False,
@@ -984,7 +984,7 @@ def maximum(
     """
     if convex_domain is None:
         convex_domain = {}
-    output_0 = substract(inputs_1, inputs_0, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
+    output_0 = subtract(inputs_1, inputs_0, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode)
     if finetune:
         finetune = kwargs["finetune_params"]
         output_1 = relu_(output_0, dc_decomp=dc_decomp, convex_domain=convex_domain, mode=mode, finetune=finetune)

--- a/tests/test_backward_utils.py
+++ b/tests/test_backward_utils.py
@@ -10,17 +10,17 @@ from decomon.backward_layers.utils import (
     backward_add,
     backward_maximum,
     backward_relu_,
-    backward_substract,
+    backward_subtract,
 )
 from decomon.layers.core import ForwardMode
-from decomon.utils import relu_, substract
+from decomon.utils import relu_, subtract
 
 
 def add_op(x, y):
     return x + y
 
 
-def substract_op(x, y):
+def subtract_op(x, y):
     return x - y
 
 
@@ -97,7 +97,7 @@ def test_relu_backward_1D_box(n, mode, floatx, helpers):
     [
         (backward_add, add_op),
         (backward_maximum, np.maximum),
-        (backward_substract, substract_op),
+        (backward_subtract, subtract_op),
     ],
 )
 def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx, helpers):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -32,7 +32,7 @@ def add_op(x, y):
     return x + y
 
 
-def substract_op(x, y):
+def subtract_op(x, y):
     return x - y
 
 
@@ -52,7 +52,7 @@ def concatenate_op(x, y):
     "decomon_op_class, tensor_op, decomon_op_kwargs",
     [
         (DecomonAdd, add_op, {}),
-        (DecomonSubtract, substract_op, {}),
+        (DecomonSubtract, subtract_op, {}),
         (DecomonAverage, average_op, {}),
         (DecomonMaximum, np.maximum, {}),
         (DecomonMinimum, np.minimum, {}),
@@ -119,7 +119,7 @@ def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mod
     "decomon_op_class, tensor_op, decomon_op_kwargs",
     [
         (DecomonAdd, add_op, {}),
-        (DecomonSubtract, substract_op, {}),
+        (DecomonSubtract, subtract_op, {}),
         (DecomonAverage, average_op, {}),
         (DecomonMaximum, np.maximum, {}),
         (DecomonMinimum, np.minimum, {}),
@@ -190,7 +190,7 @@ def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, od
     [
         (Add, add_op, {}),
         (Average, average_op, {}),
-        (Subtract, substract_op, {}),
+        (Subtract, subtract_op, {}),
         (Maximum, np.maximum, {}),
         (Minimum, np.minimum, {}),
         (Concatenate, concatenate_op, {"axis": -1}),
@@ -235,7 +235,7 @@ def test_Decomon_1D_box_to_decomon(layer_class, tensor_op, layer_kwargs, n, help
     [
         (Add, add_op, {}),
         (Average, average_op, {}),
-        (Subtract, substract_op, {}),
+        (Subtract, subtract_op, {}),
         (Maximum, np.maximum, {}),
         (Minimum, np.minimum, {}),
         (Concatenate, concatenate_op, {"axis": -1}),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 from decomon.layers.core import ForwardMode
 from decomon.layers.utils import add, get_lower, get_upper, max_, maximum, minus, relu_
-from decomon.utils import substract
+from decomon.utils import subtract
 
 
 def test_get_upper_multi_box(odd, floatx, helpers):
@@ -586,7 +586,7 @@ def test_minus(odd, mode, floatx, helpers):
     K.set_epsilon(eps)
 
 
-def test_substract(odd, mode, floatx, helpers):
+def test_subtract(odd, mode, floatx, helpers):
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
@@ -608,16 +608,16 @@ def test_substract(odd, mode, floatx, helpers):
 
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
-        output = substract(inputs_0[2:], inputs_1[2:], dc_decomp=True, mode=mode)
+        output = subtract(inputs_0[2:], inputs_1[2:], dc_decomp=True, mode=mode)
     elif mode == ForwardMode.AFFINE:
-        output = substract(
+        output = subtract(
             [z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0],
             [z_1, W_u_1, b_u_1, W_l_1, b_l_1, h_1, g_1],
             dc_decomp=True,
             mode=mode,
         )
     elif mode == ForwardMode.IBP:
-        output = substract([u_c_0, l_c_0, h_0, g_0], [u_c_1, l_c_1, h_1, g_1], dc_decomp=True, mode=mode)
+        output = subtract([u_c_0, l_c_0, h_0, g_0], [u_c_1, l_c_1, h_1, g_1], dc_decomp=True, mode=mode)
     else:
         raise ValueError("Unknown mode.")
 


### PR DESCRIPTION
I got suprised myself to discover that "soustraire" is "subtract" an not "subtract". Found it when trying to import `Substract` from `tendorflow.keras.layers`...