### PR TITLE
Fix minor issues in notebooks texts

### DIFF
--- a/tutorials/tutorial1_sinus-interactive.ipynb
+++ b/tutorials/tutorial1_sinus-interactive.ipynb
@@ -249,9 +249,10 @@
     "Several methods are possible among this list: **forward-ibp, forward-affine, forward-hybrid, crown-forward-ibp, crown-forward-affine, crown-forward-hybrid, crown**.\n",
     "\n",
     "Depending on the inner recipes, those methods will output different informations:\n",
-    "    <ul> **forward-ibp**: constant upper and lower bounds that outer-approximate every output neurons</ul>\n",
-    "    <ul> **forward-affine**: affine upper bound and affine lower bound given the input of the network that outer-approximate every output neurons</ul>\n",
-    "    <ul> **forward-hybrid, crown, crown-(...)**: other previously cited methods will output both information</ul>\n",
+    "\n",
+    "- **forward-ibp, crown-forward-ibp, crown**: constant upper and lower bounds that outer-approximate every output neurons\n",
+    "- **forward-affine, crown-forward-affine**: affine upper bound and affine lower bound given the input of the network that outer-approximate every output neurons\n",
+    "- **forward-hybrid, crown-forward-hybrid**: both types of bounds\n",
     "    \n",
     "By default, the convert method converts the Keras model in **crown**."
    ]

--- a/tutorials/tutorial2_noise_sensor.ipynb
+++ b/tutorials/tutorial2_noise_sensor.ipynb
@@ -255,7 +255,9 @@
     "to get state-of-the-art outer approximation.\n",
     "\n",
     "To use **decomon** for **local robustness to sensor noise** we first need the following imports:\n",
-    "+ *from decomon.models import clone*: to convert our current Keras model into another neural network nn_model. nn_model will output the same prediction that our model and adds extra information that will be used to derive our formal bounds. For a sake of clarity, how to get such bounds is hidden to the user, but an interested reader may refer to XXX.\n",
+    "+ *from decomon.models import clone*: to convert our current Keras model into another neural network nn_model. nn_model will output the same prediction that our model and adds extra information that will be used to derive our formal bounds. For a sake of clarity, how to get such bounds is hidden to the user, but an interested reader may refer to \n",
+    "    \n",
+    "    > _Automatic Perturbation Analysis for Scalable Certified Robustness and Beyond._ NeurIPS 2020. Kaidi Xu*, Zhouxing Shi*, Huan Zhang*, Yihan Wang, Kai-Wei Chang, Minlie Huang, Bhavya Kailkhura, Xue Lin, Cho-Jui Hsieh (* Equal contribution).\n",
     "\n",
     "+ *from decomon import get_lower_noise, get_upper_noise, get_range_noise*: a generic method to get respectively a lower bound, an upper bound, or both on the prediction of a neural network in a $L_p$ (p $\\in \\{1, 2, \\infty\\} $) ball with radius epsilon around a sample. If the type of Lp norm is not provided, we assume that we consider a worst case noise independently on every input variable ($L_{\\infty}$)."
    ]


### PR DESCRIPTION
- Add a missing paper reference in tuto 2;
- Correct the type of bounds available depending of chosen method for `clone()`.