### PR TITLE
Implement DecomonBatchNormalization.call with center or scale = False

### DIFF
--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -1310,8 +1310,14 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
         for i, ax in enumerate(self.axis):
             tuple_[ax] = self.moving_mean.shape[i]
 
-        gamma_ = K.reshape(self.gamma + z_value, tuple_)
-        beta_ = K.reshape(self.beta + z_value, tuple_)
+        if self.gamma is None:  # scale = False
+            gamma_ = tf.ones(tuple_)
+        else:  # scale = True
+            gamma_ = K.reshape(self.gamma + z_value, tuple_)
+        if self.beta is None:  # center = False
+            beta_ = tf.zeros(tuple_)
+        else:  # center = True
+            beta_ = K.reshape(self.beta + z_value, tuple_)
         moving_mean_ = K.reshape(self.moving_mean + z_value, tuple_)
         moving_variance_ = K.reshape(self.moving_variance + z_value, tuple_)
 

--- a/tests/test_decomon_reset_layer.py
+++ b/tests/test_decomon_reset_layer.py
@@ -162,8 +162,6 @@ def test_decomonconv2d_reset_layer(helpers, use_bias):
     ],
 )
 def test_decomonbacthnormalization_reset_layer(helpers, center, scale):
-    if not center or not scale:
-        pytest.xfail("DecomonBatchNormalization does not take into account yet center=False or scale=False")
 
     dc_decomp = False
     odd = 0


### PR DESCRIPTION
In that case `self.beta` (resp. `self.gamma`) are `None`, and thus `beta_` (resp. `gamma_`) must be 0 (resp 1).

We reactivate the test that was xfailed waiting for this correction.