### PR TITLE
Improve and simplify tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,38 +134,38 @@ class Helpers:
             h_ = np.linspace(-2, -1, nb)
             g_ = np.zeros_like(x_)
 
-        if n == 1:
+        elif n == 1:
             y_ = np.linspace(1, 2, nb)
             x_ = np.linspace(1, 2, nb)
             h_ = np.linspace(1, 2, nb)
             g_ = np.zeros_like(x_)
 
-        if n == 2:
+        elif n == 2:
             y_ = np.linspace(-1, 1, nb)
             x_ = np.linspace(-1, 1, nb)
             h_ = np.linspace(-1, 1, nb)
             g_ = np.zeros_like(x_)
 
-        if n == 3:
+        elif n == 3:
             # identity
             y_ = np.linspace(-2, -1, nb)
             x_ = np.linspace(-2, -1, nb)
             h_ = 2 * np.linspace(-2, -1, nb)
             g_ = -np.linspace(-2, -1, nb)
 
-        if n == 4:
+        elif n == 4:
             y_ = np.linspace(1, 2, nb)
             x_ = np.linspace(1, 2, nb)
             h_ = 2 * np.linspace(1, 2, nb)
             g_ = -np.linspace(1, 2, nb)
 
-        if n == 5:
+        elif n == 5:
             y_ = np.linspace(-1, 1, nb)
             x_ = np.linspace(-1, 1, nb)
             h_ = 2 * np.linspace(-1, 1, nb)
             g_ = -np.linspace(-1, 1, nb)
 
-        if n == 6:
+        elif n == 6:
 
             assert nb == 100, "expected nb=100 samples"
             # cosine function
@@ -178,14 +178,14 @@ class Helpers:
             b_u_ = np.ones_like(x_)
             b_l_ = -np.ones_like(x_)
 
-        if n == 7:
+        elif n == 7:
             # h and g >0
             h_ = np.linspace(0.5, 2, nb)
             g_ = np.linspace(1, 2, nb)[::-1]
             x_ = h_ + g_
             y_ = h_ + g_
 
-        if n == 8:
+        elif n == 8:
             # h <0 and g <0
             # h_max+g_max <=0
             h_ = np.linspace(-2, -1, nb)
@@ -193,13 +193,16 @@ class Helpers:
             y_ = h_ + g_
             x_ = h_ + g_
 
-        if n == 9:
+        elif n == 9:
             # h >0 and g <0
             # h_min+g_min >=0
             h_ = np.linspace(4, 5, nb)
             g_ = np.linspace(-2, -1, nb)[::-1]
             y_ = h_ + g_
             x_ = h_ + g_
+
+        else:
+            raise ValueError("n must be between 0 and 9.")
 
         x_min_ = x_.min() + np.zeros_like(x_)
         x_max_ = x_.max() + np.zeros_like(x_)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -679,35 +679,18 @@ class Helpers:
         return output
 
     @staticmethod
-    def assert_output_properties_box(
-        x_, y_, h_, g_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, name, decimal=5
-    ):
+    def assert_output_properties_box(x_, y_, h_, g_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=5):
 
         if y_ is None:
             y_ = h_ + g_
         if h_ is not None:
 
-            assert_almost_equal(
-                h_ + g_,
-                y_,
-                decimal=decimal,
-                err_msg="decomposition error for function {}".format(name),
-            )
+            assert_almost_equal(h_ + g_, y_, decimal=decimal, err_msg="decomposition error")
 
-        assert np.min(x_min_ <= x_max_), "x_min >x_max for function {}".format(name)
+        assert np.min(x_min_ <= x_max_), "x_min >x_max"
 
-        assert_almost_equal(
-            np.clip(x_min_ - x_, 0, np.inf),
-            0.0,
-            decimal=decimal,
-            err_msg="x_min >x_  for function {}".format(name),
-        )
-        assert_almost_equal(
-            np.clip(x_ - x_max_, 0, np.inf),
-            0.0,
-            decimal=decimal,
-            err_msg="x_max < x_  for function {}".format(name),
-        )
+        assert_almost_equal(np.clip(x_min_ - x_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_min >x_")
+        assert_almost_equal(np.clip(x_ - x_max_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_max < x_")
         if w_u_ is not None or w_l_ is not None:
             x_expand = x_ + np.zeros_like(x_)
             n_expand = len(w_u_.shape) - len(x_expand.shape)
@@ -725,13 +708,13 @@ class Helpers:
                 np.clip(h_[:-1] - h_[1:], 0, np.inf),
                 np.zeros_like(h_[1:]),
                 decimal=decimal,
-                err_msg="h is not increasing for function {}".format(name),
+                err_msg="h is not increasing",
             )
             assert_almost_equal(
                 np.clip(g_[1:] - g_[:-1], 0, np.inf),
                 np.zeros_like(g_[1:]),
                 decimal=decimal,
-                err_msg="g is not increasing for function {}".format(name),
+                err_msg="g is not increasing",
             )
 
         #
@@ -767,9 +750,7 @@ class Helpers:
             )
 
     @staticmethod
-    def assert_output_properties_box_linear(
-        x_, y_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, name, decimal=5
-    ):
+    def assert_output_properties_box_linear(x_, y_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=5):
 
         # flatten everything
         # flatten everyting
@@ -786,15 +767,10 @@ class Helpers:
             b_u_ = b_u_.reshape((n, -1))
             b_l_ = b_l_.reshape((n, -1))
 
-        # assert_almost_equal(h_ + g_, y_, decimal=decimal, err_msg='decomposition error for function {}'.format(name))
-        assert np.min(x_min_ <= x_max_), "x_min >x_max for function {}".format(name)
+        assert np.min(x_min_ <= x_max_), "x_min >x_max"
 
-        assert_almost_equal(
-            np.clip(x_min_ - x_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_min >x_  for function {}".format(name)
-        )
-        assert_almost_equal(
-            np.clip(x_ - x_max_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_max < x_  for function {}".format(name)
-        )
+        assert_almost_equal(np.clip(x_min_ - x_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_min >x_")
+        assert_almost_equal(np.clip(x_ - x_max_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_max < x_")
         if w_u_ is not None:
             x_expand = x_ + np.zeros_like(x_)
             n_expand = len(w_u_.shape) - len(x_expand.shape)
@@ -803,13 +779,6 @@ class Helpers:
 
             lower_ = np.sum(w_l_ * x_expand, 1) + b_l_
             upper_ = np.sum(w_u_ * x_expand, 1) + b_u_
-
-        # check that the functions h_ and g_ remains monotonic
-
-        # assert_almost_equal(np.clip(h_[:-1] - h_[1:], 0, np.inf), np.zeros_like(h_[1:]), decimal=decimal,
-        #                    err_msg='h is not increasing for function {}'.format(name))
-        # assert_almost_equal(np.clip(g_[1:] - g_[:-1], 0, np.inf), np.zeros_like(g_[1:]), decimal=decimal,
-        #                    err_msg='g is not increasing for function {}'.format(name))
 
         if y_ is not None:
             if l_c_ is not None:
@@ -841,7 +810,6 @@ class Helpers:
                 np.sum(np.maximum(0, w_u_) * x_expand_max, 1) + np.sum(np.minimum(0, w_u_) * x_expand_min, 1) + b_u_
             )
 
-            # import pdb; pdb.set_trace()
             if y_ is not None:
                 assert_almost_equal(
                     np.clip(lower_ - y_, 0.0, np.inf), np.zeros_like(y_), decimal=decimal, err_msg="l_c >y"
@@ -978,22 +946,12 @@ class Helpers:
         return [x_, y_, z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_]
 
     @staticmethod
-    def assert_output_properties_box_nodc(x_, y_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, name, decimal=5):
+    def assert_output_properties_box_nodc(x_, y_, x_min_, x_max_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=5):
 
-        assert np.min(x_min_ <= x_max_), "x_min >x_max for function {}".format(name)
+        assert np.min(x_min_ <= x_max_), "x_min >x_max"
 
-        assert_almost_equal(
-            np.clip(x_min_ - x_, 0, np.inf),
-            0.0,
-            decimal=decimal,
-            err_msg="x_min >x_  for function {}".format(name),
-        )
-        assert_almost_equal(
-            np.clip(x_ - x_max_, 0, np.inf),
-            0.0,
-            decimal=decimal,
-            err_msg="x_max < x_  for function {}".format(name),
-        )
+        assert_almost_equal(np.clip(x_min_ - x_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_min >x_")
+        assert_almost_equal(np.clip(x_ - x_max_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_max < x_")
 
         x_expand = x_ + np.zeros_like(x_)
         n_expand = len(w_u_.shape) - len(x_expand.shape)

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -12,18 +12,18 @@ from decomon.utils import Slope
 
 
 @pytest.mark.parametrize(
-    "activation_func, tensor_func, funcname, decimal",
+    "activation_func, tensor_func, decimal",
     [
-        (sigmoid, K.sigmoid, "sigmoid", 5),
-        (tanh, K.tanh, "tanh", 5),
-        (softsign, K.softsign, "softsign", 4),
-        (softmax, K.softmax, "softmax", 4),
-        (relu, K.relu, "relu", 4),
+        (sigmoid, K.sigmoid, 5),
+        (tanh, K.tanh, 5),
+        (softsign, K.softsign, 4),
+        (softmax, K.softmax, 4),
+        (relu, K.relu, 4),
     ],
 )
-def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_func, funcname, decimal):
+def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_func, decimal):
     # softmax: test only n=0,3
-    if funcname == "softmax":
+    if activation_func is softmax:
         if n not in {0, 3}:
             pytest.skip("softmax activation only possible for n=0 or 3")
 
@@ -74,20 +74,7 @@ def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_fun
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_0,
-        y_,
-        None,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        f"{funcname}_{n}",
-        decimal=decimal,
+        x_0, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float32")

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -21,18 +21,13 @@ from decomon.utils import Slope
         (relu, K.relu, 4),
     ],
 )
-def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_func, decimal):
+def test_activation_1D_box(n, mode, floatx, decimal, helpers, activation_func, tensor_func):
     # softmax: test only n=0,3
     if activation_func is softmax:
         if n not in {0, 3}:
             pytest.skip("softmax activation only possible for n=0 or 3")
 
     mode = ForwardMode(mode)
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
-        decimal = 2
 
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
@@ -76,9 +71,6 @@ def test_activation_1D_box(n, mode, floatx, helpers, activation_func, tensor_fun
     helpers.assert_output_properties_box(
         x_0, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
-
-    K.set_floatx("float32")
-    K.set_epsilon(eps)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backward_activation.py
+++ b/tests/test_backward_activation.py
@@ -17,14 +17,7 @@ from decomon.utils import Slope
         (softsign, backward_softsign),
     ],
 )
-def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_func, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
+def test_activation_backward_1D_box(n, mode, floatx, decimal, activation_func, tensor_func, helpers):
 
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
@@ -66,9 +59,6 @@ def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_fun
     helpers.assert_output_properties_box_linear(
         x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
     )
-
-    K.set_epsilon(eps)
-    K.set_floatx("float32")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backward_activation.py
+++ b/tests/test_backward_activation.py
@@ -11,13 +11,13 @@ from decomon.utils import Slope
 
 
 @pytest.mark.parametrize(
-    "activation_func, tensor_func, funcname",
+    "activation_func, tensor_func",
     [
-        (relu, backward_relu, "relu"),
-        (softsign, backward_softsign, "softsign"),
+        (relu, backward_relu),
+        (softsign, backward_softsign),
     ],
 )
-def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_func, funcname, helpers):
+def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_func, helpers):
 
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()
@@ -64,7 +64,7 @@ def test_activation_backward_1D_box(n, mode, floatx, activation_func, tensor_fun
     b_l_b = b_l_ + np.sum(np.maximum(w_l_, 0) * B_l_[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * B_u_[:, :, None], 1)
 
     helpers.assert_output_properties_box_linear(
-        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, f"{funcname}_{n}", decimal=decimal
+        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
     )
 
     K.set_epsilon(eps)

--- a/tests/test_backward_activation.py
+++ b/tests/test_backward_activation.py
@@ -2,62 +2,39 @@ import numpy as np
 import pytest
 import tensorflow.keras.backend as K
 from numpy.testing import assert_almost_equal
-from tensorflow.keras.layers import Input
 
 from decomon.backward_layers.activations import backward_relu, backward_softsign
-from decomon.layers.activations import relu, softsign
 from decomon.layers.core import ForwardMode
 from decomon.utils import Slope
 
 
 @pytest.mark.parametrize(
-    "activation_func, tensor_func",
+    "activation_func",
     [
-        (relu, backward_relu),
-        (softsign, backward_softsign),
+        backward_relu,
+        backward_softsign,
     ],
 )
-def test_activation_backward_1D_box(n, mode, floatx, decimal, activation_func, tensor_func, helpers):
+def test_activation_backward_1D_box(n, mode, floatx, decimal, activation_func, helpers):
+    dc_decomp = False
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
-    x_, y_, z_, u_c_, W_u_, B_u_, l_c_, W_l_, B_l_ = inputs_
+    # backward outputs
+    outputs = activation_func(inputs_for_mode, mode=mode)
+    f_func = K.function(inputs, outputs)
+    outputs_ = f_func(inputs_)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = activation_func(input_mode, dc_decomp=False, mode=mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [z, W_u, b_u, W_l, b_l]
-        output = activation_func(input_mode, dc_decomp=False, mode=mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [u_c, l_c]
-        output = activation_func(input_mode, dc_decomp=False, mode=mode)
-        z_0 = z_
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
-
-    w_out = Input((1, 1), dtype=K.floatx())
-    b_out = Input((1), dtype=K.floatx())
-
-    w_out_u, b_out_u, w_out_l, b_out_l = tensor_func(input_mode, mode=mode)
-    f_func = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_func(inputs_)
-
-    w_u_, b_u_, w_l_, b_l_ = output_
-    w_u_b = np.sum(np.maximum(w_u_, 0) * W_u_ + np.minimum(w_u_, 0) * W_l_, 1)[:, :, None]
-    b_u_b = b_u_ + np.sum(np.maximum(w_u_, 0) * B_u_[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * B_l_[:, :, None], 1)
-    w_l_b = np.sum(np.maximum(w_l_, 0) * W_l_ + np.minimum(w_l_, 0) * W_u_, 1)[:, :, None]
-    b_l_b = b_l_ + np.sum(np.maximum(w_l_, 0) * B_l_[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * B_u_[:, :, None], 1)
-
-    helpers.assert_output_properties_box_linear(
-        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
+        decimal=decimal,
     )
 
 
@@ -72,24 +49,29 @@ def test_activation_backward_1D_box(n, mode, floatx, decimal, activation_func, t
 def test_activation_backward_1D_box_slope(n, slope, helpers):
     mode = ForwardMode.AFFINE
     activation_func = backward_relu
+    dc_decomp = False
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
     x_, y_, z_, u_c_, W_u_, B_u_, l_c_, W_l_, B_l_ = inputs_
 
-    input_mode = [z, W_u, b_u, W_l, b_l]
+    # backward outputs
+    outputs = activation_func(inputs_for_mode, mode=mode)
+    f_func = K.function(inputs, outputs)
+    outputs_ = f_func(inputs_)
 
-    w_out_u, b_out_u, w_out_l, b_out_l = activation_func(input_mode, mode=mode)
-    f_func = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_func(inputs_)
-
-    w_u_, b_u_, w_l_, b_l_ = output_
+    # backward recomposition
+    w_u_, b_u_, w_l_, b_l_ = outputs_
     w_u_b = np.sum(np.maximum(w_u_, 0) * W_u_ + np.minimum(w_u_, 0) * W_l_, 1)[:, :, None]
     b_u_b = b_u_ + np.sum(np.maximum(w_u_, 0) * B_u_[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * B_l_[:, :, None], 1)
     w_l_b = np.sum(np.maximum(w_l_, 0) * W_l_ + np.minimum(w_l_, 0) * W_u_, 1)[:, :, None]
     b_l_b = b_l_ + np.sum(np.maximum(w_l_, 0) * B_l_[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * B_u_[:, :, None], 1)
 
+    # check bounds according to slope
     slope = Slope(slope)
     if n == 0:
         assert_almost_equal(w_u_b, np.zeros(w_u_b.shape))

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -99,9 +99,7 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, helpers)
         + b_l_
     )
 
-    helpers.assert_output_properties_box_linear(
-        x, None, z_[:, 0], z_[:, 1], None, w_r_u, b_r_u, None, w_r_l, b_r_l, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, None, z_[:, 0], z_[:, 1], None, w_r_u, b_r_u, None, w_r_l, b_r_l)
 
     K.set_floatx("float32")
     K.set_epsilon(eps)

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -4,11 +4,9 @@
 import numpy as np
 import pytest
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import Input
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.backward_layers.convert import to_backward
-from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 
 
@@ -18,69 +16,57 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal,
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
+    dc_decomp = False
 
-    layer = DecomonConv2D(
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=dc_decomp)
+    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+
+    # decomon layer
+    decomon_layer = DecomonConv2D(
         10,
         kernel_size=(3, 3),
-        dc_decomp=False,
+        dc_decomp=dc_decomp,
         padding=padding,
         use_bias=use_bias,
         mode=mode,
         dtype=K.floatx(),
     )
+    decomon_layer(inputs_for_mode)  # init weights
 
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = layer(input_mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-        output = layer(input_mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-        output = layer(input_mode)
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
-
-    output_shape = np.prod(output[-1].shape[1:])
-
-    w_out = Input((output_shape, output_shape))
-    b_out = Input((output_shape,))
     # get backward layer
-    layer_backward = to_backward(layer)
+    backward_layer = to_backward(decomon_layer)
 
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_conv = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_conv(inputs_)
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
 
-    w_u_, b_u_, w_l_, b_l_ = output_
+    w_u_, b_u_, w_l_, b_l_ = outputs_
 
+    # reshape the matrices
     w_u_ = w_u_[:, None]
     w_l_ = w_l_[:, None]
     b_u_ = b_u_[:, None]
     b_l_ = b_l_[:, None]
 
-    # step 1: flatten W_u
+    b_l = b_l.reshape((len(b_l), -1))
+    b_u = b_u.reshape((len(b_u), -1))
     W_u = W_u.reshape((len(W_u), W_u.shape[1], -1))
     W_l = W_l.reshape((len(W_l), W_l.shape[1], -1))
 
+    # backward recomposition
     w_r_u = np.sum(np.maximum(0.0, w_u_) * np.expand_dims(W_u, -1), 2) + np.sum(
         np.minimum(0.0, w_u_) * np.expand_dims(W_l, -1), 2
     )
     w_r_l = np.sum(np.maximum(0.0, w_l_) * np.expand_dims(W_l, -1), 2) + np.sum(
         np.minimum(0.0, w_l_) * np.expand_dims(W_u, -1), 2
     )
-
-    b_l = b_l.reshape((len(b_l), -1))
-    b_u = b_u.reshape((len(b_u), -1))
-
     b_r_u = (
         np.sum(np.maximum(0, w_u_[:, 0]) * np.expand_dims(b_u, -1), 1)[:, None]
         + np.sum(np.minimum(0, w_u_[:, 0]) * np.expand_dims(b_l, -1), 1)[:, None]
@@ -92,4 +78,5 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal,
         + b_l_
     )
 
-    helpers.assert_output_properties_box_linear(x, None, z_[:, 0], z_[:, 1], None, w_r_u, b_r_u, None, w_r_l, b_r_l)
+    # check bounds consistency
+    helpers.assert_output_properties_box_linear(x, None, z[:, 0], z[:, 1], None, w_r_u, b_r_u, None, w_r_l, b_r_l)

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -12,19 +12,12 @@ from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 
 
-def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, helpers):
+def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     layer = DecomonConv2D(
         10,
@@ -100,6 +93,3 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, helpers)
     )
 
     helpers.assert_output_properties_box_linear(x, None, z_[:, 0], z_[:, 1], None, w_r_u, b_r_u, None, w_r_l, b_r_l)
-
-    K.set_floatx("float32")
-    K.set_epsilon(eps)

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -64,7 +64,6 @@ def test_Backward_Dense_1D_box(n, use_bias, mode, floatx, helpers):
         b_l_[:, 0]
         + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
         + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-        "dense_{}".format(n),
     )
 
     helpers.assert_output_properties_box_linear(
@@ -82,7 +81,6 @@ def test_Backward_Dense_1D_box(n, use_bias, mode, floatx, helpers):
         b_l_[:, 0]
         + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
         + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-        "dense_{}".format(n),
     )
 
     helpers.assert_output_properties_box_linear(
@@ -100,7 +98,6 @@ def test_Backward_Dense_1D_box(n, use_bias, mode, floatx, helpers):
         b_l_[:, 0]
         + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
         + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-        "dense_{}".format(n),
     )
 
     K.set_epsilon(eps)
@@ -150,7 +147,6 @@ def test_Backward_DecomonDense_multiD_box(odd, floatx, mode, helpers):
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -1,155 +1,112 @@
-# Test unit for decomon with Dense layers
-
-
-import numpy as np
-import pytest
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Dense, Input
-from tensorflow.keras.models import Model
 
 from decomon.backward_layers.convert import to_backward
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonDense
-from decomon.utils import Slope
 
 
-def test_Backward_Dense_1D_box(n, use_bias, mode, floatx, helpers):
+def test_Backward_Dense_1D_box(n, use_bias, mode, floatx, decimal, helpers):
+    dc_decomp = False
 
-    slope = Slope.V_SLOPE
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_dim = helpers.get_input_dim_from_full_inputs(inputs)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
-    layer_ = Dense(1, use_bias=use_bias, dtype=K.floatx())
-    input_dim = x.shape[-1]
-    layer_(inputs[1])
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-    else:
-        raise ValueError("Unknown mode.")
+    # keras layer
+    keras_layer = Dense(1, use_bias=use_bias, dtype=K.floatx())
+    keras_layer(input_ref)  # init weights
 
     # get backward layer
-    layer_backward = to_backward(layer_, input_dim=input_dim, slope=slope, mode=mode, convex_domain={})
+    backward_layer = to_backward(keras_layer, mode=mode, input_dim=input_dim)
 
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_dense(inputs_)
-    w_u_, b_u_, w_l_, b_l_ = output_
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
 
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_[:, 0], 0) * W_u + np.minimum(w_u_[:, 0], 0) * W_l, 1)[:, :, None],
-        b_u_[:, 0]
-        + np.sum(np.maximum(w_u_[:, 0], 0) * b_u[:, :, None], 1)
-        + np.sum(np.minimum(w_u_[:, 0], 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_[:, 0], 0) * W_l + np.minimum(w_l_[:, 0], 0) * W_u, 1)[:, :, None],
-        b_l_[:, 0]
-        + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
-        + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-    )
-
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_[:, 0], 0) * W_u + np.minimum(w_u_[:, 0], 0) * W_l, 1)[:, :, None],
-        b_u_[:, 0]
-        + np.sum(np.maximum(w_u_[:, 0], 0) * b_u[:, :, None], 1)
-        + np.sum(np.minimum(w_u_[:, 0], 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_[:, 0], 0) * W_l + np.minimum(w_l_[:, 0], 0) * W_u, 1)[:, :, None],
-        b_l_[:, 0]
-        + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
-        + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-    )
-
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_[:, 0], 0) * W_u + np.minimum(w_u_[:, 0], 0) * W_l, 1)[:, :, None],
-        b_u_[:, 0]
-        + np.sum(np.maximum(w_u_[:, 0], 0) * b_u[:, :, None], 1)
-        + np.sum(np.minimum(w_u_[:, 0], 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_[:, 0], 0) * W_l + np.minimum(w_l_[:, 0], 0) * W_u, 1)[:, :, None],
-        b_l_[:, 0]
-        + np.sum(np.maximum(w_l_[:, 0], 0) * b_l[:, :, None], 1)
-        + np.sum(np.minimum(w_l_[:, 0], 0) * b_u[:, :, None], 1),
-    )
-
-
-def test_Backward_DecomonDense_multiD_box(odd, floatx, decimal, mode, helpers):
-
-    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    input_dim = x.shape[-1]
-
-    layer_keras = Dense(1, use_bias=True, dtype=K.floatx())
-    layer_keras(inputs[1])
-    mode = ForwardMode(mode)
-
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-    else:
-        raise ValueError("Unknown mode.")
-
-    # get backward layer
-    layer_backward = to_backward(layer_keras, input_dim=input_dim, mode=mode, convex_domain={})
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_dense(inputs_)
-    w_u_, b_u_, w_l_, b_l_ = output_
-
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-        b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-        b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
         decimal=decimal,
     )
 
 
-def test_Backward_DecomonDense_1D_box_model(n, helpers):
-    layer = DecomonDense(1, use_bias=True, dc_decomp=False)
+def test_Backward_Dense_multiD_box(odd, floatx, decimal, mode, helpers):
+    dc_decomp = False
+    use_bias = True
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_dim = helpers.get_input_dim_from_full_inputs(inputs)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
-    output = layer(inputs[2:])
-    z_0, u_c_0, _, _, l_c_0, _, _ = output
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
+    # keras layer
+    keras_layer = Dense(1, use_bias=use_bias, dtype=K.floatx())
+    keras_layer(input_ref)  # init weights
+
+    # get backward layer
+    backward_layer = to_backward(keras_layer, mode=mode, input_dim=input_dim)
+
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
+        decimal=decimal,
+    )
+
+
+def test_Backward_DecomonDense_1D_box(n, helpers):
+    dc_decomp = False
+    use_bias = True
+    mode = ForwardMode.HYBRID
+    decimal = 5
+
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_dim = helpers.get_input_dim_from_full_inputs(inputs)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
+
+    # decomon layer
+    decomon_layer = DecomonDense(1, use_bias=use_bias, dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+    decomon_layer(inputs_for_mode)  # init weights
+
+    # get backward layer
+    backward_layer = to_backward(decomon_layer, input_dim=input_dim)
+
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
+        decimal=decimal,
+    )
+
+    # try to call the backward layer with previous bounds
     w_out = Input((1, 1))
     b_out = Input((1,))
-    # get backward layer
-    layer_backward = to_backward(layer, input_dim=1)
-    w_out_u_, b_out_u_, w_out_l_, b_out_l_ = layer_backward(inputs[2:] + [w_out, b_out, w_out, b_out])
-
-    Model(inputs[2:] + [w_out, b_out], [w_out_u_, b_out_u_, w_out_l_, b_out_l_])
+    previous_bounds = [w_out, b_out, w_out, b_out]
+    backward_layer(inputs_for_mode + previous_bounds)

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -1,11 +1,6 @@
-# Test unit for decomon with Dense layers
-
-
-import numpy as np
 import pytest
 import tensorflow.keras.backend as K
-from tensorflow.keras.layers import Input, Layer, Reshape
-from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Layer, Reshape
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.backward_layers.convert import to_backward
@@ -16,47 +11,30 @@ from decomon.utils import Slope
 
 
 def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, decimal, helpers):
-    layer = DecomonActivation(activation, dc_decomp=False, mode=mode, dtype=K.floatx())
+    dc_decomp = False
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = layer(input_mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-        output = layer(input_mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-        output = layer(input_mode)
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
-    w_out = Input((1, 1), dtype=K.floatx())
-    b_out = Input((1,), dtype=K.floatx())
+    # decomon layer
+    decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+
     # get backward layer
-    layer_backward = to_backward(layer)
-    w_out_u_, b_out_u_, w_out_l_, b_out_l_ = layer_backward(input_mode)
-    model = Model(inputs[2:], [w_out_u_, b_out_u_, w_out_l_, b_out_l_])
-    w_u_, b_u_, w_l_, b_l_ = model.predict(inputs_[2:])
+    backward_layer = to_backward(decomon_layer)
 
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-        b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-        b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
         decimal=decimal,
     )
 
@@ -64,23 +42,27 @@ def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, decimal, 
 def test_Backward_Activation_1D_box_model_slope(helpers):
     n = 2
     activation = "relu"
-    use_bias = False
     mode = ForwardMode.AFFINE
+    dc_decomp = False
 
-    layer = DecomonActivation(activation, dc_decomp=False, mode=mode, dtype=K.floatx())
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
+    #  decomon layer
+    decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+
+    # to_backward with a given slope => outputs
     outputs_by_slope = {}
     for slope in Slope:
-        layer_backward = to_backward(layer, slope=slope, mode=mode, convex_domain={})
+        layer_backward = to_backward(decomon_layer, slope=slope, mode=mode, convex_domain={})
         assert layer_backward.slope == slope
-        w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-        f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-        outputs_by_slope[slope] = f_dense(inputs_)
+        outputs = layer_backward(inputs_for_mode)
+        f_decomon = K.function(inputs, outputs)
+        outputs_by_slope[slope] = f_decomon(inputs_)
 
     # check results
     # O_Slope != Z_Slope
@@ -95,47 +77,30 @@ def test_Backward_Activation_1D_box_model_slope(helpers):
 
 
 def test_Backward_Activation_multiD_box(odd, activation, floatx, decimal, mode, helpers):
-    layer = DecomonActivation(activation, dc_decomp=False, mode=mode, dtype=K.floatx())
-    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    dc_decomp = False
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = layer(input_mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-        output = layer(input_mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-        output = layer(input_mode)
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    w_out = Input((1, 1), dtype=K.floatx())
-    b_out = Input((1,), dtype=K.floatx())
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
+
+    #  decomon layer
+    decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+
     # get backward layer
-    layer_backward = to_backward(layer)
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_dense(inputs_)
-    w_u_, b_u_, w_l_, b_l_ = output_
+    backward_layer = to_backward(decomon_layer)
 
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-        b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-        b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
         decimal=decimal,
     )
 
@@ -145,101 +110,59 @@ def test_Backward_Flatten_multiD_box(odd, floatx, decimal, mode, data_format, he
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
-    layer = DecomonFlatten("channels_last", dc_decomp=False, mode=mode, dtype=K.floatx())
-    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    dc_decomp = False
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = layer(input_mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-        output = layer(input_mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-        output = layer(input_mode)
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    # output = layer(inputs[2:])
-    # z_0, u_c_0, _, _, l_c_0, _, _ = output
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
-    w_out = Input((1, 1))
-    b_out = Input((1,))
+    #  decomon layer
+    decomon_layer = DecomonFlatten(data_format, dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+
     # get backward layer
-    layer_backward = to_backward(
-        layer,
-    )
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_dense(inputs_)
-    w_u_, b_u_, w_l_, b_l_ = output_
+    backward_layer = to_backward(decomon_layer)
 
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-        b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-        b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
         decimal=decimal,
     )
 
 
-def test_Backward_Reshape_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
-    if data_format == "channels_first" and not len(_get_available_gpus()):
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+def test_Backward_Reshape_multiD_box(odd, floatx, decimal, mode, helpers):
+    dc_decomp = False
 
-    layer = DecomonReshape((-1,), dc_decomp=False, mode=mode, dtype=K.floatx())
-    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
-    x, y, z_, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = layer(input_mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [inputs[2], inputs[4], inputs[5], inputs[7], inputs[8]]
-        output = layer(input_mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [inputs[3], inputs[6]]
-        output = layer(input_mode)
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
-    w_out = Input((1, 1), dtype=K.floatx())
-    b_out = Input((1,), dtype=K.floatx())
+    #  decomon layer
+    decomon_layer = DecomonReshape((-1,), dc_decomp=dc_decomp, mode=mode, dtype=K.floatx())
+
     # get backward layer
-    layer_backward = to_backward(layer)
-    w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
-    f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_dense(inputs_)
-    w_u_, b_u_, w_l_, b_l_ = output_
+    backward_layer = to_backward(decomon_layer)
 
-    helpers.assert_output_properties_box_linear(
-        x,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        None,
-        np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-        b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-        None,
-        np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-        b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
+    # backward outputs
+    outputs = backward_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
+
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
         decimal=decimal,
     )
 

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -64,7 +64,6 @@ def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, helpers):
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "activation_{}".format(activation),
         decimal=decimal,
     )
 
@@ -159,7 +158,6 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, mode, helpers):
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     """
@@ -243,7 +241,6 @@ def test_Backward_Flatten_multiD_box(odd, floatx, mode, data_format, helpers):
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")
@@ -305,7 +302,6 @@ def test_Backward_Reshape_multiD_box(odd, floatx, mode, data_format, helpers):
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -15,14 +15,7 @@ from decomon.layers.decomon_reshape import DecomonReshape
 from decomon.utils import Slope
 
 
-def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, helpers):
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, decimal, helpers):
     layer = DecomonActivation(activation, dc_decomp=False, mode=mode, dtype=K.floatx())
 
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
@@ -67,9 +60,6 @@ def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, helpers):
         decimal=decimal,
     )
 
-    K.set_floatx("float32")
-    K.set_epsilon(eps)
-
 
 def test_Backward_Activation_1D_box_model_slope(helpers):
     n = 2
@@ -104,15 +94,7 @@ def test_Backward_Activation_1D_box_model_slope(helpers):
         assert (a == b).all()
 
 
-def test_Backward_Activation_multiD_box(odd, activation, floatx, mode, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_Backward_Activation_multiD_box(odd, activation, floatx, decimal, mode, helpers):
     layer = DecomonActivation(activation, dc_decomp=False, mode=mode, dtype=K.floatx())
     inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
     inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
@@ -134,16 +116,12 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, mode, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    # output = layer(inputs[2:])
-    # z_0, u_c_0, _, _, l_c_0, _, _ = output
-
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
     # get backward layer
     layer_backward = to_backward(layer)
     w_out_u, b_out_u, w_out_l, b_out_l = layer_backward(input_mode)
     f_dense = K.function(inputs, [w_out_u, b_out_u, w_out_l, b_out_l])
-    # import pdb; pdb.set_trace()
     output_ = f_dense(inputs_)
     w_u_, b_u_, w_l_, b_l_ = output_
 
@@ -160,40 +138,12 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, mode, helpers):
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
         decimal=decimal,
     )
-    """
-    try:
-        assert_output_properties_box_linear(
-            x,
-            None,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            np.sum(np.maximum(w_u_, 0) * W_u + np.minimum(w_u_, 0) * W_l, 1)[:, :, None],
-            b_u_ + np.sum(np.maximum(w_u_, 0) * b_u[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * b_l[:, :, None], 1),
-            None,
-            np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
-            b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-            "dense_{}".format(odd),
-            decimal=decimal,
-        )
-    except ValueError:
-        import pdb; pdb.set_trace()
-    """
-    K.set_floatx("float32")
-    K.set_epsilon(eps)
 
 
-def test_Backward_Flatten_multiD_box(odd, floatx, mode, data_format, helpers):
+def test_Backward_Flatten_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     layer = DecomonFlatten("channels_last", dc_decomp=False, mode=mode, dtype=K.floatx())
     inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
@@ -243,20 +193,11 @@ def test_Backward_Flatten_multiD_box(odd, floatx, mode, data_format, helpers):
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
         decimal=decimal,
     )
-    K.set_floatx("float32")
-    K.set_epsilon(eps)
 
 
-def test_Backward_Reshape_multiD_box(odd, floatx, mode, data_format, helpers):
+def test_Backward_Reshape_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     layer = DecomonReshape((-1,), dc_decomp=False, mode=mode, dtype=K.floatx())
     inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
@@ -278,9 +219,6 @@ def test_Backward_Reshape_multiD_box(odd, floatx, mode, data_format, helpers):
         u_c_0, l_c_0 = output
     else:
         raise ValueError("Unknown mode.")
-
-    # output = layer(inputs[2:])
-    # z_0, u_c_0, _, _, l_c_0, _, _ = output
 
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
@@ -304,8 +242,6 @@ def test_Backward_Reshape_multiD_box(odd, floatx, mode, data_format, helpers):
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
         decimal=decimal,
     )
-    K.set_floatx("float32")
-    K.set_epsilon(eps)
 
 
 def test_to_backward_ko():

--- a/tests/test_backward_layers_get_config.py
+++ b/tests/test_backward_layers_get_config.py
@@ -1,5 +1,5 @@
 import pytest
-from keras.layers import Layer
+from tensorflow.keras.layers import Layer
 
 from decomon.backward_layers.backward_layers import (
     BackwardActivation,

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -63,7 +63,6 @@ def test_Backward_NativeActivation_1D_box_model(n, activation, mode, floatx, hel
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "activation_{}".format(activation),
         decimal=decimal,
     )
 
@@ -125,7 +124,6 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, mode, hel
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")
@@ -189,7 +187,6 @@ def test_Backward_NativeFlatten_multiD_box(odd, floatx, mode, data_format, helpe
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")
@@ -251,7 +248,6 @@ def test_Backward_NativeReshape_multiD_box(odd, floatx, mode, data_format, helpe
         None,
         np.sum(np.maximum(w_l_, 0) * W_l + np.minimum(w_l_, 0) * W_u, 1)[:, :, None],
         b_l_ + np.sum(np.maximum(w_l_, 0) * b_l[:, :, None], 1) + np.sum(np.minimum(w_l_, 0) * b_u[:, :, None], 1),
-        "dense_{}".format(odd),
         decimal=decimal,
     )
     K.set_floatx("float32")

--- a/tests/test_backward_utils.py
+++ b/tests/test_backward_utils.py
@@ -12,8 +12,6 @@ from decomon.backward_layers.utils import (
     backward_relu_,
     backward_subtract,
 )
-from decomon.layers.core import ForwardMode
-from decomon.utils import relu_, subtract
 
 
 def add_op(x, y):
@@ -25,50 +23,31 @@ def subtract_op(x, y):
 
 
 def test_relu_backward_1D_box(n, mode, floatx, decimal, helpers):
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
+    dc_decomp = False
 
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs=inputs_)
+    batchsize = input_ref_.shape[0]
 
     x_, y_, z_, u_c_, W_u_, B_u_, l_c_, W_l_, B_l_ = inputs_
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_mode = inputs[2:]
-        output = relu_(input_mode, dc_decomp=False, mode=mode)
-        z_0, u_c_0, _, _, l_c_0, _, _ = output
-    elif mode == ForwardMode.AFFINE:
-        input_mode = [z, W_u, b_u, W_l, b_l]
-        output = relu_(input_mode, dc_decomp=False, mode=mode)
-        z_0, _, _, _, _ = output
-    elif mode == ForwardMode.IBP:
-        input_mode = [u_c, l_c]
-        output = relu_(input_mode, dc_decomp=False, mode=mode)
-        z_0 = z_
-        u_c_0, l_c_0 = output
-    else:
-        raise ValueError("Unknown mode.")
-
+    # backward outputs
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1), dtype=K.floatx())
+    outputs = backward_relu_(inputs_for_mode, w_out, b_out, w_out, b_out, mode=mode)
+    f_decomon = K.function(inputs + [w_out, b_out], outputs)
+    outputs_ = f_decomon(inputs_ + [np.ones((batchsize, 1, 1)), np.zeros((batchsize, 1))])
 
-    w_out_u, b_out_u, w_out_l, b_out_l = backward_relu_(input_mode, w_out, b_out, w_out, b_out, mode=mode)
-
-    f_relu = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
-    output_ = f_relu(inputs_ + [np.ones((len(x_), 1, 1)), np.zeros((len(x_), 1))])
-    w_u_, b_u_, w_l_, b_l_ = output_
-
-    w_u_b = np.sum(np.maximum(w_u_, 0) * W_u_ + np.minimum(w_u_, 0) * W_l_, 1)[:, :, None]
-    b_u_b = b_u_ + np.sum(np.maximum(w_u_, 0) * B_u_[:, :, None], 1) + np.sum(np.minimum(w_u_, 0) * B_l_[:, :, None], 1)
-    w_l_b = np.sum(np.maximum(w_l_, 0) * W_l_ + np.minimum(w_l_, 0) * W_u_, 1)[:, :, None]
-    b_l_b = (
-        b_l_
-        + np.sum(np.maximum(w_l_[:, 0], 0) * B_l_[:, :, None], 1)
-        + np.sum(np.minimum(w_l_[:, 0], 0) * B_u_[:, :, None], 1)
-    )
-
-    helpers.assert_output_properties_box_linear(
-        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
+    # check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_,
+        backward_outputs=outputs_,
+        decimal=decimal,
     )
 
 
@@ -89,85 +68,55 @@ def test_relu_backward_1D_box(n, mode, floatx, decimal, helpers):
     ],
 )
 def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx, decimal, helpers):
-    inputs_0 = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_0_ = helpers.get_standard_values_1d_box(n_0, dc_decomp=False)
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0 = inputs_0_
+    dc_decomp = False
 
-    inputs_1 = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_1_ = helpers.get_standard_values_1d_box(n_1, dc_decomp=False)
+    #  tensor inputs
+    inputs_0 = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode_0 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_0, mode=mode, dc_decomp=dc_decomp)
+    inputs_1 = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode_1 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1, mode=mode, dc_decomp=dc_decomp)
+
+    # numpy inputs
+    inputs_0_ = helpers.get_standard_values_1d_box(n_0, dc_decomp=dc_decomp)
+    inputs_1_ = helpers.get_standard_values_1d_box(n_1, dc_decomp=dc_decomp)
+    input_ref_0_ = helpers.get_input_ref_from_full_inputs(inputs=inputs_0_)
+    batchsize = input_ref_0_.shape[0]
+
+    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0 = inputs_0_
     x_1, y_1, z_1, u_c_1, W_u_1, b_u_1, l_c_1, W_l_1, b_l_1 = inputs_1_
 
+    # backward outputs
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1,), dtype=K.floatx())
-
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        input_tmp_0 = inputs_0[2:]
-        input_tmp_1 = inputs_1[2:]
-    elif mode == ForwardMode.IBP:
-        input_tmp_0 = [inputs_0[3], inputs_0[6]]
-        input_tmp_1 = [inputs_1[3], inputs_1[6]]
-    elif mode == ForwardMode.AFFINE:
-        input_tmp_0 = [inputs_0[2], inputs_0[4], inputs_0[5], inputs_0[7], inputs_0[8]]
-        input_tmp_1 = [inputs_1[2], inputs_1[4], inputs_1[5], inputs_1[7], inputs_1[8]]
-    else:
-        raise ValueError("Unknown mode.")
-
-    back_bounds_0, back_bounds_1 = backward_func(input_tmp_0, input_tmp_1, w_out, b_out, w_out, b_out, mode=mode)
+    back_bounds_0, back_bounds_1 = backward_func(
+        inputs_for_mode_0, inputs_for_mode_1, w_out, b_out, w_out, b_out, mode=mode
+    )
     f_add = K.function(inputs_0 + inputs_1 + [w_out, b_out], back_bounds_0 + back_bounds_1)
-    output_ = f_add(inputs_0_ + inputs_1_ + [np.ones((len(x_0), 1, 1)), np.zeros((len(x_0), 1))])
-    w_u_0_, b_u_0_, w_l_0_, b_l_0_, w_u_1_, b_u_1_, w_l_1_, b_l_1_ = output_
+    outputs_ = f_add(inputs_0_ + inputs_1_ + [np.ones((batchsize, 1, 1)), np.zeros((batchsize, 1))])
+    # get back separate outputs
+    outputs_0_ = outputs_[: len(outputs_) // 2]
+    outputs_1_ = outputs_[len(outputs_) // 2 :]
 
-    w_u_b_0 = np.sum(np.maximum(w_u_0_, 0) * W_u_0 + np.minimum(w_u_0_, 0) * W_l_0, 1)[:, :, None]
-    b_u_b_0 = (
-        b_u_0_
-        + np.sum(np.maximum(w_u_0_, 0) * b_u_0[:, :, None], 1)
-        + np.sum(np.minimum(w_u_0_, 0) * b_l_0[:, :, None], 1)
-    )
-    w_l_b_0 = np.sum(np.maximum(w_l_0_, 0) * W_l_0 + np.minimum(w_l_0_, 0) * W_u_0, 1)[:, :, None]
-    b_l_b_0 = (
-        b_l_0_
-        + np.sum(np.maximum(w_l_0_, 0) * b_l_0[:, :, None], 1)
-        + np.sum(np.minimum(w_l_0_, 0) * b_u_0[:, :, None], 1)
-    )
+    # reference output and constant lower and upper bounds
+    output_ref = tensor_op(y_0, y_1)
+    upper_constant_bound = tensor_op(u_c_0, u_c_1)
+    lower_constant_bound = tensor_op(l_c_0, l_c_1)
 
-    w_u_b_1 = np.sum(np.maximum(w_u_1_, 0) * W_u_1 + np.minimum(w_u_1_, 0) * W_l_1, 1)[:, :, None]
-    b_u_b_1 = (
-        b_u_1_
-        + np.sum(np.maximum(w_u_1_, 0) * b_u_1[:, :, None], 1)
-        + np.sum(np.minimum(w_u_1_, 0) * b_l_1[:, :, None], 1)
-    )
-    w_l_b_1 = np.sum(np.maximum(w_l_1_, 0) * W_l_1 + np.minimum(w_l_1_, 0) * W_u_1, 1)[:, :, None]
-    b_l_b_1 = (
-        b_l_1_
-        + np.sum(np.maximum(w_l_1_, 0) * b_l_1[:, :, None], 1)
-        + np.sum(np.minimum(w_l_1_, 0) * b_u_1[:, :, None], 1)
-    )
-
-    helpers.assert_output_properties_box_linear(
-        x_0,
-        tensor_op(y_0, y_1),
-        z_0[:, 0],
-        z_0[:, 1],
-        tensor_op(u_c_0, u_c_1),
-        w_u_b_0,
-        b_u_b_0,
-        tensor_op(l_c_0, l_c_1),
-        w_l_b_0,
-        b_l_b_0,
+    #  check bounds consistency
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_0_,
+        backward_outputs=outputs_0_,
         decimal=decimal,
+        output_ref=output_ref,
+        upper_constant_bound=upper_constant_bound,
+        lower_constant_bound=lower_constant_bound,
     )
 
-    helpers.assert_output_properties_box_linear(
-        x_1,
-        tensor_op(y_0, y_1),
-        z_1[:, 0],
-        z_1[:, 1],
-        tensor_op(u_c_0, u_c_1),
-        w_u_b_1,
-        b_u_b_1,
-        tensor_op(l_c_0, l_c_1),
-        w_l_b_1,
-        b_l_b_1,
+    helpers.assert_backward_layer_output_properties_box_linear(
+        full_inputs=inputs_1_,
+        backward_outputs=outputs_1_,
         decimal=decimal,
+        output_ref=output_ref,
+        upper_constant_bound=upper_constant_bound,
+        lower_constant_bound=lower_constant_bound,
     )

--- a/tests/test_backward_utils.py
+++ b/tests/test_backward_utils.py
@@ -24,15 +24,7 @@ def subtract_op(x, y):
     return x - y
 
 
-def test_relu_backward_1D_box(n, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_relu_backward_1D_box(n, mode, floatx, decimal, helpers):
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
 
@@ -60,7 +52,6 @@ def test_relu_backward_1D_box(n, mode, floatx, helpers):
     w_out = Input((1, 1), dtype=K.floatx())
     b_out = Input((1), dtype=K.floatx())
 
-    # backward_relu_(input_mode, w_out, b_out, w_out, b_out, mode=mode)
     w_out_u, b_out_u, w_out_l, b_out_l = backward_relu_(input_mode, w_out, b_out, w_out, b_out, mode=mode)
 
     f_relu = K.function(inputs + [w_out, b_out], [w_out_u, b_out_u, w_out_l, b_out_l])
@@ -80,9 +71,6 @@ def test_relu_backward_1D_box(n, mode, floatx, helpers):
         x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
     )
 
-    K.set_epsilon(eps)
-    K.set_floatx("float32")
-
 
 @pytest.mark.parametrize(
     "n_0, n_1",
@@ -100,15 +88,7 @@ def test_relu_backward_1D_box(n, mode, floatx, helpers):
         (backward_subtract, subtract_op),
     ],
 )
-def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_0_ = helpers.get_standard_values_1d_box(n_0, dc_decomp=False)
     x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0 = inputs_0_
@@ -191,6 +171,3 @@ def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx
         b_l_b_1,
         decimal=decimal,
     )
-
-    K.set_epsilon(eps)
-    K.set_floatx("float32")

--- a/tests/test_backward_utils.py
+++ b/tests/test_backward_utils.py
@@ -77,7 +77,7 @@ def test_relu_backward_1D_box(n, mode, floatx, helpers):
     )
 
     helpers.assert_output_properties_box_linear(
-        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, "dense_{}".format(n), decimal=decimal
+        x_, None, z_[:, 0], z_[:, 1], None, w_u_b, b_u_b, None, w_l_b, b_l_b, decimal=decimal
     )
 
     K.set_epsilon(eps)
@@ -175,7 +175,6 @@ def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx
         tensor_op(l_c_0, l_c_1),
         w_l_b_0,
         b_l_b_0,
-        "dense_{}".format(n_0),
         decimal=decimal,
     )
 
@@ -190,7 +189,6 @@ def test_reduce_backward_1D_box(n_0, n_1, backward_func, tensor_op, mode, floatx
         tensor_op(l_c_0, l_c_1),
         w_l_b_1,
         b_l_b_1,
-        "dense_{}".format(n_1),
         decimal=decimal,
     )
 

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -32,17 +32,10 @@ else:
 deel_lip_skip_reason = "deel-lip is not available"
 
 
-def test_convert_1D(n, method, mode, floatx, helpers):
+def test_convert_1D(n, method, mode, floatx, decimal, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x_, y_, z_, u_c_, W_u_, b_u_, l_c_, W_l_, b_l_ = inputs_
@@ -88,14 +81,11 @@ def test_convert_1D(n, method, mode, floatx, helpers):
         b_l_model,
         decimal=decimal,
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_convert_1D_forward_slope(slope, helpers):
     n, method, mode = 0, "forward-hybrid", "hybrid"
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
 
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
     ref_nn(inputs[1])
@@ -114,7 +104,6 @@ def test_convert_1D_forward_slope(slope, helpers):
 def test_convert_1D_backward_slope(slope, helpers):
     n, method, mode = 0, "crown-forward-hybrid", "hybrid"
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
 
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
     ref_nn(inputs[1])
@@ -195,7 +184,6 @@ def test_name_backward_deellip():
 
 @pytest.mark.skipif(not (deel_lip_available), reason=deel_lip_skip_reason)
 def test_clone_full_deellip_model_forward(helpers):
-    decimal = 5
     target_shape = (6, 6, 2)
     input_shape = (np.prod(target_shape),)
     model = DeellipSequential(

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -86,7 +86,6 @@ def test_convert_1D(n, method, mode, floatx, helpers):
         l_c_model,
         w_l_model,
         b_l_model,
-        "clone_{}".format(n),
         decimal=decimal,
     )
     K.set_floatx("float{}".format(32))

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -96,7 +96,6 @@ def test_convert_backward_1D(n, mode, floatx, helpers):
         l_c_model,
         w_l_model,
         b_l_model,
-        "convert_backward_{}".format(n),
         decimal=decimal,
     )
     K.set_floatx("float{}".format(32))

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -1,47 +1,34 @@
 # creating toy network and assess that the decomposition is correct
 
 
-import numpy as np
 import tensorflow.keras.backend as K
 
-from decomon.layers.core import ForwardMode
+from decomon.backward_layers.utils import get_affine, get_ibp
 from decomon.models.backward_cloning import convert_backward
 from decomon.models.forward_cloning import convert_forward
 
 
 def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
-    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
-    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
-    x_, y_, z_, u_c_, W_u_, b_u_, l_c_, W_l_, b_l_ = inputs_
+    ibp = get_ibp(mode=mode)
+    affine = get_affine(mode=mode)
+    dc_decomp = False
 
-    # We force W & b to be identity and zeros
-    b_u_ = np.zeros_like(b_u_)
-    b_l_ = np.zeros_like(b_l_)
-    W_u_ = np.repeat(np.identity(n=W_u_.shape[-1])[None, :, :], repeats=W_u_.shape[0], axis=0)
-    W_l_ = np.repeat(np.identity(n=W_l_.shape[-1])[None, :, :], repeats=W_l_.shape[0], axis=0)
-    inputs_ = x_, y_, z_, u_c_, W_u_, b_u_, l_c_, W_l_, b_l_
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    input_tensors = helpers.get_input_tensors_for_decomon_convert_from_full_inputs(
+        inputs=inputs, mode=mode, dc_decomp=dc_decomp
+    )
 
-    input_ref = y_
-    input_box_tensor = K.concatenate([K.expand_dims(l_c, 1), K.expand_dims(u_c, 1)], 1)
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
+    inputs_ = helpers.prepare_full_np_inputs_for_convert_model(inputs_, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
 
+    # keras model and output of reference
     ref_nn = helpers.toy_network_tutorial(dtype=K.floatx())
-    output_ref = ref_nn.predict(input_ref)
+    output_ref_ = ref_nn.predict(input_ref_)
 
-    ibp = True
-    affine = True
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.AFFINE:
-        ibp = False
-    elif mode == ForwardMode.IBP:
-        affine = False
-
-    input_tensors = [input_box_tensor, u_c, W_u, b_u, l_c, W_l, b_l]
-    if mode == ForwardMode.IBP:
-        input_tensors = [u_c, l_c]
-    if mode == ForwardMode.AFFINE:
-        input_tensors = [input_box_tensor, W_u, b_u, W_l, b_l]
-
+    # decomon conversion
     back_bounds = []
     _, _, _, forward_map = convert_forward(
         ref_nn,
@@ -49,11 +36,9 @@ def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
         affine=affine,
         shared=True,
         input_tensors=input_tensors,
-        final_ibp=ibp,
-        final_affine=affine,
         back_bounds=back_bounds,
     )
-    _, output, _, _ = convert_backward(
+    _, outputs, _, _ = convert_backward(
         ref_nn,
         input_tensors=input_tensors,
         ibp=ibp,
@@ -64,30 +49,16 @@ def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
         back_bounds=back_bounds,
     )
 
-    f_decomon = K.function(inputs, output)
+    # decomon outputs
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
 
-    u_c_model, w_u_model, b_u_model, l_c_model, w_l_model, b_l_model = [None] * 6
-    if mode == ForwardMode.HYBRID:
-        z_model, u_c_model, w_u_model, b_u_model, l_c_model, w_l_model, b_l_model = f_decomon(inputs_)
-    elif mode == ForwardMode.IBP:
-        u_c_model, l_c_model = f_decomon(inputs_)
-    elif mode == ForwardMode.AFFINE:
-        z_model, w_u_model, b_u_model, w_l_model, b_l_model = f_decomon(inputs_)
-    else:
-        raise ValueError("Unknown mode.")
-
-    helpers.assert_output_properties_box(
-        input_ref,
-        output_ref,
-        None,
-        None,
-        l_c_,
-        u_c_,
-        u_c_model,
-        w_u_model,
-        b_u_model,
-        l_c_model,
-        w_l_model,
-        b_l_model,
+    # check bounds consistency
+    helpers.assert_decomon_model_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        mode=mode,
+        dc_decomp=dc_decomp,
         decimal=decimal,
     )

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -9,14 +9,7 @@ from decomon.models.backward_cloning import convert_backward
 from decomon.models.forward_cloning import convert_forward
 
 
-def test_convert_backward_1D(n, mode, floatx, helpers):
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
@@ -98,5 +91,3 @@ def test_convert_backward_1D(n, mode, floatx, helpers):
         b_l_model,
         decimal=decimal,
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -86,7 +86,6 @@ def test_convert_forward_1D(n, mode, floatx, helpers):
         l_c_model,
         w_l_model,
         b_l_model,
-        "convert_forward_{}".format(n),
         decimal=decimal,
     )
     K.set_floatx("float{}".format(32))

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -19,14 +19,7 @@ from decomon.layers.core import ForwardMode
 from decomon.models.forward_cloning import convert_forward
 
 
-def test_convert_forward_1D(n, mode, floatx, helpers):
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_convert_forward_1D(n, mode, floatx, decimal, helpers):
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs
@@ -88,5 +81,3 @@ def test_convert_forward_1D(n, mode, floatx, helpers):
         b_l_model,
         decimal=decimal,
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -19,53 +19,6 @@ from decomon.layers.core import ForwardMode
 from decomon.models.forward_cloning import convert_forward
 
 
-# @pytest.mark.parametrize(
-#    "n, activation, mode, shared, floatx",
-#
-def test_toy_network_1D(helpers, n, archi=None, activation="relu", use_bias=True):
-
-    if archi is None:
-        archi = [4, 1]
-    inputs = helpers.get_tensor_decomposition_1d_box()
-    inputs_ = helpers.get_standard_values_1d_box(n)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
-
-    seq_nn = helpers.dense_NN_1D(1, archi, True, activation, use_bias)
-    model_nn = helpers.dense_NN_1D(1, archi, False, activation, use_bias)
-
-    _ = seq_nn.predict(y)
-    _ = model_nn.predict(y)
-    model_nn.set_weights(seq_nn.get_weights())
-
-    y_0 = seq_nn.predict(y)
-    y_1 = model_nn.predict(y)
-
-    np.allclose(y_0, y_1)
-
-
-def test_toy_network_multiD(helpers, odd, archi=None, activation="relu", use_bias=True):
-
-    if archi is None:
-        archi = [4, 1]
-    inputs = helpers.get_tensor_decomposition_multid_box(odd)
-    inputs_ = helpers.get_standard_values_multid_box(odd)
-
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
-
-    seq_nn = helpers.dense_NN_1D(y.shape[-1], archi, True, activation, use_bias)
-    model_nn = helpers.dense_NN_1D(y.shape[-1], archi, False, activation, use_bias)
-
-    _ = seq_nn.predict(y)
-    _ = model_nn.predict(y)
-    model_nn.set_weights(seq_nn.get_weights())
-
-    y_0 = seq_nn.predict(y)
-    y_1 = model_nn.predict(y)
-
-    np.allclose(y_0, y_1)
-
-
-# network from tutorial 1
 def test_convert_forward_1D(n, mode, floatx, helpers):
     K.set_floatx("float{}".format(floatx))
     eps = K.epsilon()

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -62,20 +62,7 @@ def test_Decomon_conv_box(data_format, mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        None,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "conv_{}_{}_{}_{}".format(data_format, odd, m_0, m_1),
-        decimal=decimal,
+        x_, None, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
     decomon_layer.set_weights([np.minimum(0.0, W_), bias])
 
@@ -92,20 +79,7 @@ def test_Decomon_conv_box(data_format, mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        None,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "conv_{}_{}_{}_{}".format(data_format, odd, m_0, m_1),
-        decimal=decimal,
+        x_, None, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -140,12 +114,12 @@ def test_Decomon_conv_box_nodc(data_format, floatx, helpers):
 
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
     helpers.assert_output_properties_box_linear(
-        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc", decimal=decimal
+        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
     decomon_layer.set_weights([np.minimum(0.0, W_), bias])
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
     helpers.assert_output_properties_box_linear(
-        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc", decimal=decimal
+        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -182,20 +156,7 @@ def test_Decomon_conv_to_decomon_box(shared, floatx, helpers):
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
 
     helpers.assert_output_properties_box(
-        x,
-        y_ref,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "conv_{}_{}_{}_{}".format(data_format, odd, m_0, m_1),
-        decimal=decimal,
+        x, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -223,6 +184,4 @@ def test_Decomon_conv_to_decomon_box_nodc(helpers):
 
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
 
-    helpers.assert_output_properties_box_linear(
-        x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -7,156 +7,115 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Conv2D
 from tensorflow.python.keras.backend import _get_available_gpus
 
+from decomon.backward_layers.utils import get_affine, get_ibp
 from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 
 
-def test_Decomon_conv_box(data_format, mode, floatx, decimal, helpers):
+def test_Decomon_conv_box(data_format, mode, dc_decomp, floatx, decimal, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
+    kwargs_layer = dict(filters=10, kernel_size=(3, 3), dtype=K.floatx(), data_format=data_format)
 
-    decomon_layer = DecomonConv2D(
-        10, kernel_size=(3, 3), dc_decomp=True, mode=mode, data_format=data_format, dtype=K.floatx()
-    )
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs
-    x_ = inputs_[0]
-    z_ = inputs_[2]
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=dc_decomp)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = decomon_layer(inputs[2:])
-    elif mode == ForwardMode.AFFINE:
-        output = decomon_layer([z, W_u, b_u, W_l, b_l, h, g])
-    elif mode == ForwardMode.IBP:
-        output = decomon_layer([u_c, l_c, h, g])
-    else:
-        raise ValueError("Unknown mode.")
+    # decomon layer
+    decomon_layer = DecomonConv2D(dc_decomp=dc_decomp, mode=mode, **kwargs_layer)
 
+    # original output  (not computed here)
+    output_ref_ = None
+
+    # decomon function
+    outputs = decomon_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+
+    # test with several kernel (negative or positive part)
     W_, bias = decomon_layer.get_weights()
-    decomon_layer.set_weights([np.maximum(0.0, W_), bias])
-    f_conv = K.function(inputs[2:], output)
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
-        u_c_ = None
-        l_c_ = None
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_conv(inputs_[2:])
-        w_u_, b_u_, w_l_, b_l_ = [None] * 4
-    else:
-        raise ValueError("Unknown mode.")
-
-    helpers.assert_output_properties_box(
-        x_, None, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-    )
-    decomon_layer.set_weights([np.minimum(0.0, W_), bias])
-
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
-        u_c_ = None
-        l_c_ = None
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_conv(inputs_[2:])
-        w_u_, b_u_, w_l_, b_l_ = [None] * 4
-    else:
-        raise ValueError("Unknown mode.")
-
-    helpers.assert_output_properties_box(
-        x_, None, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-    )
+    for np_function in [np.maximum, np.minimum]:
+        decomon_layer.set_weights([np_function(0.0, W_), bias])
+        outputs_ = f_decomon(inputs_)
+        # check bounds consistency
+        if dc_decomp:
+            helpers.assert_decomon_layer_output_properties_box(
+                full_inputs=inputs_,
+                output_ref=output_ref_,
+                outputs_for_mode=outputs_,
+                dc_decomp=dc_decomp,
+                decimal=decimal,
+                mode=mode,
+            )
+        else:
+            helpers.assert_decomon_layer_output_properties_box_linear(
+                full_inputs=inputs_,
+                output_ref=output_ref_,
+                outputs_for_mode=outputs_,
+                dc_decomp=dc_decomp,
+                decimal=decimal,
+                mode=mode,
+            )
 
 
-def test_Decomon_conv_box_nodc(data_format, floatx, decimal, helpers):
-
-    if data_format == "channels_first" and not len(_get_available_gpus()):
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
-
-    odd, m_0, m_1 = 0, 0, 1
-
-    decomon_layer = DecomonConv2D(10, kernel_size=(3, 3), dc_decomp=False, dtype=K.floatx())
-
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=False)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-
-    output = decomon_layer(inputs[2:])
-
-    W_, bias = decomon_layer.get_weights()
-    decomon_layer.set_weights([np.maximum(0.0, W_), bias])
-    f_conv = K.function(inputs[2:], output)
-
-    z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
-    helpers.assert_output_properties_box_linear(
-        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-    )
-    decomon_layer.set_weights([np.minimum(0.0, W_), bias])
-    z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
-    helpers.assert_output_properties_box_linear(
-        x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-    )
-
-
-def test_Decomon_conv_to_decomon_box(shared, floatx, helpers):
+def test_Decomon_conv_to_decomon_box(shared, floatx, dc_decomp, helpers):
     data_format = "channels_last"
     odd, m_0, m_1 = 0, 0, 1
+    dc_decomp = True
+    mode = ForwardMode.HYBRID
+    ibp = get_ibp(mode=mode)
+    affine = get_affine(mode=mode)
+    kwargs_layer = dict(filters=10, kernel_size=(3, 3), dtype=K.floatx(), data_format=data_format)
 
     if floatx == 16:
         decimal = 1
     else:
         decimal = 5
 
-    conv_ref = Conv2D(10, kernel_size=(3, 3), dtype=K.floatx())
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
-    output_ref = conv_ref(inputs[1])
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=dc_decomp)
 
-    input_dim = x.shape[-1]
-    decomon_layer = to_decomon(conv_ref, input_dim, dc_decomp=True, shared=shared)
-    output = decomon_layer(inputs[2:])
-
+    # keras layer & function & output
+    keras_layer = Conv2D(**kwargs_layer)
+    output_ref = keras_layer(input_ref)
     f_ref = K.function(inputs, output_ref)
+    output_ref_ = f_ref(inputs_)
 
-    f_conv = K.function(inputs[2:], output)
-    y_ref = f_ref(inputs_)
+    #  decomon layer & function & output via to_decomon
+    input_dim = helpers.get_input_dim_from_full_inputs(inputs)
+    decomon_layer = to_decomon(keras_layer, input_dim, dc_decomp=dc_decomp, shared=shared, ibp=ibp, affine=affine)
+    outputs = decomon_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
 
-    z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_conv(inputs_[2:])
-
-    helpers.assert_output_properties_box(
-        x, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-    )
-
-
-def test_Decomon_conv_to_decomon_box_nodc(helpers):
-    data_format = "channels_last"
-    odd, m_0, m_1 = 0, 0, 1
-
-    conv_ref = Conv2D(10, kernel_size=(3, 3))
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=False)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-
-    output_ref = conv_ref(inputs[1])
-
-    input_dim = x.shape[-1]
-    decomon_layer = to_decomon(conv_ref, input_dim, dc_decomp=False)
-    output = decomon_layer(inputs[2:])
-
-    f_ref = K.function(inputs, output_ref)
-    f_conv = K.function(inputs[2:], output)
-    y_ref = f_ref(inputs_)
-
-    z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_conv(inputs_[2:])
-
-    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
+    # check bounds consistency
+    if dc_decomp:
+        helpers.assert_decomon_layer_output_properties_box(
+            full_inputs=inputs_,
+            output_ref=output_ref_,
+            outputs_for_mode=outputs_,
+            dc_decomp=dc_decomp,
+            decimal=decimal,
+            mode=mode,
+        )
+    else:
+        helpers.assert_decomon_layer_output_properties_box_linear(
+            full_inputs=inputs_,
+            output_ref=output_ref_,
+            outputs_for_mode=outputs_,
+            dc_decomp=dc_decomp,
+            decimal=decimal,
+            mode=mode,
+        )

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -12,19 +12,12 @@ from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonConv2D
 
 
-def test_Decomon_conv_box(data_format, mode, floatx, helpers):
+def test_Decomon_conv_box(data_format, mode, floatx, decimal, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 4
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     decomon_layer = DecomonConv2D(
         10, kernel_size=(3, 3), dc_decomp=True, mode=mode, data_format=data_format, dtype=K.floatx()
@@ -82,23 +75,13 @@ def test_Decomon_conv_box(data_format, mode, floatx, helpers):
         x_, None, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_Decomon_conv_box_nodc(data_format, floatx, helpers):
+def test_Decomon_conv_box_nodc(data_format, floatx, decimal, helpers):
 
     if data_format == "channels_first" and not len(_get_available_gpus()):
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     decomon_layer = DecomonConv2D(10, kernel_size=(3, 3), dc_decomp=False, dtype=K.floatx())
 
@@ -122,20 +105,15 @@ def test_Decomon_conv_box_nodc(data_format, floatx, helpers):
         x, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
-
 
 def test_Decomon_conv_to_decomon_box(shared, floatx, helpers):
     data_format = "channels_last"
     odd, m_0, m_1 = 0, 0, 1
 
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 4
     if floatx == 16:
-        K.set_epsilon(1e-2)
         decimal = 1
+    else:
+        decimal = 5
 
     conv_ref = Conv2D(10, kernel_size=(3, 3), dtype=K.floatx())
     inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
@@ -158,9 +136,6 @@ def test_Decomon_conv_to_decomon_box(shared, floatx, helpers):
     helpers.assert_output_properties_box(
         x, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
-
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_Decomon_conv_to_decomon_box_nodc(helpers):

--- a/tests/test_decomon_activation_layer.py
+++ b/tests/test_decomon_activation_layer.py
@@ -31,8 +31,8 @@ def test_decomon_activation_slope(helpers):
         x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs  # tensors
         inputs_for_mode = [z, W_u, b_u, W_l, b_l]
         output = layer(inputs_for_mode)
-        f_func = K.function(inputs[2:], output)
-        outputs_by_slope[slope] = f_func(inputs_[2:])
+        f_func = K.function(inputs, output)
+        outputs_by_slope[slope] = f_func(inputs_)
 
     # check results
     # O_Slope != Z_Slope

--- a/tests/test_decomon_reset_layer.py
+++ b/tests/test_decomon_reset_layer.py
@@ -22,7 +22,8 @@ def test_decomondense_reset_layer(helpers, use_bias):
     layer(tf.zeros((2, input_dim)))
     decomon_layer = DecomonDense(units=units, use_bias=use_bias, mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
-    decomon_layer(inputs[2:])
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    decomon_layer(inputs_for_mode)
 
     kernel = layer.kernel
     layer.kernel.assign(2 * np.ones_like(kernel))
@@ -52,7 +53,8 @@ def test_decomondense_reset_layer_decomon_with_new_weights(helpers):
     layer(tf.zeros((2, input_dim)))
     decomon_layer = DecomonDense(units=units, mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
-    decomon_layer(inputs[2:])
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    decomon_layer(inputs_for_mode)
     # Add new variables
     decomon_layer.add_weight(shape=(input_dim, units), initializer="ones", name="alpha", trainable=True)
     decomon_layer.add_weight(shape=(input_dim, units), initializer="ones", name="beta", trainable=False)
@@ -80,7 +82,8 @@ def test_decomondense_reset_layer_keras_with_new_weights(helpers):
     layer(tf.zeros((2, input_dim)))
     decomon_layer = DecomonDense(units=units, mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
-    decomon_layer(inputs[2:])
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    decomon_layer(inputs_for_mode)
     # Add new variables
     layer.add_weight(shape=(input_dim, units), initializer="ones", name="alpha", trainable=False)
     assert len(layer.weights) == 3
@@ -131,12 +134,15 @@ def test_decomonconv2d_reset_layer(helpers, use_bias):
     mode = ForwardMode.HYBRID
 
     inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=False)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
+
     layer = Conv2D(filters=filters, kernel_size=kernel_size, use_bias=use_bias)
-    layer(inputs[1])
+    layer(input_ref)
     decomon_layer = DecomonConv2D(
         filters=filters, kernel_size=kernel_size, use_bias=use_bias, mode=mode, dc_decomp=dc_decomp
     )
-    decomon_layer(inputs[2:])
+    decomon_layer(inputs_for_mode)
 
     kernel = layer.kernel
     layer.kernel.assign(2 * np.ones_like(kernel))
@@ -167,11 +173,13 @@ def test_decomonbacthnormalization_reset_layer(helpers, center, scale):
     odd = 0
     mode = ForwardMode.HYBRID
     inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
     layer = BatchNormalization(center=center, scale=scale)
-    layer(inputs[1])
+    layer(input_ref)
     decomon_layer = DecomonBatchNormalization(center=center, scale=scale, mode=mode, dc_decomp=dc_decomp)
-    decomon_layer(inputs[2:])
+    decomon_layer(inputs_for_mode)
 
     moving_mean = layer.moving_mean
     layer.moving_mean.assign(np.ones_like(moving_mean))
@@ -204,6 +212,7 @@ def test_decomonflatten_reset_layer(helpers):
     layer(tf.zeros((2, input_dim)))
     decomon_layer = DecomonFlatten(mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
-    decomon_layer(inputs[2:])
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    decomon_layer(inputs_for_mode)
 
     decomon_layer.reset_layer(layer)

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -13,14 +13,7 @@ from decomon.layers.decomon_layers import DecomonDense
 from decomon.models.utils import split_activation
 
 
-def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
-
-    K.set_floatx(f"float{floatx}")
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
+def test_DecomonDense_1D_box(n, mode, shared, floatx, decimal, helpers):
 
     decomon_dense = DecomonDense(1, use_bias=True, dc_decomp=True, mode=mode, shared=shared, dtype=K.floatx())
 
@@ -101,9 +94,6 @@ def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
         )
     else:
         raise ValueError("Unknown mode.")
-
-    K.set_epsilon(eps)
-    K.set_floatx("float32")
 
 
 def test_DecomonDense_multiD_box(odd, mode, helpers):

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -57,20 +57,7 @@ def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
@@ -78,39 +65,13 @@ def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
         u_c_ = None
         l_c_ = None
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")
@@ -122,20 +83,7 @@ def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
@@ -143,39 +91,13 @@ def test_DecomonDense_1D_box(n, mode, shared, floatx, helpers):
         u_c_ = None
         l_c_ = None
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            f"dense_{n}",
-            decimal=decimal,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")
@@ -215,57 +137,15 @@ def test_DecomonDense_multiD_box(odd, mode, helpers):
     y_ref = f_ref(inputs_)
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_multid_{odd}",
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         u_c_ = None
         l_c_ = None
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            f"dense_multid_{odd}",
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "dense_multid_{}".format(odd),
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None)
     else:
         raise ValueError("Unknown mode.")
 
@@ -275,57 +155,15 @@ def test_DecomonDense_multiD_box(odd, mode, helpers):
 
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "dense_multid_{}".format(odd),
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         u_c_ = None
         l_c_ = None
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "dense_multid_{}".format(odd),
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
-        helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "dense_multid_{}".format(odd),
-        )
+        helpers.assert_output_properties_box(x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None)
     else:
         raise ValueError("Unknown mode.")
 
@@ -384,58 +222,19 @@ def test_DecomonDense_1D_to_decomon_box(n, activation, mode, shared, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "dense_to_decomon_{}".format(n),
-            decimal=5,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=5
         )
 
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "dense_to_decomon_{}".format(n),
-            decimal=5,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=5
         )
 
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_ref,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "dense_to_decomon_{}".format(n),
-            decimal=5,
+            x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=5
         )
     else:
         raise ValueError("Unknown mode.")
@@ -505,58 +304,19 @@ def test_DecomonDense_multiD_to_decomon_box(odd, activation, mode, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "dense_to_decomon_{}".format(0),
-            decimal=5,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=5
         )
 
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "dense_to_decomon_{}".format(0),
-            decimal=5,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=5
         )
 
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_dense(inputs_[2:])
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "dense_to_decomon_{}".format(0),
-            decimal=5,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=5
         )
     else:
         raise ValueError("Unknown mode.")
@@ -584,9 +344,7 @@ def test_DecomonDense_1D_box_nodc(n, helpers):
 
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_dense(inputs_[2:])
     y_ref = f_ref(inputs_)
-    helpers.assert_output_properties_box_linear(
-        x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
 
 
 def test_DecomonDense_multiD_to_decomon_box_nodc(odd, activation, mode, helpers):
@@ -634,9 +392,7 @@ def test_DecomonDense_multiD_to_decomon_box_nodc(odd, activation, mode, helpers)
 
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_dense(inputs_[2:])
 
-    helpers.assert_output_properties_box_linear(
-        x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
 
 
 def test_DecomonDense_multiD_box_dc(odd, helpers):
@@ -661,15 +417,11 @@ def test_DecomonDense_multiD_box_dc(odd, helpers):
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_dense(inputs_[2:])
     y_ref = f_ref(inputs_)
 
-    helpers.assert_output_properties_box_linear(
-        x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)
 
     decomon_dense.set_weights([-3 * np.ones_like(W_), np.ones_like(bias)])
     ref_dense.set_weights([-3 * np.ones_like(W_), np.ones_like(bias)])
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_dense(inputs_[2:])
     y_ref = f_ref(inputs_)
 
-    helpers.assert_output_properties_box_linear(
-        x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, "nodc"
-    )
+    helpers.assert_output_properties_box_linear(x, y_ref, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -108,7 +108,7 @@ def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mod
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, name="add", decimal=decimal
+        inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_epsilon(eps)
@@ -175,7 +175,7 @@ def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, od
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, name="add", decimal=decimal
+        inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_epsilon(eps)
@@ -222,9 +222,7 @@ def test_Decomon_1D_box_to_decomon(layer_class, tensor_op, layer_kwargs, n, help
     z_, u_, w_u_, b_u_, l_, w_l_, b_l_ = output_
     y_ = tensor_op(inputs_0_[1], inputs_1_[1])
 
-    helpers.assert_output_properties_box_linear(
-        inputs_0_[0], y_, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, name="add"
-    )
+    helpers.assert_output_properties_box_linear(inputs_0_[0], y_, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_)
 
 
 #### to_decomon multiD
@@ -265,6 +263,4 @@ def test_Decomon_multiD_box_to_decomon(layer_class, tensor_op, layer_kwargs, odd
     # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     z_, u_, w_u_, b_u_, l_, w_l_, b_l_ = output_
     y_ = tensor_op(y0, y1)
-    helpers.assert_output_properties_box_linear(
-        inputs_0_[0], y_, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, name="add"
-    )
+    helpers.assert_output_properties_box_linear(inputs_0_[0], y_, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -60,15 +60,7 @@ def concatenate_op(x, y):
         (DecomonMultiply, multiply_op, {}),
     ],
 )
-def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mode, floatx, decimal, helpers):
     decomon_op = decomon_op_class(dc_decomp=False, mode=mode, dtype=K.floatx(), **decomon_op_kwargs)
 
     inputs_0 = helpers.get_tensor_decomposition_1d_box(dc_decomp=False)
@@ -94,7 +86,6 @@ def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mod
 
     model = Model(inputs_0[2:] + inputs_1[2:], output_decomon)
     y_ = tensor_op(y0_, y1_)
-    # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     output_ = model.predict(inputs_0_[2:] + inputs_1_[2:])
     u_, w_u_, b_u_, l_, w_l_, b_l_ = [None] * 6
     z_ = z0_
@@ -111,9 +102,6 @@ def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mod
         inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_epsilon(eps)
-    K.set_floatx("float32")
-
 
 @pytest.mark.parametrize(
     "decomon_op_class, tensor_op, decomon_op_kwargs",
@@ -127,15 +115,7 @@ def test_DecomonOp_1D_box(decomon_op_class, tensor_op, decomon_op_kwargs, n, mod
         (DecomonMultiply, multiply_op, {}),
     ],
 )
-def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
-
+def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, odd, mode, floatx, decimal, helpers):
     decomon_op = decomon_op_class(dc_decomp=False, mode=mode, dtype=K.floatx(), **decomon_op_kwargs)
 
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
@@ -161,7 +141,6 @@ def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, od
 
     model = Model(inputs_0[2:] + inputs_1[2:], output_decomon)
     y_ = tensor_op(y0_, y1_)
-    # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     output_ = model.predict(inputs_0_[2:] + inputs_1_[2:])
     u_, w_u_, b_u_, l_, w_l_, b_l_ = [None] * 6
     z_ = z0_
@@ -177,12 +156,6 @@ def test_DecomonOp_multiD_box(decomon_op_class, tensor_op, decomon_op_kwargs, od
     helpers.assert_output_properties_box(
         inputs_0_[0], y_, None, None, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_, decimal=decimal
     )
-
-    K.set_epsilon(eps)
-    K.set_floatx("float32")
-
-
-### to decomon
 
 
 @pytest.mark.parametrize(
@@ -217,7 +190,6 @@ def test_Decomon_1D_box_to_decomon(layer_class, tensor_op, layer_kwargs, n, help
 
     model = Model(inputs_0[2:] + inputs_1[2:], output_decomon)
 
-    # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     output_ = model.predict(inputs_0_[2:] + inputs_1_[2:])
     z_, u_, w_u_, b_u_, l_, w_l_, b_l_ = output_
     y_ = tensor_op(inputs_0_[1], inputs_1_[1])
@@ -258,9 +230,7 @@ def test_Decomon_multiD_box_to_decomon(layer_class, tensor_op, layer_kwargs, odd
     output_decomon = decomon_op(inputs_0[2:] + inputs_1[2:])
     model = Model(inputs_0[2:] + inputs_1[2:], output_decomon)
 
-    # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     output_ = model.predict(inputs_0_[2:] + inputs_1_[2:])
-    # output_ = K.function(inputs_0[1:]+inputs_1[1:], output_decomon)(inputs_0_[1:]+inputs_1_[1:])
     z_, u_, w_u_, b_u_, l_, w_l_, b_l_ = output_
     y_ = tensor_op(y0, y1)
     helpers.assert_output_properties_box_linear(inputs_0_[0], y_, z_[:, 0], z_[:, 1], u_, w_u_, b_u_, l_, w_l_, b_l_)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -42,56 +42,17 @@ def test_categorical_cross_entropy(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_entropy(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            None,
-            None,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_ = f_entropy(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            None,
-            None,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, None, None, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.IBP:
         u_c_, l_c_ = f_entropy(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            None,
-            None,
-            inputs_[2][:, 0],
-            inputs_[2][:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, None, None, inputs_[2][:, 0], inputs_[2][:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,45 +1,34 @@
-import pytest
 import tensorflow.keras.backend as K
 
-from decomon.layers.core import ForwardMode
 from decomon.metrics.utils import categorical_cross_entropy
 
 
 def test_categorical_cross_entropy(odd, mode, floatx, decimal, helpers):
-    inputs_0 = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
-    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
+    dc_decomp = False
 
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0 = inputs_0
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = categorical_cross_entropy(inputs_0[2:], dc_decomp=False, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = categorical_cross_entropy([z_0, W_u_0, b_u_0, W_l_0, b_l_0], dc_decomp=False, mode=mode)
-    elif mode == ForwardMode.IBP:
-        output = categorical_cross_entropy([u_c_0, l_c_0], dc_decomp=False, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
-    f_ref = K.function(inputs_0, -y_0 + K.log(K.sum(K.exp(y_0), -1))[:, None])
-    f_entropy = K.function(inputs_0, output)
+    # original output
+    f_ref = K.function(inputs, -input_ref + K.log(K.sum(K.exp(input_ref), -1))[:, None])
+    output_ref_ = f_ref(inputs_)
 
-    y_ = f_ref(inputs_)
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = f_entropy(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_ = f_entropy(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, None, None, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_ = f_entropy(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, None, None, inputs_[2][:, 0], inputs_[2][:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
-        )
-    else:
-        raise ValueError("Unknown mode.")
+    # decomon output
+    output = categorical_cross_entropy(inputs_for_mode, dc_decomp=dc_decomp, mode=mode)
+    f_entropy = K.function(inputs, output)
+    outputs_ = f_entropy(inputs_)
+
+    # check bounds consistency
+    helpers.assert_decomon_layer_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        dc_decomp=dc_decomp,
+        mode=mode,
+        decimal=decimal,
+    )

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,6 +1,3 @@
-# Test unit for decomon with Dense layers
-
-
 import pytest
 import tensorflow.keras.backend as K
 
@@ -8,17 +5,7 @@ from decomon.layers.core import ForwardMode
 from decomon.metrics.utils import categorical_cross_entropy
 
 
-def test_categorical_cross_entropy(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
-
+def test_categorical_cross_entropy(odd, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=False)
     inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=False)
 
@@ -56,6 +43,3 @@ def test_categorical_cross_entropy(odd, mode, floatx, helpers):
         )
     else:
         raise ValueError("Unknown mode.")
-
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -1,6 +1,3 @@
-# Test unit for decomon with Dense layers
-
-
 import pytest
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import MaxPooling2D
@@ -9,17 +6,10 @@ from decomon.layers.core import ForwardMode
 from decomon.layers.maxpooling import DecomonMaxPooling2D
 
 
-def test_MaxPooling2D_box(mode, floatx, helpers):
+def test_MaxPooling2D_box(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
     data_format = "channels_last"
     fast = False
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
     inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1)
@@ -59,5 +49,3 @@ def test_MaxPooling2D_box(mode, floatx, helpers):
     helpers.assert_output_properties_box(
         x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -57,20 +57,7 @@ def test_MaxPooling2D_box(mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x,
-        y_,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "maxpooling_{}".format(odd),
-        decimal=decimal,
+        x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
     K.set_floatx("float{}".format(32))
     K.set_epsilon(eps)

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -1,51 +1,44 @@
-import pytest
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import MaxPooling2D
 
-from decomon.layers.core import ForwardMode
 from decomon.layers.maxpooling import DecomonMaxPooling2D
 
 
 def test_MaxPooling2D_box(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
     data_format = "channels_last"
+    dc_decomp = True
     fast = False
+    kwargs_layer = dict(pool_size=(2, 2), strides=(2, 2), padding="valid", dtype=K.floatx())
 
-    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
-    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1)
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
-    output_ref = MaxPooling2D(pool_size=(2, 2), strides=(2, 2), padding="valid", dtype=K.floatx())(inputs[1])
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=dc_decomp)
+
+    # keras & decomon layer
+    keras_layer = MaxPooling2D(**kwargs_layer)
+    decomon_layer = DecomonMaxPooling2D(dc_decomp=dc_decomp, fast=fast, mode=mode, **kwargs_layer)
+
+    # original output
+    output_ref = keras_layer(input_ref)
     f_ref = K.function(inputs, output_ref)
+    output_ref_ = f_ref(inputs_)
 
-    layer = DecomonMaxPooling2D(
-        pool_size=(2, 2), strides=(2, 2), padding="valid", dc_decomp=True, fast=fast, mode=mode, dtype=K.floatx()
-    )
+    # decomon outputs
+    outputs = decomon_layer(inputs_for_mode)
+    f_decomon = K.function(inputs, outputs)
+    outputs_ = f_decomon(inputs_)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = layer(inputs[2:])
-    elif mode == ForwardMode.AFFINE:
-        output = layer([inputs[2], inputs[4], inputs[5], inputs[7], inputs[8], inputs[9], inputs[10]])
-    elif mode == ForwardMode.IBP:
-        output = layer([inputs[3], inputs[6], inputs[9], inputs[10]])
-    else:
-        raise ValueError("Unknown mode.")
-
-    f_pooling = K.function(inputs, output)
-
-    y_ = f_ref(inputs_)
-    z_ = z
-    u_c_, w_u_, b_u_, l_c_, w_l_, b_l_ = [None] * 6
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_pooling(inputs_)
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_pooling(inputs_)
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_pooling(inputs_)
-    else:
-        raise ValueError("Unknown mode.")
-
-    helpers.assert_output_properties_box(
-        x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
+    # check bounds consistency
+    helpers.assert_decomon_layer_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        dc_decomp=dc_decomp,
+        decimal=decimal,
+        mode=mode,
     )

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -52,20 +52,7 @@ def test_Decomon_reshape_box(mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        y_,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -116,20 +103,7 @@ def test_Decomon_reshape_box_nodc(mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        y_,
-        None,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -169,20 +143,7 @@ def test_Decomon_reshape_to_decomon_box(shared, floatx, helpers):
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_reshape(inputs_[2:])
 
     helpers.assert_output_properties_box(
-        x_,
-        y_ref,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -237,20 +198,7 @@ def test_Decomon_permute_box(mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        y_,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -304,20 +252,7 @@ def test_Decomon_permute_box_nodc(mode, floatx, helpers):
         raise ValueError("Unknown mode.")
 
     helpers.assert_output_properties_box(
-        x_,
-        y_,
-        None,
-        None,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))
@@ -357,20 +292,7 @@ def test_Decomon_permute_to_decomon_box(shared, floatx, helpers):
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_permute(inputs_[2:])
 
     helpers.assert_output_properties_box(
-        x_,
-        y_ref,
-        h_,
-        g_,
-        z_[:, 0],
-        z_[:, 1],
-        u_c_,
-        w_u_,
-        b_u_,
-        l_c_,
-        w_l_,
-        b_l_,
-        "reshape_{}_{}_{}".format(odd, m_0, m_1),
-        decimal=decimal,
+        x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
     K.set_floatx("float{}".format(32))

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -8,15 +8,8 @@ from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
 
 
-def test_Decomon_reshape_box(mode, floatx, helpers):
+def test_Decomon_reshape_box(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1)
@@ -55,19 +48,9 @@ def test_Decomon_reshape_box(mode, floatx, helpers):
         x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_Decomon_reshape_box_nodc(mode, floatx, helpers):
+def test_Decomon_reshape_box_nodc(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd, dc_decomp=False)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1, dc_decomp=False)
@@ -106,19 +89,9 @@ def test_Decomon_reshape_box_nodc(mode, floatx, helpers):
         x_, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_Decomon_reshape_to_decomon_box(shared, floatx, helpers):
+def test_Decomon_reshape_to_decomon_box(shared, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 4
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1)
@@ -146,20 +119,10 @@ def test_Decomon_reshape_to_decomon_box(shared, floatx, helpers):
         x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
-
 
 # permute
-def test_Decomon_permute_box(mode, floatx, helpers):
+def test_Decomon_permute_box(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1)
@@ -201,19 +164,9 @@ def test_Decomon_permute_box(mode, floatx, helpers):
         x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_Decomon_permute_box_nodc(mode, floatx, helpers):
+def test_Decomon_permute_box_nodc(mode, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd, dc_decomp=False)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1, dc_decomp=False)
@@ -255,19 +208,9 @@ def test_Decomon_permute_box_nodc(mode, floatx, helpers):
         x_, y_, None, None, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_Decomon_permute_to_decomon_box(shared, floatx, helpers):
+def test_Decomon_permute_to_decomon_box(shared, floatx, decimal, helpers):
     odd, m_0, m_1 = 0, 0, 1
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 4
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 1
 
     inputs = helpers.get_tensor_decomposition_images_box("channels_last", odd)
     inputs_ = helpers.get_standard_values_images_box("channels_last", odd, m0=m_0, m1=m_1)
@@ -294,6 +237,3 @@ def test_Decomon_permute_to_decomon_box(shared, floatx, helpers):
     helpers.assert_output_properties_box(
         x_, y_ref, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
     )
-
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,11 +13,6 @@ from decomon.utils import subtract
 
 def test_get_upper_multi_box(odd, floatx, helpers):
 
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
-
     inputs = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_ = helpers.get_standard_values_multid_box(odd)
 
@@ -36,15 +31,9 @@ def test_get_upper_multi_box(odd, floatx, helpers):
     upper_ = f_upper([x_0_, W_u_, b_u_])
 
     assert_allclose(upper_pred, upper_)
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_get_upper_box_numpy(n, floatx, helpers):
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
     inputs = helpers.get_tensor_decomposition_1d_box()
     inputs_ = helpers.get_standard_values_1d_box(n)
 
@@ -65,16 +54,9 @@ def test_get_upper_box_numpy(n, floatx, helpers):
     upper_ = f_upper([x_0_, W_u_, b_u_]).max()
 
     assert_allclose(upper_pred, upper_)
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_get_upper_box(n, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
     inputs = helpers.get_tensor_decomposition_1d_box()
     inputs_ = helpers.get_standard_values_1d_box(n)
 
@@ -105,16 +87,9 @@ def test_get_upper_box(n, floatx, helpers):
         decimal=6,
         err_msg="upper_<y_ in call {}".format(n),
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_get_lower_box(n, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
     inputs = helpers.get_tensor_decomposition_1d_box()
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, _, _, l_c, W_l, b_l, _, _ = inputs
@@ -141,16 +116,9 @@ def test_get_lower_box(n, floatx, helpers):
         decimal=6,
         err_msg="lower_> y_ in call {}".format(n),
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
 def test_get_lower_upper_box(n, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-4)
     inputs = helpers.get_tensor_decomposition_1d_box()
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, W_u, b_u, _, W_l, b_l, _, _ = inputs
@@ -170,21 +138,9 @@ def test_get_lower_upper_box(n, floatx, helpers):
         decimal=6,
         err_msg="lower_> upper_ in call {}".format(n),
     )
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
 
-def test_relu_1D_box(n, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
+def test_relu_1D_box(n, mode, floatx, decimal, helpers):
     inputs = helpers.get_tensor_decomposition_1d_box()
     inputs_ = helpers.get_standard_values_1d_box(n)
 
@@ -231,8 +187,6 @@ def test_relu_1D_box(n, mode, floatx, helpers):
     f_relu_ = K.function(x_vec, output)
     f_ref = K.function(y, K.relu(y))
     y_ = f_ref(y_0)
-
-    # y_, z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_relu_(inputs_[1:])
 
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_relu_(x_vec_)
@@ -347,21 +301,8 @@ def test_relu_1D_box(n, mode, floatx, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_add(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(32))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
-
+def test_add(odd, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
 
@@ -392,7 +333,6 @@ def test_add(odd, mode, floatx, helpers):
     f_ref = K.function(inputs_0 + inputs_1, inputs_0[1] + inputs_1[1])
     f_add = K.function(inputs_0 + inputs_1, output)
 
-    # y_, z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
     y_ = f_ref(inputs_ + inputs_)
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
@@ -425,21 +365,8 @@ def test_add(odd, mode, floatx, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_minus(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
-
+def test_minus(odd, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_ = helpers.get_standard_values_multid_box(odd)
 
@@ -477,29 +404,15 @@ def test_minus(odd, mode, floatx, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)
 
-
-def test_subtract(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
+def test_subtract(odd, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
 
     inputs_ = helpers.get_standard_values_multid_box(odd)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_0
 
     x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0, h_0, g_0 = inputs_0
     x_1, y_1, z_1, u_c_1, W_u_1, b_u_1, l_c_1, W_l_1, b_l_1, h_1, g_1 = inputs_1
-    # x_, y_, z_, u_c_, W_u_, b_u_, l_c_, W_l_, b_l_, h_, g_ = inputs_
 
     mode = ForwardMode(mode)
     if mode == ForwardMode.HYBRID:
@@ -521,7 +434,6 @@ def test_subtract(odd, mode, floatx, helpers):
     f_ref = K.function(inputs_0 + inputs_1, inputs_0[1] - inputs_1[1])
     f_sub = K.function(inputs_0 + inputs_1, output)
 
-    # y_, z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
     y_ = f_ref(inputs_ + inputs_)
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_sub(inputs_ + inputs_)
@@ -554,20 +466,8 @@ def test_subtract(odd, mode, floatx, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    K.set_floatx("float{}".format(floatx))
-    K.set_epsilon(eps)
 
-
-def test_maximum(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
+def test_maximum(odd, mode, floatx, decimal, helpers):
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
 
@@ -618,20 +518,8 @@ def test_maximum(odd, mode, floatx, helpers):
     else:
         raise ValueError("Unknown mode.")
 
-    K.set_floatx("float{}".format(floatx))
-    K.set_epsilon(eps)
 
-
-def test_max_(odd, mode, floatx, helpers):
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-    if floatx == 16:
-        decimal = 2
-    else:
-        decimal = 5
+def test_max_(odd, mode, floatx, decimal, helpers):
 
     inputs = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_ = helpers.get_standard_values_multid_box(odd)
@@ -676,9 +564,6 @@ def test_max_(odd, mode, floatx, helpers):
         )
     else:
         raise ValueError("Unknown mode.")
-
-    K.set_epsilon(eps)
-    K.set_floatx("float{}".format(32))
 
 
 # DC_DECOMP = FALSE

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -332,56 +332,17 @@ def test_relu_1D_box(n, mode, floatx, helpers):
 
     if mode == ForwardMode.HYBRID:
         helpers.assert_output_properties_box(
-            x_0,
-            y_,
-            h_,
-            g_,
-            z_0[:, 0],
-            z_0[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "relu_{}".format(n),
-            decimal=decimal,
+            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
         helpers.assert_output_properties_box(
-            x_0,
-            y_,
-            h_,
-            g_,
-            z_0[:, 0],
-            z_0[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "relu_{}".format(n),
-            decimal=decimal,
+            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.IBP:
         helpers.assert_output_properties_box(
-            x_0,
-            y_,
-            h_,
-            g_,
-            z_0[:, 0],
-            z_0[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "relu_{}".format(n),
-            decimal=decimal,
+            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")
@@ -436,39 +397,13 @@ def test_add(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
         helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "add_multid_{}".format(odd),
-            decimal=decimal,
+            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
         helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "add_multid_{}".format(odd),
-            decimal=decimal,
+            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_add(inputs_ + inputs_)
@@ -485,7 +420,6 @@ def test_add(odd, mode, floatx, helpers):
             l_c_,
             None,
             None,
-            "add_multid_{}".format(odd),
             decimal=decimal,
         )
     else:
@@ -528,56 +462,17 @@ def test_minus(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_minus(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_minus(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_minus(inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            inputs_[2][:, 0],
-            inputs_[2][:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "minus_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, inputs_[2][:, 0], inputs_[2][:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")
@@ -631,39 +526,13 @@ def test_subtract(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_sub(inputs_ + inputs_)
         helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "add_multid_{}".format(odd),
-            decimal=decimal,
+            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_sub(inputs_ + inputs_)
         helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "add_multid_{}".format(odd),
-            decimal=decimal,
+            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_sub(inputs_ + inputs_)
@@ -680,7 +549,6 @@ def test_subtract(odd, mode, floatx, helpers):
             l_c_,
             None,
             None,
-            "add_multid_{}".format(odd),
             decimal=decimal,
         )
     else:
@@ -732,59 +600,20 @@ def test_maximum(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_maximum(inputs_ + inputs_)
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "maximum_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.AFFINE:
         output_ = f_maximum(inputs_ + inputs_)
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = output_
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "maximum_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
     elif mode == ForwardMode.IBP:
         output_ = f_maximum(inputs_ + inputs_)
         u_c_, l_c_, h_, g_ = output_
         z_ = inputs_[2]
         helpers.assert_output_properties_box(
-            x,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "maximum_multid_{}".format(odd),
-            decimal=decimal,
+            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")
@@ -831,58 +660,19 @@ def test_max_(odd, mode, floatx, helpers):
     if mode == ForwardMode.HYBRID:
         z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_max(inputs_)
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            w_u_,
-            b_u_,
-            l_c_,
-            w_l_,
-            b_l_,
-            "max_multid_{}".format(odd),
-            decimal=decimal,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.AFFINE:
         z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_max(inputs_)
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            None,
-            w_u_,
-            b_u_,
-            None,
-            w_l_,
-            b_l_,
-            "max_multid_{}".format(odd),
-            decimal=decimal,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
         )
 
     elif mode == ForwardMode.IBP:
         u_c_, l_c_, h_, g_ = f_max(inputs_)
         helpers.assert_output_properties_box(
-            x_,
-            y_,
-            h_,
-            g_,
-            z_[:, 0],
-            z_[:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            "max_multid_{}".format(odd),
-            decimal=decimal,
+            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
         )
     else:
         raise ValueError("Unknown mode.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,20 +99,20 @@ def test_get_lower_box(n, floatx, helpers):
     f_lower = K.function(inputs, lower)
     f_l = K.function(inputs, l_c)
 
-    output = inputs_[1]
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs_)
 
     lower_ = f_lower(inputs_)
     l_c_ = f_l(inputs_)
 
     assert_almost_equal(
-        np.clip(lower_ - output, 0, np.inf),
-        np.zeros_like(output),
+        np.clip(lower_ - input_ref, 0, np.inf),
+        np.zeros_like(input_ref),
         decimal=6,
         err_msg="lower_> y_ in call {}".format(n),
     )
     assert_almost_equal(
         np.clip(lower_ - l_c_, 0, np.inf),
-        np.zeros_like(output),
+        np.zeros_like(input_ref),
         decimal=6,
         err_msg="lower_> y_ in call {}".format(n),
     )
@@ -141,100 +141,127 @@ def test_get_lower_upper_box(n, floatx, helpers):
 
 
 def test_relu_1D_box(n, mode, floatx, decimal, helpers):
-    inputs = helpers.get_tensor_decomposition_1d_box()
-    inputs_ = helpers.get_standard_values_1d_box(n)
+    dc_decomp = True
 
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs  # tensors
+    #  tensor inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
+
+    # original output
+    f_ref = K.function(inputs, K.relu(input_ref))
+    output_ref_ = f_ref(inputs_)
+
+    # decomon output
+    output = relu_(inputs_for_mode, dc_decomp=dc_decomp, mode=mode)
+    f_decomon = K.function(inputs, output)
+    outputs_ = f_decomon(inputs_)
+
+    # full outputs
     (
-        x_0,
-        y_0,
-        z_0,
-        u_c_0,
-        W_u_0,
-        b_u_0,
-        l_c_0,
-        W_l_0,
-        b_l_0,
-        h_0,
-        g_0,
+        z_output,
+        u_c_output,
+        w_u_output,
+        b_u_output,
+        l_c_output,
+        w_l_output,
+        b_l_output,
+        h_output,
+        g_output,
+    ) = helpers.get_full_outputs_from_outputs_for_mode(
+        outputs_for_mode=outputs_,
+        full_inputs=inputs_,
+        mode=mode,
+        dc_decomp=dc_decomp,
+    )
+
+    #  check bounds consistency
+    helpers.assert_decomon_layer_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        mode=mode,
+        dc_decomp=dc_decomp,
+        decimal=decimal,
+    )
+
+    # Further checks
+    (
+        x_tensor,
+        y_tensor,
+        z_tensor,
+        u_c_tensor,
+        W_u_tensor,
+        b_u_tensor,
+        l_c_tensor,
+        W_l_tensor,
+        b_l_tensor,
+        h_tensor,
+        g_tensor,
+    ) = inputs  # tensors
+    (
+        x_input,
+        y_input,
+        z_input,
+        u_c_input,
+        W_u_input,
+        b_u_input,
+        l_c_input,
+        W_l_input,
+        b_l_input,
+        h_input,
+        g_input,
     ) = inputs_  # numpy values
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        x_vec = inputs[2:]
-        x_vec_ = inputs_[2:]
-        output = relu_(x_vec, dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.IBP:
-        x_vec = [u_c, l_c, h, g]
-        x_vec_ = [u_c_0, l_c_0, h_0, g_0]
-        output = relu_(x_vec, dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        x_vec = [z, W_u, b_u, W_l, b_l, h, g]
-        x_vec_ = [z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0]
-        output = relu_(x_vec, dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
-
-    lower = get_lower(z, W_l, b_l)
-    upper = get_upper(z, W_u, b_u)
-
+    # lower and upper bounds from affine coefficients
+    lower = get_lower(z_tensor, W_l_tensor, b_l_tensor)
+    upper = get_upper(z_tensor, W_u_tensor, b_u_tensor)
     f_lower = K.function(inputs, lower)
     f_upper = K.function(inputs, upper)
-
     lower_ = np.min(f_lower(inputs_))
     upper_ = np.max(f_upper(inputs_))
-
-    f_relu_ = K.function(x_vec, output)
-    f_ref = K.function(y, K.relu(y))
-    y_ = f_ref(y_0)
-
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_relu_(x_vec_)
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_relu_(x_vec_)
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_relu_(x_vec_)
-    else:
-        raise ValueError("Unknown mode.")
 
     if upper_ <= 0:
         # check that we find this case !
         if mode in [ForwardMode.AFFINE, ForwardMode.HYBRID]:
             assert_almost_equal(
-                w_u_,
-                np.zeros_like(w_u_),
+                w_u_output,
+                np.zeros_like(w_u_output),
                 decimal=decimal,
                 err_msg="w_u_!=0 but upper_<=0 in call {}".format(n),
             )
             assert_almost_equal(
-                b_u_,
-                np.zeros_like(b_u_),
+                b_u_output,
+                np.zeros_like(b_u_output),
                 decimal=decimal,
                 err_msg="b_u_!=0 but upper_<=0 in call {}".format(n),
             )
             assert_almost_equal(
-                w_l_,
-                np.zeros_like(w_l_),
+                w_l_output,
+                np.zeros_like(w_l_output),
                 decimal=decimal,
                 err_msg="w_l_!=0 but upper_<=0 in call {}".format(n),
             )
             assert_almost_equal(
-                b_l_,
-                np.zeros_like(b_l_),
+                b_l_output,
+                np.zeros_like(b_l_output),
                 decimal=decimal,
                 err_msg="b_l_!=0 but upper_<=0 in call {}".format(n),
             )
 
         if mode in [ForwardMode.IBP, ForwardMode.HYBRID]:
             assert_almost_equal(
-                u_c_,
-                np.zeros_like(u_c_),
+                u_c_output,
+                np.zeros_like(u_c_output),
                 decimal=decimal,
                 err_msg="u_c_!=0 but upper_<=0 in call {}".format(n),
             )
             assert_almost_equal(
-                l_c_,
-                np.zeros_like(l_c_),
+                l_c_output,
+                np.zeros_like(l_c_output),
                 decimal=6,
                 err_msg="l_c_!=0 but upper_<=0 in call {}".format(n),
             )
@@ -243,327 +270,144 @@ def test_relu_1D_box(n, mode, floatx, decimal, helpers):
         # check that we find this case !
         if mode in [ForwardMode.AFFINE, ForwardMode.HYBRID]:
             assert_almost_equal(
-                w_u_,
-                W_u_0,
+                w_u_output,
+                W_u_input,
                 decimal=decimal,
                 err_msg="w_u_!=W_u but lower_>=0 in call {}".format(n),
             )
             assert_almost_equal(
-                b_u_,
-                b_u_0,
+                b_u_output,
+                b_u_input,
                 decimal=decimal,
                 err_msg="b_u_!=b_u but lower_>=0  in call {}".format(n),
             )
             assert_almost_equal(
-                w_l_,
-                W_l_0,
+                w_l_output,
+                W_l_input,
                 decimal=decimal,
                 err_msg="w_l_!=W_l but lower_>=0 upper_<=0 in call {}".format(n),
             )
             assert_almost_equal(
-                b_l_,
-                b_l_0,
+                b_l_output,
+                b_l_input,
                 decimal=decimal,
                 err_msg="b_l_!=b_l but lower_>=0 upper_<=0 in call {}".format(n),
             )
         if mode in [ForwardMode.IBP, ForwardMode.HYBRID]:
             assert_almost_equal(
-                u_c_,
-                u_c_0,
+                u_c_output,
+                u_c_input,
                 decimal=decimal,
                 err_msg="u_c_!=u_c but lower_>=0  in call {}".format(n),
             )
             assert_almost_equal(
-                l_c_,
-                l_c_0,
+                l_c_output,
+                l_c_input,
                 decimal=decimal,
                 err_msg="l_c_!=l_c but lower_>=0  in call {}".format(n),
             )
 
     if mode != ForwardMode.IBP:
-        assert_almost_equal(z_0[:, 0], z_[:, 0], decimal=decimal, err_msg="the lower bound should be unchanged")
-        assert_almost_equal(z_0[:, 1], z_[:, 1], decimal=decimal, err_msg="the upper bound should be unchanged")
-
-    if mode == ForwardMode.HYBRID:
-        helpers.assert_output_properties_box(
-            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
+        assert_almost_equal(
+            z_input[:, 0], z_output[:, 0], decimal=decimal, err_msg="the lower bound should be unchanged"
+        )
+        assert_almost_equal(
+            z_input[:, 1], z_output[:, 1], decimal=decimal, err_msg="the upper bound should be unchanged"
         )
 
-    elif mode == ForwardMode.AFFINE:
-        helpers.assert_output_properties_box(
-            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
 
-    elif mode == ForwardMode.IBP:
-        helpers.assert_output_properties_box(
-            x_0, y_, h_, g_, z_0[:, 0], z_0[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
-        )
-    else:
-        raise ValueError("Unknown mode.")
+def add_op(x, y):
+    return x + y
 
 
-def test_add(odd, mode, floatx, decimal, helpers):
+def subtract_op(x, y):
+    return x - y
+
+
+def minus_op(x):
+    return -x
+
+
+@pytest.mark.parametrize(
+    "decomon_func, tensor_func",
+    [
+        (add, add_op),
+        (subtract, subtract_op),
+        (maximum, K.maximum),
+    ],
+)
+def test_func_with_2_inputs(decomon_func, tensor_func, odd, mode, floatx, decimal, helpers):
+    dc_decomp = True
+
+    #  tensor inputs
     inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
     inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
+    inputs_for_mode_0 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_0, mode=mode, dc_decomp=dc_decomp)
+    inputs_for_mode_1 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1, mode=mode, dc_decomp=dc_decomp)
+    input_ref_0 = helpers.get_input_ref_from_full_inputs(inputs=inputs_0)
+    input_ref_1 = helpers.get_input_ref_from_full_inputs(inputs=inputs_1)
 
-    inputs_ = helpers.get_standard_values_multid_box(odd)
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_0
-
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0, h_0, g_0 = inputs_0
-    x_1, y_1, z_1, u_c_1, W_u_1, b_u_1, l_c_1, W_l_1, b_l_1, h_1, g_1 = inputs_1
-    # x_, y_, z_, u_c_, W_u_, b_u_, l_c_, W_l_, b_l_, h_, g_ = inputs_
-
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = add(inputs_0[2:], inputs_1[2:], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = add(
-            [z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0],
-            [z_1, W_u_1, b_u_1, W_l_1, b_l_1, h_1, g_1],
-            dc_decomp=True,
-            mode=mode,
-        )
-    elif mode == ForwardMode.IBP:
-        output = add([u_c_0, l_c_0, h_0, g_0], [u_c_1, l_c_1, h_1, g_1], dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
-
-    # TO FINISH
-
-    f_ref = K.function(inputs_0 + inputs_1, inputs_0[1] + inputs_1[1])
-    f_add = K.function(inputs_0 + inputs_1, output)
-
-    y_ = f_ref(inputs_ + inputs_)
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_add(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_add(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            inputs_[2][:, 0],
-            inputs_[2][:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            decimal=decimal,
-        )
-    else:
-        raise ValueError("Unknown mode.")
-
-
-def test_minus(odd, mode, floatx, decimal, helpers):
-    inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
+    # numpy inputs
     inputs_ = helpers.get_standard_values_multid_box(odd)
 
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0, h_0, g_0 = inputs_0
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
+    # original output
+    f_ref = K.function(inputs_0 + inputs_1, tensor_func(input_ref_0, input_ref_1))
+    output_ref_ = f_ref(inputs_ + inputs_)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = minus(inputs_0[2:], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = minus([z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.IBP:
-        output = minus([u_c_0, l_c_0, h_0, g_0], dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
+    # decomon output
+    output = decomon_func(inputs_for_mode_0, inputs_for_mode_1, dc_decomp=dc_decomp, mode=mode)
+    f_decomon = K.function(inputs_0 + inputs_1, output)
+    outputs_ = f_decomon(inputs_ + inputs_)
 
-    f_ref = K.function(inputs_0, -inputs_0[1])
-    f_minus = K.function(inputs_0, output)
-    y_ = f_ref(inputs_)
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_minus(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_minus(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_minus(inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, inputs_[2][:, 0], inputs_[2][:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
-        )
-    else:
-        raise ValueError("Unknown mode.")
+    #  check bounds consistency
+    helpers.assert_decomon_layer_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        mode=mode,
+        dc_decomp=dc_decomp,
+        decimal=decimal,
+    )
 
 
-def test_subtract(odd, mode, floatx, decimal, helpers):
-    inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
-    inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
+@pytest.mark.parametrize(
+    "decomon_func, tensor_func, tensor_func_kwargs",
+    [
+        (minus, minus_op, None),
+        (max_, K.max, {"axis": -1}),
+    ],
+)
+def test_func_with_1_input(decomon_func, tensor_func, tensor_func_kwargs, odd, mode, floatx, decimal, helpers):
+    dc_decomp = True
+    if tensor_func_kwargs is None:
+        tensor_func_kwargs = {}
 
-    inputs_ = helpers.get_standard_values_multid_box(odd)
+    # tensor inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs=inputs)
 
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0, h_0, g_0 = inputs_0
-    x_1, y_1, z_1, u_c_1, W_u_1, b_u_1, l_c_1, W_l_1, b_l_1, h_1, g_1 = inputs_1
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = subtract(inputs_0[2:], inputs_1[2:], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = subtract(
-            [z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0],
-            [z_1, W_u_1, b_u_1, W_l_1, b_l_1, h_1, g_1],
-            dc_decomp=True,
-            mode=mode,
-        )
-    elif mode == ForwardMode.IBP:
-        output = subtract([u_c_0, l_c_0, h_0, g_0], [u_c_1, l_c_1, h_1, g_1], dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
+    # original output
+    f_ref = K.function(inputs, tensor_func(input_ref, **tensor_func_kwargs))
+    output_ref_ = f_ref(inputs_)
 
-    # TO FINISH
+    # decomon output
+    output = decomon_func(inputs_for_mode, dc_decomp=dc_decomp, mode=mode)
+    f_decomon = K.function(inputs, output)
+    outputs_ = f_decomon(inputs_)
 
-    f_ref = K.function(inputs_0 + inputs_1, inputs_0[1] - inputs_1[1])
-    f_sub = K.function(inputs_0 + inputs_1, output)
-
-    y_ = f_ref(inputs_ + inputs_)
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_sub(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_sub(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0], y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_sub(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            inputs_[0],
-            y_,
-            h_,
-            g_,
-            inputs_[2][:, 0],
-            inputs_[2][:, 1],
-            u_c_,
-            None,
-            None,
-            l_c_,
-            None,
-            None,
-            decimal=decimal,
-        )
-    else:
-        raise ValueError("Unknown mode.")
-
-
-def test_maximum(odd, mode, floatx, decimal, helpers):
-    inputs_0 = helpers.get_tensor_decomposition_multid_box(odd)
-    inputs_1 = helpers.get_tensor_decomposition_multid_box(odd)
-
-    x_0, y_0, z_0, u_c_0, W_u_0, b_u_0, l_c_0, W_l_0, b_l_0, h_0, g_0 = inputs_0
-    x_1, y_1, z_1, u_c_1, W_u_1, b_u_1, l_c_1, W_l_1, b_l_1, h_1, g_1 = inputs_1
-
-    inputs_ = helpers.get_standard_values_multid_box(odd)
-
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
-
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = maximum(inputs_0[2:], inputs_1[2:], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = maximum(
-            [z_0, W_u_0, b_u_0, W_l_0, b_l_0, h_0, g_0],
-            [z_1, W_u_1, b_u_1, W_l_1, b_l_1, h_1, g_1],
-            dc_decomp=True,
-            mode=mode,
-        )
-    elif mode == ForwardMode.IBP:
-        output = maximum([u_c_0, l_c_0, h_0, g_0], [u_c_1, l_c_1, h_1, g_1], dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
-
-    f_ref = K.function(inputs_0 + inputs_1, K.maximum(inputs_0[1], inputs_1[1]))
-    f_maximum = K.function(inputs_0 + inputs_1, output)
-    y_ = f_ref(inputs_ + inputs_)
-
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_maximum(inputs_ + inputs_)
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.AFFINE:
-        output_ = f_maximum(inputs_ + inputs_)
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = output_
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-    elif mode == ForwardMode.IBP:
-        output_ = f_maximum(inputs_ + inputs_)
-        u_c_, l_c_, h_, g_ = output_
-        z_ = inputs_[2]
-        helpers.assert_output_properties_box(
-            x, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
-        )
-    else:
-        raise ValueError("Unknown mode.")
-
-
-def test_max_(odd, mode, floatx, decimal, helpers):
-
-    inputs = helpers.get_tensor_decomposition_multid_box(odd)
-    inputs_ = helpers.get_standard_values_multid_box(odd)
-
-    x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs
-    # x, y, z, u_c, W_u, b_u, l_c, W_l, b_l, h, g = inputs_
-
-    x_ = inputs_[0]
-    z_ = inputs_[2]
-
-    mode = ForwardMode(mode)
-    if mode == ForwardMode.HYBRID:
-        output = max_(inputs[2:], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.AFFINE:
-        output = max_([z, W_u, b_u, W_l, b_l, h, g], dc_decomp=True, mode=mode)
-    elif mode == ForwardMode.IBP:
-        output = max_([u_c, l_c, h, g], dc_decomp=True, mode=mode)
-    else:
-        raise ValueError("Unknown mode.")
-
-    f_ref = K.function(inputs, K.max(inputs[1], -1))
-    f_max = K.function(inputs, output)
-
-    y_ = f_ref(inputs_)
-
-    if mode == ForwardMode.HYBRID:
-        z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = f_max(inputs_)
-        helpers.assert_output_properties_box(
-            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, decimal=decimal
-        )
-
-    elif mode == ForwardMode.AFFINE:
-        z_, w_u_, b_u_, w_l_, b_l_, h_, g_ = f_max(inputs_)
-        helpers.assert_output_properties_box(
-            x_, y_, h_, g_, z_[:, 0], z_[:, 1], None, w_u_, b_u_, None, w_l_, b_l_, decimal=decimal
-        )
-
-    elif mode == ForwardMode.IBP:
-        u_c_, l_c_, h_, g_ = f_max(inputs_)
-        helpers.assert_output_properties_box(
-            x_, y_, h_, g_, z_[:, 0], z_[:, 1], u_c_, None, None, l_c_, None, None, decimal=decimal
-        )
-    else:
-        raise ValueError("Unknown mode.")
+    # check bounds consistency
+    helpers.assert_decomon_layer_output_properties_box(
+        full_inputs=inputs_,
+        output_ref=output_ref_,
+        outputs_for_mode=outputs_,
+        mode=mode,
+        dc_decomp=dc_decomp,
+        decimal=decimal,
+    )
 
 
 # DC_DECOMP = FALSE

--- a/tests/test_utils_pooling.py
+++ b/tests/test_utils_pooling.py
@@ -18,7 +18,9 @@ from decomon.layers.utils_pooling import (
         (get_upper_linear_hull_max, np.min, 0.0, np.inf),
     ],
 )
-def test_get_lower_upper_linear_hull_max(func, minmax, clipmin, clipmax, mode, floatx, axis, finetune_odd, helpers):
+def test_get_lower_upper_linear_hull_max(
+    func, minmax, clipmin, clipmax, mode, floatx, decimal, axis, finetune_odd, helpers
+):
 
     if finetune_odd is not None and func is not get_lower_linear_hull_max:
         # skip test with finetune if not get_lower
@@ -26,13 +28,6 @@ def test_get_lower_upper_linear_hull_max(func, minmax, clipmin, clipmax, mode, f
 
     odd, m_0, m_1 = 0, 0, 1
     data_format = "channels_last"
-
-    K.set_floatx("float{}".format(floatx))
-    eps = K.epsilon()
-    decimal = 5
-    if floatx == 16:
-        K.set_epsilon(1e-2)
-        decimal = 2
 
     inputs = helpers.get_tensor_decomposition_images_box(data_format, odd)
     inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1)
@@ -66,6 +61,3 @@ def test_get_lower_upper_linear_hull_max(func, minmax, clipmin, clipmax, mode, f
         decimal=decimal,
         err_msg=f"linear hull for bounding max",
     )
-
-    K.set_floatx("float{}".format(32))
-    K.set_epsilon(eps)

--- a/tests/test_utils_pooling.py
+++ b/tests/test_utils_pooling.py
@@ -12,17 +12,15 @@ from decomon.layers.utils_pooling import (
 
 
 @pytest.mark.parametrize(
-    "name, func, minmax, clipmin, clipmax",
+    "func, minmax, clipmin, clipmax",
     [
-        ("lower", get_lower_linear_hull_max, np.max, -np.inf, 0.0),
-        ("upper", get_upper_linear_hull_max, np.min, 0.0, np.inf),
+        (get_lower_linear_hull_max, np.max, -np.inf, 0.0),
+        (get_upper_linear_hull_max, np.min, 0.0, np.inf),
     ],
 )
-def test_get_lower_upper_linear_hull_max(
-    name, func, minmax, clipmin, clipmax, mode, floatx, axis, finetune_odd, helpers
-):
+def test_get_lower_upper_linear_hull_max(func, minmax, clipmin, clipmax, mode, floatx, axis, finetune_odd, helpers):
 
-    if finetune_odd is not None and name == "upper":
+    if finetune_odd is not None and func is not get_lower_linear_hull_max:
         # skip test with finetune if not get_lower
         pytest.skip("finetune_odd is only intended for get_lower_linear_hull_max()")
 
@@ -66,7 +64,7 @@ def test_get_lower_upper_linear_hull_max(
         minmax(np.clip(np.sum(w_ * y, axis) + b_ - y_, clipmin, clipmax)),
         0.0,
         decimal=decimal,
-        err_msg=f"linear hull for {name} bounding max",
+        err_msg=f"linear hull for bounding max",
     )
 
     K.set_floatx("float{}".format(32))

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -9,150 +9,135 @@ from decomon.backward_layers.utils import get_affine, get_ibp
 from decomon.models import clone
 
 
-def test_get_upper_1d_box(n, method, mode, helpers):
+@pytest.fixture()
+def toy_model_1d():
+    sequential = Sequential()
+    sequential.add(Dense(1, activation="linear", input_dim=1))
+    sequential.add(Activation("relu"))
+    sequential.add(Dense(1, activation="linear"))
+    return sequential
+
+
+@pytest.fixture()
+def toy_model_multid(odd, helpers):
+    input_dim = helpers.get_input_dim_multid_box(odd)
+    sequential = Sequential()
+    sequential.add(Dense(1, activation="linear", input_dim=input_dim))
+    sequential.add(Activation("relu"))
+    sequential.add(Dense(1, activation="linear"))
+    return sequential
+
+
+def test_get_upper_1d_box(toy_model_1d, n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
+
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, ibp=ibp, affine=affine, mode=mode)
-
+    backward_model = clone(toy_model_1d, method=method, ibp=ibp, affine=affine, mode=mode)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_1d.predict(y)
 
     try:
         assert (upper - y_ref).min() + 1e-6 >= 0.0
     except AssertionError:
-        sequential.save_weights("get_upper_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
+        toy_model_1d.save_weights("get_upper_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
         raise AssertionError
 
 
-def test_get_lower_1d_box(n, method, mode, helpers):
+def test_get_lower_1d_box(toy_model_1d, n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
+
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
-
+    backward_model = clone(toy_model_1d, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_1d.predict(y)
 
     try:
         assert (y_ref - lower).min() + 1e-6 >= 0.0
     except AssertionError:
-        sequential.save_weights("get_lower_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
+        toy_model_1d.save_weights("get_lower_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
         raise AssertionError
 
 
-def test_get_range_1d_box(n, method, mode, helpers):
+def test_get_range_1d_box(toy_model_1d, n, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
+
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
-
+    backward_model = clone(toy_model_1d, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_1d.predict(y)
 
     try:
         assert (upper - y_ref).min() + 1e-6 >= 0.0
         assert (y_ref - lower).min() + 1e-6 >= 0.0
     except AssertionError:
-        sequential.save_weights("get_range_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
+        toy_model_1d.save_weights("get_range_1d_box_fail_{}_{}_{}.hd5".format(n, method, mode))
         raise AssertionError
 
 
-def test_get_upper_multid_box(odd, method, mode, helpers):
+def test_get_upper_multid_box(toy_model_multid, odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_multid.predict(y)
 
     assert (upper - y_ref).min() + 1e-6 >= 0.0
 
 
-def test_get_lower_multid_box(odd, method, mode, helpers):
+def test_get_lower_multid_box(toy_model_multid, odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
+
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_multid.predict(y)
 
     assert (y_ref - lower).min() + 1e-6 >= 0.0
 
 
-def test_get_range_multid_box(odd, method, mode, helpers):
+def test_get_range_multid_box(toy_model_multid, odd, method, mode, helpers):
     if not helpers.is_method_mode_compatible(method=method, mode=mode):
         # skip method=ibp/crown-ibp with mode=affine/hybrid
         pytest.skip(f"output mode {mode} is not compatible with convert method {method}")
 
     inputs_ = helpers.get_standard_values_multid_box_convert(odd, dc_decomp=False)
     x, y, z, u_c, W_u, b_u, l_c, W_l, b_l = inputs_
-    # build a simple sequential model from keras
-    # start with 1D
-    sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=y.shape[-1]))  #
-    sequential.add(Activation("relu"))
-    sequential.add(Dense(1, activation="linear"))
+
     ibp = get_ibp(mode)
     affine = get_affine(mode)
-    backward_model = clone(sequential, method=method, final_ibp=ibp, final_affine=affine)
+    backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = sequential.predict(y)
+    y_ref = toy_model_multid.predict(y)
 
     assert (upper - y_ref).min() + 1e-6 >= 0.0
     assert (y_ref - lower).min() + 1e-6 >= 0.0


### PR DESCRIPTION
Fixes:
- Use appropriate inputs when testing decomon models (the are different from the one for decomon layers)

Clarification & refactoring:
- Add fixtures to avoid code duplication and simplify the tests
- keras/decomon model creation
- setting floatx and epsilon back and forth (using teardown feature)
- extraction of appropriate inputs from fulll inputs according to mode for decomon layers, keras layers, decomon models
- creation of full outputs from the outputs of decomon layers depending on modes
- assert based using directly ouputs from layers/models and full inputs (without having to decompose everything)
  - with auto-reconstruction of backward bounds when testing backward layers