### PR TITLE
Add tests for clone on more toy models

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from tensorflow.keras.layers import (
     Dense,
     Flatten,
     Input,
+    Reshape,
 )
 from tensorflow.keras.models import Model, Sequential
 
@@ -1458,16 +1459,16 @@ class Helpers:
         return Model(x, y)
 
     @staticmethod
-    def toy_struct_cnn(dtype="float32"):
-
+    def toy_struct_cnn(dtype="float32", image_data_shape=(6, 6, 2)):
+        input_dim = np.prod(image_data_shape)
         layers = [
+            Reshape(target_shape=image_data_shape, input_dim=input_dim),
             Conv2D(
                 10,
                 kernel_size=(3, 3),
                 activation="relu",
                 data_format="channels_last",
                 dtype=dtype,
-                input_shape=(28, 28, 3),
             ),
             Flatten(dtype=dtype),
             Dense(1, dtype=dtype),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1474,6 +1474,37 @@ class Helpers:
         ]
         return Sequential(layers)
 
+    @staticmethod
+    def toy_model(model_name, dtype="float32"):
+        if model_name == "tutorial":
+            return Helpers.toy_network_tutorial(dtype=dtype)
+        elif model_name == "tutorial_activation_embedded":
+            return Helpers.toy_network_tutorial_with_embedded_activation(dtype=dtype)
+        elif model_name == "merge_v0":
+            return Helpers.toy_struct_v0_1D(dtype=dtype, input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True)
+        elif model_name == "merge_v1":
+            return Helpers.toy_struct_v1_1D(
+                dtype=dtype, input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
+            )
+        elif model_name == "merge_v1_seq":
+            return Helpers.toy_struct_v1_1D(
+                dtype=dtype, input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=True
+            )
+        elif model_name == "merge_v1_2":
+            return Helpers.toy_struct_v1_1D(
+                dtype=dtype, input_dim=2, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
+            )
+        elif model_name == "merge_v2":
+            return Helpers.toy_struct_v2_1D(
+                dtype=dtype, input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
+            )
+        elif model_name == "cnn":
+            return Helpers.toy_struct_cnn(dtype=dtype)
+        elif model_name == "embedded_model":
+            return Helpers.toy_embedded_sequential(dtype=dtype)
+        else:
+            raise ValueError(f"model_name {model_name} unknown")
+
 
 @pytest.fixture
 def helpers():
@@ -1493,35 +1524,22 @@ def helpers():
         "embedded_model",
     ]
 )
-def toy_model(request, floatx, helpers):
+def toy_model(request, helpers):
     model_name = request.param
-    if model_name == "tutorial":
-        return helpers.toy_network_tutorial(dtype=K.floatx())
-    elif model_name == "tutorial_activation_embedded":
-        return helpers.toy_network_tutorial_with_embedded_activation(dtype=K.floatx())
-    elif model_name == "merge_v0":
-        return helpers.toy_struct_v0_1D(
-            dtype=K.floatx(), input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True
-        )
-    elif model_name == "merge_v1":
-        return helpers.toy_struct_v1_1D(
-            dtype=K.floatx(), input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
-        )
-    elif model_name == "merge_v1_seq":
-        return helpers.toy_struct_v1_1D(
-            dtype=K.floatx(), input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=True
-        )
-    elif model_name == "merge_v1_2":
-        return helpers.toy_struct_v1_1D(
-            dtype=K.floatx(), input_dim=2, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
-        )
-    elif model_name == "merge_v2":
-        return helpers.toy_struct_v2_1D(
-            dtype=K.floatx(), input_dim=1, archi=[2, 3, 2], activation="relu", use_bias=True, sequential=False
-        )
-    elif model_name == "cnn":
-        return helpers.toy_struct_cnn(dtype=K.floatx())
-    elif model_name == "embedded_model":
-        return helpers.toy_embedded_sequential(dtype=K.floatx())
-    else:
-        raise ValueError(f"model_name {model_name} unknown")
+    return helpers.toy_model(model_name, dtype=K.floatx())
+
+
+@pytest.fixture(
+    params=[
+        "tutorial",
+        "tutorial_activation_embedded",
+        "merge_v0",
+        "merge_v1",
+        "merge_v1_seq",
+        "merge_v2",
+        "embedded_model",
+    ]
+)
+def toy_model_1d(request, helpers):
+    model_name = request.param
+    return helpers.toy_model(model_name, dtype=K.floatx())


### PR DESCRIPTION
Test clone and resulting bounds on
- 1d toy models
- cnn model (with a first reshape layer to feed it with flatten multid inputs)
- deel-lip model (with layers having an export_vanilla method only)