### PR TITLE
Replace convex domain dictionariess by a specific class PerturbationDomain and subclasses according to its type

### DIFF
--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -7,9 +7,9 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.layers import Layer
 
 from decomon.backward_layers.utils import backward_relu_, backward_softplus_
+from decomon.core import BoxDomain, PerturbationDomain, Slope
 from decomon.layers.core import ForwardMode, StaticVariables
 from decomon.utils import (
-    Slope,
     get_linear_hull_relu,
     get_linear_hull_s_shape,
     get_linear_hull_sigmoid,
@@ -39,7 +39,7 @@ LINEAR = "linear"
 def backward_relu(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     alpha: float = 0.0,
     max_value: Optional[float] = None,
     threshold: float = 0.0,
@@ -52,7 +52,7 @@ def backward_relu(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         alpha
         max_value
         threshold
@@ -63,8 +63,8 @@ def backward_relu(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
     if dc_decomp:
         raise NotImplementedError()
@@ -95,7 +95,7 @@ def backward_relu(
 def backward_sigmoid(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -105,7 +105,7 @@ def backward_sigmoid(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -113,8 +113,8 @@ def backward_sigmoid(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -136,7 +136,7 @@ def backward_sigmoid(
 def backward_tanh(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -146,7 +146,7 @@ def backward_tanh(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -154,8 +154,8 @@ def backward_tanh(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -177,7 +177,7 @@ def backward_tanh(
 def backward_hard_sigmoid(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -187,7 +187,7 @@ def backward_hard_sigmoid(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -195,8 +195,8 @@ def backward_hard_sigmoid(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -206,7 +206,7 @@ def backward_hard_sigmoid(
 def backward_elu(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -216,7 +216,7 @@ def backward_elu(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -224,8 +224,8 @@ def backward_elu(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -236,7 +236,7 @@ def backward_elu(
 def backward_selu(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -246,7 +246,7 @@ def backward_selu(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -254,8 +254,8 @@ def backward_selu(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -266,7 +266,7 @@ def backward_selu(
 def backward_linear(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -276,15 +276,15 @@ def backward_linear(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
     Returns:
 
     """
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
     slope = Slope(slope)
     raise NotImplementedError()
@@ -293,7 +293,7 @@ def backward_linear(
 def backward_exponential(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -303,15 +303,15 @@ def backward_exponential(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
     Returns:
 
     """
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -322,7 +322,7 @@ def backward_exponential(
 def backward_softplus(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -332,7 +332,7 @@ def backward_softplus(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
 
@@ -340,8 +340,8 @@ def backward_softplus(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)
@@ -363,7 +363,7 @@ def backward_softplus(
 def backward_softsign(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
@@ -376,7 +376,7 @@ def backward_softsign(
         b_u_out
         w_l_out
         b_l_out
-        convex_domain
+        perturbation_domain
         slope: backward slope
         mode
 
@@ -384,11 +384,11 @@ def backward_softsign(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
 
     bounds = get_linear_hull_s_shape(
-        inputs, func=K.softsign, f_prime=softsign_prime, convex_domain=convex_domain, mode=mode
+        inputs, func=K.softsign, f_prime=softsign_prime, perturbation_domain=perturbation_domain, mode=mode
     )
     shape = np.prod(inputs[-1].shape[1:])
     return [K.reshape(elem, (-1, shape)) for elem in bounds]
@@ -400,16 +400,16 @@ def backward_softsign_(
     b_u_out: tf.Tensor,
     w_l_out: tf.Tensor,
     b_l_out: tf.Tensor,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
 ) -> List[tf.Tensor]:
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     w_u_0, b_u_0, w_l_0, b_l_0 = get_linear_hull_s_shape(
-        inputs, func=K.softsign, f_prime=softsign_prime, convex_domain=convex_domain, mode=mode, slope=slope
+        inputs, func=K.softsign, f_prime=softsign_prime, perturbation_domain=perturbation_domain, mode=mode, slope=slope
     )
 
     w_u_0 = K.expand_dims(w_u_0, -1)
@@ -430,7 +430,7 @@ def backward_softsign_(
 def backward_softmax(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
@@ -441,7 +441,7 @@ def backward_softmax(
     Args:
         inputs
         dc_decomp
-        convex_domain
+        perturbation_domain
         slope
         mode
         axis
@@ -450,8 +450,8 @@ def backward_softmax(
 
     """
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     if dc_decomp:
         raise NotImplementedError()
     mode = ForwardMode(mode)

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -7,8 +7,9 @@ from tensorflow.keras.layers import Flatten, Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import backward_max_
+from decomon.core import PerturbationDomain
 from decomon.layers.core import ForwardMode
-from decomon.utils import Slope, get_lower, get_upper
+from decomon.utils import get_lower, get_upper
 
 
 class BackwardMaxPooling2D(BackwardLayer):
@@ -25,7 +26,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         layer: Layer,
         rec: int = 1,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         **kwargs: Any,
     ):
@@ -33,7 +34,7 @@ class BackwardMaxPooling2D(BackwardLayer):
             layer=layer,
             rec=rec,
             mode=mode,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             **kwargs,
         )
@@ -50,7 +51,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         strides: Tuple[int, int],
         padding: str,
         data_format: str,
-        convex_domain: Dict[str, Any],
+        perturbation_domain: PerturbationDomain,
     ) -> List[tf.Tensor]:
         if self.fast:
             return self._pooling_function_fast(
@@ -63,7 +64,7 @@ class BackwardMaxPooling2D(BackwardLayer):
                 strides=strides,
                 padding=padding,
                 data_format=data_format,
-                convex_domain=convex_domain,
+                perturbation_domain=perturbation_domain,
             )
         else:
             return self._pooling_function_not_fast(
@@ -76,7 +77,7 @@ class BackwardMaxPooling2D(BackwardLayer):
                 strides=strides,
                 padding=padding,
                 data_format=data_format,
-                convex_domain=convex_domain,
+                perturbation_domain=perturbation_domain,
             )
 
     def _pooling_function_fast(
@@ -90,15 +91,15 @@ class BackwardMaxPooling2D(BackwardLayer):
         strides: Tuple[int, int],
         padding: str,
         data_format: str,
-        convex_domain: Dict[str, Any],
+        perturbation_domain: PerturbationDomain,
     ) -> List[tf.Tensor]:
 
         if self.mode == ForwardMode.HYBRID:
             x_0, u_c, w_u, b_u, l_c, w_l, b_l = inputs[:7]
         elif self.mode == ForwardMode.AFFINE:
             x_0, w_u, b_u, w_l, b_l = inputs[:5]
-            u_c = get_upper(x_0, w_u, b_u, convex_domain=convex_domain)
-            l_c = get_lower(x_0, w_l, b_l, convex_domain=convex_domain)
+            u_c = get_upper(x_0, w_u, b_u, perturbation_domain=perturbation_domain)
+            l_c = get_lower(x_0, w_l, b_l, perturbation_domain=perturbation_domain)
         elif self.mode == ForwardMode.IBP:
             u_c, l_c = inputs[:2]
         else:
@@ -138,7 +139,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         strides: Tuple[int, int],
         padding: str,
         data_format: str,
-        convex_domain: Dict[str, Any],
+        perturbation_domain: PerturbationDomain,
     ) -> List[tf.Tensor]:
         """
         Args:
@@ -220,7 +221,7 @@ class BackwardMaxPooling2D(BackwardLayer):
             b_u_out,
             w_l_out,
             b_l_out,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             mode=self.mode,
             axis=-1,
         )
@@ -275,5 +276,5 @@ class BackwardMaxPooling2D(BackwardLayer):
             strides=self.strides,
             padding=self.padding,
             data_format=self.data_format,
-            convex_domain=self.convex_domain,
+            perturbation_domain=self.perturbation_domain,
         )

--- a/src/decomon/backward_layers/convert.py
+++ b/src/decomon/backward_layers/convert.py
@@ -7,8 +7,8 @@ import decomon.backward_layers.backward_maxpooling
 import decomon.backward_layers.backward_merge
 import decomon.backward_layers.deel_lip
 from decomon.backward_layers.core import BackwardLayer
+from decomon.core import BoxDomain, PerturbationDomain, Slope
 from decomon.layers.core import ForwardMode
-from decomon.utils import Slope
 
 _mapping_name2class: Dict[str, Any] = vars(decomon.backward_layers.backward_layers)
 _mapping_name2class.update(vars(decomon.backward_layers.deel_lip))
@@ -20,12 +20,12 @@ def to_backward(
     layer: Layer,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     finetune: bool = False,
     **kwargs: Any,
 ) -> BackwardLayer:
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
     class_name = layer.__class__.__name__
     if class_name.startswith("Decomon"):
         class_name = "".join(layer.__class__.__name__.split("Decomon")[1:])
@@ -40,7 +40,7 @@ def to_backward(
         layer,
         slope=slope,
         mode=mode,
-        convex_domain=convex_domain,
+        perturbation_domain=perturbation_domain,
         finetune=finetune,
         dtype=layer.dtype,
         name=backward_layer_name,

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 import tensorflow as tf
 from tensorflow.keras.layers import Layer, Wrapper
 
+from decomon.core import BoxDomain, PerturbationDomain
 from decomon.layers.core import DecomonLayer, ForwardMode
 
 
@@ -17,7 +18,7 @@ class BackwardLayer(ABC, Wrapper):
         layer: Layer,
         rec: int = 1,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         **kwargs: Any,
     ):
@@ -27,14 +28,14 @@ class BackwardLayer(ABC, Wrapper):
         self.rec = rec
         if isinstance(self.layer, DecomonLayer):
             self.mode = self.layer.mode
-            self.convex_domain = self.layer.convex_domain
+            self.perturbation_domain = self.layer.perturbation_domain
             self.dc_decomp = self.layer.dc_decomp
         else:
             self.mode = ForwardMode(mode)
-            if convex_domain is None:
-                self.convex_domain = {}
+            if perturbation_domain is None:
+                self.perturbation_domain = BoxDomain()
             else:
-                self.convex_domain = convex_domain
+                self.perturbation_domain = perturbation_domain
             self.dc_decomp = dc_decomp
 
     def get_config(self) -> Dict[str, Any]:
@@ -43,7 +44,7 @@ class BackwardLayer(ABC, Wrapper):
             {
                 "rec": self.rec,
                 "mode": self.mode,
-                "convex_domain": self.convex_domain,
+                "perturbation_domain": self.perturbation_domain,
                 "dc_decomp": self.dc_decomp,
             }
         )

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -5,6 +5,7 @@ from tensorflow.keras.layers import Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import get_affine, get_ibp
+from decomon.core import PerturbationDomain
 from decomon.layers.convert import to_decomon
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonLayer
@@ -29,7 +30,7 @@ class BackwardGroupSort2(BackwardLayer):
         input_dim: int = -1,
         rec: int = 1,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         **kwargs: Any,
     ):
@@ -37,7 +38,7 @@ class BackwardGroupSort2(BackwardLayer):
             layer=layer,
             rec=rec,
             mode=mode,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             **kwargs,
         )
@@ -47,7 +48,7 @@ class BackwardGroupSort2(BackwardLayer):
                 layer=layer,
                 input_dim=input_dim,
                 dc_decomp=False,
-                convex_domain=self.convex_domain,
+                perturbation_domain=self.perturbation_domain,
                 finetune=False,
                 ibp=get_ibp(self.mode),
                 affine=get_affine(self.mode),

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -1,0 +1,50 @@
+from enum import Enum
+from typing import Union
+
+import numpy as np
+
+
+class Option(Enum):
+    lagrangian = "lagrangian"
+    milp = "milp"
+
+
+class Slope(Enum):
+    V_SLOPE = "volume-slope"
+    A_SLOPE = "adaptative-slope"
+    S_SLOPE = "same-slope"
+    Z_SLOPE = "zero-lb"
+    O_SLOPE = "one-lb"
+
+
+class PerturbationDomain:
+    opt_option: Option
+
+    def __init__(self, opt_option: Union[str, Option] = Option.milp):
+        self.opt_option = Option(opt_option)
+
+
+class BoxDomain(PerturbationDomain):
+    pass
+
+
+class GridDomain(PerturbationDomain):
+    pass
+
+
+class VertexDomain(PerturbationDomain):
+    pass
+
+
+class BallDomain(PerturbationDomain):
+    def __init__(self, eps: float, p: float = 2, opt_option: Option = Option.milp):
+        super().__init__(opt_option=opt_option)
+        self.eps = eps
+        # check on p
+        p_error_msg = "p must be a positive integer or np.inf"
+        try:
+            if p != np.inf and (int(p) != p or p <= 0):
+                raise ValueError(p_error_msg)
+        except:
+            raise ValueError(p_error_msg)
+        self.p = p

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
+from decomon.core import BoxDomain, PerturbationDomain
 from decomon.keras_utils import get_weight_index_from_name
 
 
@@ -77,7 +78,7 @@ class DecomonLayer(ABC, Layer):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -87,7 +88,7 @@ class DecomonLayer(ABC, Layer):
     ):
         """
         Args:
-            convex_domain: type of convex input domain (None or dict)
+            perturbation_domain: type of convex input domain (None or dict)
             dc_decomp: boolean that indicates whether we return a
             mode: type of Forward propagation (ibp, affine, or hybrid)
             **kwargs: extra parameters
@@ -96,11 +97,11 @@ class DecomonLayer(ABC, Layer):
         kwargs.pop("slope", None)  # remove it if not used by the decomon layer
         super().__init__(**kwargs)
 
-        if convex_domain is None:
-            convex_domain = {}
+        if perturbation_domain is None:
+            perturbation_domain = BoxDomain()
         self.nb_tensors = StaticVariables(dc_decomp, mode).nb_tensors
         self.dc_decomp = dc_decomp
-        self.convex_domain = convex_domain
+        self.perturbation_domain = perturbation_domain
         self.mode = ForwardMode(mode)
         self.finetune = finetune  # extra optimization with hyperparameters
         self.frozen_weights = False
@@ -118,7 +119,7 @@ class DecomonLayer(ABC, Layer):
                 "fast": self.fast,
                 "finetune": self.finetune,
                 "mode": self.mode,
-                "convex_domain": self.convex_domain,
+                "perturbation_domain": self.perturbation_domain,
             }
         )
         return config

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -14,6 +14,7 @@ from tensorflow.keras.layers import (
     Subtract,
 )
 
+from decomon.core import PerturbationDomain
 from decomon.layers.core import DecomonLayer, ForwardMode
 from decomon.layers.utils import broadcast, multiply, permute_dimensions
 from decomon.utils import maximum, minus, subtract
@@ -43,7 +44,7 @@ class DecomonAdd(DecomonMerge, Add):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -52,7 +53,7 @@ class DecomonAdd(DecomonMerge, Add):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -123,7 +124,7 @@ class DecomonAverage(DecomonMerge, Average):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -132,7 +133,7 @@ class DecomonAverage(DecomonMerge, Average):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -202,7 +203,7 @@ class DecomonSubtract(DecomonMerge, Subtract):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -211,7 +212,7 @@ class DecomonSubtract(DecomonMerge, Subtract):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -230,7 +231,11 @@ class DecomonSubtract(DecomonMerge, Subtract):
         inputs_list = [inputs[n_comp * i : n_comp * (i + 1)] for i in range(len(inputs) // n_comp)]
 
         output = subtract(
-            inputs_list[0], inputs_list[1], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+            inputs_list[0],
+            inputs_list[1],
+            dc_decomp=self.dc_decomp,
+            perturbation_domain=self.perturbation_domain,
+            mode=self.mode,
         )
         return output
 
@@ -245,7 +250,7 @@ class DecomonMinimum(DecomonMerge, Minimum):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -254,7 +259,7 @@ class DecomonMinimum(DecomonMerge, Minimum):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -280,11 +285,19 @@ class DecomonMinimum(DecomonMerge, Minimum):
         ]
 
         output = maximum(
-            inputs_list[0], inputs_list[1], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+            inputs_list[0],
+            inputs_list[1],
+            dc_decomp=self.dc_decomp,
+            perturbation_domain=self.perturbation_domain,
+            mode=self.mode,
         )
         for j in range(2, len(inputs) // n_comp):
             output = maximum(
-                output, inputs_list[j], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+                output,
+                inputs_list[j],
+                dc_decomp=self.dc_decomp,
+                perturbation_domain=self.perturbation_domain,
+                mode=self.mode,
             )
 
         return minus(output, mode=self.mode)
@@ -300,7 +313,7 @@ class DecomonMaximum(DecomonMerge, Maximum):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -309,7 +322,7 @@ class DecomonMaximum(DecomonMerge, Maximum):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -332,11 +345,19 @@ class DecomonMaximum(DecomonMerge, Maximum):
         inputs_list = [inputs[n_comp * i : n_comp * (i + 1)] for i in range(len(inputs) // n_comp)]
 
         output = maximum(
-            inputs_list[0], inputs_list[1], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+            inputs_list[0],
+            inputs_list[1],
+            dc_decomp=self.dc_decomp,
+            perturbation_domain=self.perturbation_domain,
+            mode=self.mode,
         )
         for j in range(2, len(inputs) // n_comp):
             output = maximum(
-                output, inputs_list[j], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+                output,
+                inputs_list[j],
+                dc_decomp=self.dc_decomp,
+                perturbation_domain=self.perturbation_domain,
+                mode=self.mode,
             )
 
         return output
@@ -353,7 +374,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
     def __init__(
         self,
         axis: int = -1,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -363,7 +384,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
     ):
         super().__init__(
             axis=axis,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -440,7 +461,7 @@ class DecomonMultiply(DecomonMerge, Multiply):
 
     def __init__(
         self,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -449,7 +470,7 @@ class DecomonMultiply(DecomonMerge, Multiply):
         **kwargs: Any,
     ):
         super().__init__(
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -469,11 +490,19 @@ class DecomonMultiply(DecomonMerge, Multiply):
         inputs_list = [inputs[n_comp * i : n_comp * (i + 1)] for i in range(len(inputs) // n_comp)]
 
         output = multiply(
-            inputs_list[0], inputs_list[1], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+            inputs_list[0],
+            inputs_list[1],
+            dc_decomp=self.dc_decomp,
+            perturbation_domain=self.perturbation_domain,
+            mode=self.mode,
         )
         for j in range(2, len(inputs) // n_comp):
             output = multiply(
-                output, inputs_list[j], dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+                output,
+                inputs_list[j],
+                dc_decomp=self.dc_decomp,
+                perturbation_domain=self.perturbation_domain,
+                mode=self.mode,
             )
 
         return output
@@ -490,7 +519,7 @@ class DecomonDot(DecomonMerge, Dot):
     def __init__(
         self,
         axes: Union[int, Tuple[int, int]] = (-1, -1),
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -500,7 +529,7 @@ class DecomonDot(DecomonMerge, Dot):
     ):
         super().__init__(
             axes=axes,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -540,7 +569,7 @@ class DecomonDot(DecomonMerge, Dot):
         inputs_1 = broadcast(inputs_1, n_0, 2, mode=self.mode)
 
         outputs_multiply = multiply(
-            inputs_0, inputs_1, dc_decomp=self.dc_decomp, convex_domain=self.convex_domain, mode=self.mode
+            inputs_0, inputs_1, dc_decomp=self.dc_decomp, perturbation_domain=self.perturbation_domain, mode=self.mode
         )
 
         if self.mode == ForwardMode.IBP:

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import InputSpec, Layer, Permute, Reshape
 
+from decomon.core import PerturbationDomain
 from decomon.layers.core import DecomonLayer, ForwardMode
 
 
@@ -17,7 +18,7 @@ class DecomonReshape(DecomonLayer, Reshape):
     def __init__(
         self,
         target_shape: Tuple[int, ...],
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -32,7 +33,7 @@ class DecomonReshape(DecomonLayer, Reshape):
         """
         super().__init__(
             target_shape=target_shape,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,
@@ -133,7 +134,7 @@ class DecomonPermute(DecomonLayer, Permute):
     def __init__(
         self,
         dims: Tuple[int, ...],
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -148,7 +149,7 @@ class DecomonPermute(DecomonLayer, Permute):
         """
         super().__init__(
             dims=dims,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -6,6 +6,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.backend import conv2d
 from tensorflow.keras.layers import InputSpec, MaxPooling2D
 
+from decomon.core import PerturbationDomain
 from decomon.layers.core import DecomonLayer, ForwardMode
 from decomon.layers.utils import max_
 from decomon.utils import get_lower, get_upper
@@ -31,7 +32,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
         strides: Optional[Union[int, Tuple[int, int]]] = None,
         padding: str = "valid",
         data_format: Optional[str] = None,
-        convex_domain: Optional[Dict[str, Any]] = None,
+        perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         finetune: bool = False,
@@ -45,7 +46,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             strides=strides,
             padding=padding,
             data_format=data_format,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
             finetune=finetune,

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.keras import backend as K
 
+from decomon.core import PerturbationDomain
 from decomon.layers.core import ForwardMode, StaticVariables
 from decomon.utils import get_lower, get_upper
 
@@ -14,7 +15,7 @@ from decomon.utils import get_lower, get_upper
 def get_upper_linear_hull_max(
     inputs: List[tf.Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
     **kwargs: Any,
 ) -> List[tf.Tensor]:
@@ -23,7 +24,7 @@ def get_upper_linear_hull_max(
     Args:
         inputs: list of input tensors
         mode: type of Forward propagation (ibp, affine, or hybrid). Default to hybrid.
-        convex_domain (optional): type of convex domain that encompass the set of perturbations. Defaults to None.
+        perturbation_domain (optional): type of perturbation domain that encompass the set of perturbations. Defaults to None.
         axis (optional): Defaults to -1. See Keras offical documentation backend.max(., axis)
 
     Raises:
@@ -53,15 +54,15 @@ def get_upper_linear_hull_max(
     elif mode == ForwardMode.AFFINE:
 
         x, w_u, b_u, w_l, b_l = inputs[:nb_tensor]
-        u_c = get_upper(x, w_u, b_u, convex_domain=convex_domain)
+        u_c = get_upper(x, w_u, b_u, perturbation_domain=perturbation_domain)
         # assuming axis=-1 u_c.shape=(None, shape, n_dim)
-        l_c = get_lower(x, w_l, b_l, convex_domain=convex_domain)
+        l_c = get_lower(x, w_l, b_l, perturbation_domain=perturbation_domain)
 
     elif mode == ForwardMode.HYBRID:
 
         x, u_c_h, w_u, b_u, l_c_h, w_l, b_l = inputs[:nb_tensor]
-        u_c = K.minimum(u_c_h, get_upper(x, w_u, b_u, convex_domain=convex_domain))
-        l_c = K.maximum(l_c_h, get_lower(x, w_l, b_l, convex_domain=convex_domain))
+        u_c = K.minimum(u_c_h, get_upper(x, w_u, b_u, perturbation_domain=perturbation_domain))
+        l_c = K.maximum(l_c_h, get_lower(x, w_l, b_l, perturbation_domain=perturbation_domain))
 
     # get the shape of the dimension
     n_dim = K.int_shape(inputs[-1])[axis]
@@ -132,7 +133,7 @@ def get_upper_linear_hull_max(
 def get_lower_linear_hull_max(
     inputs: List[tf.Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
     finetune_lower: Optional[tf.Tensor] = None,
     **kwargs: Any,
@@ -142,7 +143,7 @@ def get_lower_linear_hull_max(
     Args:
         inputs: list of input tensors
         mode: type of Forward propagation (ibp, affine, or hybrid). Default to hybrid.
-        convex_domain (optional): type of convex domain that encompass the set of perturbations. Defaults to None.
+        perturbation_domain (optional): type of perturbation domain that encompass the set of perturbations. Defaults to None.
         axis (optional): Defaults to -1. See Keras offical documentation backend.max(., axis)
         finetune_lower: If not None, should be a constant tensor used to fine tune the lower relaxation.
 
@@ -171,15 +172,15 @@ def get_lower_linear_hull_max(
     elif mode == ForwardMode.AFFINE:
 
         x, w_u, b_u, w_l, b_l = inputs[:nb_tensor]
-        u_c = get_upper(x, w_u, b_u, convex_domain=convex_domain)
+        u_c = get_upper(x, w_u, b_u, perturbation_domain=perturbation_domain)
         # assuming axis=-1 u_c.shape=(None, shape, n_dim)
-        l_c = get_lower(x, w_l, b_l, convex_domain=convex_domain)
+        l_c = get_lower(x, w_l, b_l, perturbation_domain=perturbation_domain)
 
     elif mode == ForwardMode.HYBRID:
 
         x, u_c_h, w_u, b_u, l_c_h, w_l, b_l = inputs[:nb_tensor]
-        u_c = K.minimum(u_c_h, get_upper(x, w_u, b_u, convex_domain=convex_domain))
-        l_c = K.maximum(l_c_h, get_lower(x, w_l, b_l, convex_domain=convex_domain))
+        u_c = K.minimum(u_c_h, get_upper(x, w_u, b_u, perturbation_domain=perturbation_domain))
+        l_c = K.maximum(l_c_h, get_lower(x, w_l, b_l, perturbation_domain=perturbation_domain))
 
     V = u_c + l_c
     M = -u_c + K.expand_dims(K.max(l_c, axis), axis)

--- a/src/decomon/metrics/utils.py
+++ b/src/decomon/metrics/utils.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import tensorflow as tf
 
+from decomon.core import BoxDomain, PerturbationDomain
 from decomon.layers.core import ForwardMode
 from decomon.layers.utils import exp, expand_dims, log, sum
 from decomon.utils import add, minus
@@ -13,23 +14,23 @@ def categorical_cross_entropy(
     inputs: List[tf.Tensor],
     dc_decomp: bool = False,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
 ) -> List[tf.Tensor]:
 
     # step 1: exponential
-    if convex_domain is None:
-        convex_domain = {}
-    outputs = exp(inputs, mode=mode, convex_domain=convex_domain, dc_decomp=dc_decomp)
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
+    outputs = exp(inputs, mode=mode, perturbation_domain=perturbation_domain, dc_decomp=dc_decomp)
     # step 2: sum
     outputs = sum(outputs, axis=-1, mode=mode)
     # step 3: log
-    outputs = log(outputs, dc_decomp=dc_decomp, mode=mode, convex_domain=convex_domain)
-    outputs = expand_dims(outputs, dc_decomp=dc_decomp, mode=mode, convex_domain=convex_domain, axis=-1)
+    outputs = log(outputs, dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain)
+    outputs = expand_dims(outputs, dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain, axis=-1)
     # step 4: - inputs
     return add(
-        minus(inputs, mode=mode, convex_domain=convex_domain, dc_decomp=dc_decomp),
+        minus(inputs, mode=mode, perturbation_domain=perturbation_domain, dc_decomp=dc_decomp),
         outputs,
         mode=mode,
-        convex_domain=convex_domain,
+        perturbation_domain=perturbation_domain,
         dc_decomp=dc_decomp,
     )

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -12,6 +12,7 @@ from tensorflow.keras.layers import Layer
 from tensorflow.keras.models import Model
 from tensorflow.python.keras.utils.generic_utils import to_list
 
+from decomon.core import BoxDomain, PerturbationDomain, Slope
 from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
@@ -22,7 +23,6 @@ from decomon.models.utils import (
     prepare_inputs_for_layer,
     wrap_outputs_from_layer_in_list,
 )
-from decomon.utils import Slope
 
 OutputMapKey = Union[str, int]
 OutputMapVal = Union[List[tf.Tensor], "OutputMapDict"]
@@ -37,7 +37,7 @@ def include_dim_layer_fn(
     input_dim: int,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     ibp: bool = True,
     affine: bool = True,
     finetune: bool = False,
@@ -49,14 +49,14 @@ def include_dim_layer_fn(
         layer_fn
         input_dim
         dc_decomp
-        convex_domain
+        perturbation_domain
         finetune
 
     Returns:
 
     """
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
 
     if not callable(layer_fn):
         raise ValueError("Expected `layer_fn` argument to be a callable.")
@@ -71,7 +71,7 @@ def include_dim_layer_fn(
                     layer,
                     input_dim=input_dim,
                     slope=slope,
-                    convex_domain=convex_domain,
+                    perturbation_domain=perturbation_domain,
                     dc_decomp=dc_decomp,
                     ibp=ibp,
                     affine=affine,
@@ -95,7 +95,7 @@ def convert_forward(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     input_dim: int = -1,
     dc_decomp: bool = False,
-    convex_domain: Optional[Dict[str, Any]] = None,
+    perturbation_domain: Optional[PerturbationDomain] = None,
     ibp: bool = True,
     affine: bool = True,
     finetune: bool = False,
@@ -105,8 +105,8 @@ def convert_forward(
     **kwargs: Any,
 ) -> Tuple[List[tf.Tensor], List[tf.Tensor], LayerMapDict, OutputMapDict]:
 
-    if convex_domain is None:
-        convex_domain = {}
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
 
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
@@ -118,7 +118,7 @@ def convert_forward(
         layer_fn,
         input_dim=input_dim,
         slope=slope,
-        convex_domain=convex_domain,
+        perturbation_domain=perturbation_domain,
         ibp=ibp,
         affine=affine,
         finetune=finetune,

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -4,10 +4,10 @@ import numpy as np
 import numpy.typing as npt
 import tensorflow as tf
 
+from decomon.core import BallDomain, BoxDomain, GridDomain
 from decomon.models.convert import clone
 from decomon.models.models import DecomonModel
 from decomon.models.utils import ConvertMethod
-from decomon.utils import ConvexDomainType
 
 IntegerType = Union[int, np.int_]
 """Alias for integers types."""
@@ -72,10 +72,7 @@ def get_adv_box(
     if not isinstance(model, DecomonModel):
         decomon_model = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
-            ConvexDomainType.BOX,
-            ConvexDomainType.GRID,
-        ]
+        assert isinstance(model.perturbation_domain, (BoxDomain, GridDomain))
         decomon_model = model
 
     n_split = 1
@@ -299,10 +296,7 @@ def check_adv_box(
     if not isinstance(model, DecomonModel):
         decomon_model = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
-            ConvexDomainType.BOX,
-            ConvexDomainType.GRID,
-        ]
+        assert isinstance(model.perturbation_domain, (BoxDomain, GridDomain))
         decomon_model = model
 
     ibp = decomon_model.ibp
@@ -504,10 +498,7 @@ def get_range_box(
     if not (isinstance(model, DecomonModel)):
         decomon_model = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
-            ConvexDomainType.BOX,
-            ConvexDomainType.GRID,
-        ]
+        assert isinstance(model.perturbation_domain, (BoxDomain, GridDomain))
         decomon_model = model
 
     n_split = 1
@@ -684,18 +675,18 @@ def get_range_noise(
     """
 
     # check that the model is a DecomonModel, else do the conversion
-    convex_domain = {"name": ConvexDomainType.BALL, "p": p, "eps": max(0, eps)}
+    perturbation_domain = BallDomain(p=p, eps=max(0, eps))
 
     if not isinstance(model, DecomonModel):
         decomon_model = clone(
             model,
             method=ConvertMethod.CROWN_FORWARD_HYBRID,
-            convex_domain=convex_domain,
+            perturbation_domain=perturbation_domain,
         )
     else:
         decomon_model = model
         if eps >= 0:
-            decomon_model.set_domain(convex_domain)
+            decomon_model.set_domain(perturbation_domain)
 
     # reshape x_mmin, x_max
     input_shape = list(decomon_model.input_shape[1:])
@@ -840,10 +831,7 @@ def refine_box(
     if not isinstance(model, DecomonModel):
         decomon_model = clone(model)
     else:
-        assert len(model.convex_domain) == 0 or ConvexDomainType(model.convex_domain["name"]) in [
-            ConvexDomainType.BOX,
-            ConvexDomainType.GRID,
-        ]
+        assert isinstance(model.perturbation_domain, (BoxDomain, GridDomain))
         decomon_model = model
 
     # reshape x_mmin, x_max
@@ -959,17 +947,17 @@ def get_adv_noise(
         numpy array, vector with upper bounds for adversarial attacks
     """
 
-    convex_domain = {"name": ConvexDomainType.BALL, "p": p, "eps": max(0, eps)}
+    perturbation_domain = BallDomain(p=p, eps=max(0, eps))
 
     # check that the model is a DecomonModel, else do the conversion
     if not isinstance(model, DecomonModel):
-        decomon_model = clone(model, convex_domain=convex_domain)
+        decomon_model = clone(model, perturbation_domain=perturbation_domain)
     else:
         decomon_model = model
         if eps >= 0:
-            decomon_model.set_domain(convex_domain)
+            decomon_model.set_domain(perturbation_domain)
 
-    eps = model.convex_domain["eps"]
+    eps = model.perturbation_domain.eps
 
     # reshape x_mmin, x_max
     input_shape = list(decomon_model.input_shape[1:])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,9 @@ from tensorflow.keras.layers import (
 )
 from tensorflow.keras.models import Model, Sequential
 
+from decomon.core import Slope
 from decomon.layers.core import ForwardMode
 from decomon.models.utils import ConvertMethod
-from decomon.utils import Slope
 
 
 @pytest.fixture(params=[m.value for m in ForwardMode])

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -6,9 +6,9 @@ import pytest
 import tensorflow.keras.backend as K
 from numpy.testing import assert_almost_equal
 
+from decomon.core import Slope
 from decomon.layers.activations import relu, sigmoid, softmax, softsign, tanh
 from decomon.layers.core import ForwardMode
-from decomon.utils import Slope
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backward_activation.py
+++ b/tests/test_backward_activation.py
@@ -4,8 +4,8 @@ import tensorflow.keras.backend as K
 from numpy.testing import assert_almost_equal
 
 from decomon.backward_layers.activations import backward_relu, backward_softsign
+from decomon.core import Slope
 from decomon.layers.core import ForwardMode
-from decomon.utils import Slope
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -4,10 +4,10 @@ from tensorflow.keras.layers import Layer, Reshape
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.backward_layers.convert import to_backward
+from decomon.core import Slope
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonActivation, DecomonFlatten
 from decomon.layers.decomon_reshape import DecomonReshape
-from decomon.utils import Slope
 
 
 def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, decimal, helpers):
@@ -58,7 +58,7 @@ def test_Backward_Activation_1D_box_model_slope(helpers):
     # to_backward with a given slope => outputs
     outputs_by_slope = {}
     for slope in Slope:
-        layer_backward = to_backward(decomon_layer, slope=slope, mode=mode, convex_domain={})
+        layer_backward = to_backward(decomon_layer, slope=slope, mode=mode)
         assert layer_backward.slope == slope
         outputs = layer_backward(inputs_for_mode)
         f_decomon = K.function(inputs, outputs)

--- a/tests/test_backward_layers_get_config.py
+++ b/tests/test_backward_layers_get_config.py
@@ -30,6 +30,7 @@ from decomon.backward_layers.crown import (
     MergeWithPrevious,
 )
 from decomon.backward_layers.deel_lip import BackwardGroupSort2
+from decomon.core import BoxDomain
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import (
     DecomonActivation,
@@ -151,7 +152,7 @@ def test_deel_lip():
 
 def test_crown():
     mode = ForwardMode.AFFINE
-    convex_domain = {}
+    perturbation_domain = BoxDomain()
     input_shape_layer = (1, 2, 4)
     backward_shape_layer = (2, 5, 10)
 
@@ -159,10 +160,10 @@ def test_crown():
     config = layer.get_config()
     assert config["mode"] == mode
 
-    layer = Convert2BackwardMode(mode=mode, convex_domain=convex_domain)
+    layer = Convert2BackwardMode(mode=mode, perturbation_domain=perturbation_domain)
     config = layer.get_config()
     assert config["mode"] == mode
-    assert "convex_domain" in config
+    assert "perturbation_domain" in config
 
     layer = MergeWithPrevious(input_shape_layer=input_shape_layer, backward_shape_layer=backward_shape_layer)
     config = layer.get_config()

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -8,6 +8,7 @@ from tensorflow.keras.layers import Activation, Dense, Flatten, Input, Reshape
 from tensorflow.keras.models import Sequential
 
 from decomon.backward_layers.utils import get_affine, get_ibp
+from decomon.core import Slope
 from decomon.layers.core import ForwardMode, get_mode
 from decomon.layers.decomon_reshape import DecomonReshape
 from decomon.models import clone
@@ -17,7 +18,6 @@ from decomon.models.utils import (
     get_ibp_affine_from_method,
     has_merge_layers,
 )
-from decomon.utils import Slope
 
 try:
     import deel.lip

--- a/tests/test_decomon_activation_layer.py
+++ b/tests/test_decomon_activation_layer.py
@@ -1,8 +1,8 @@
 import tensorflow.python.keras.backend as K
 
+from decomon.core import Slope
 from decomon.layers.core import ForwardMode
 from decomon.layers.decomon_layers import DecomonActivation
-from decomon.utils import Slope
 
 
 def test_decomon_activation_slope(helpers):

--- a/tests/test_metrics_get_config.py
+++ b/tests/test_metrics_get_config.py
@@ -24,11 +24,11 @@ def test_decomon_loss():
 
 
 def test_metric():
-    ibp, affine, mode, convex_domain = True, False, MetricMode.BACKWARD, {}
+    ibp, affine, mode, perturbation_domain = True, False, MetricMode.BACKWARD, {}
     for cls in [AdversarialCheck, AdversarialScore, UpperScore]:
-        layer = cls(ibp=ibp, affine=affine, mode=mode, convex_domain=convex_domain)
+        layer = cls(ibp=ibp, affine=affine, mode=mode, perturbation_domain=perturbation_domain)
         config = layer.get_config()
         assert config["ibp"] == ibp
         assert config["affine"] == affine
         assert config["mode"] == mode
-        assert "convex_domain" in config
+        assert "perturbation_domain" in config

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,7 +48,7 @@ def test_get_upper_box_numpy(n, floatx, decimal, helpers):
     upper_pred = np.sum(W_u_ * x_expand, 1) + b_u_
     upper_pred = upper_pred.max(0)
 
-    upper = get_upper(x_0, W_u, b_u, {})
+    upper = get_upper(x_0, W_u, b_u)
 
     f_upper = K.function([x_0, W_u, b_u], upper)
     upper_ = f_upper([x_0_, W_u_, b_u_]).max()
@@ -63,7 +63,7 @@ def test_get_upper_box(n, floatx, decimal, helpers):
     x, y, x_0, u_c, W_u, b_u, _, _, _, _, _ = inputs
     _, _, x_0_, u_c_, W_u_, b_u_, _, _, _, _, _ = inputs_
 
-    upper = get_upper(x_0, W_u, b_u, {})
+    upper = get_upper(x_0, W_u, b_u)
 
     f_upper = K.function([x_0, W_u, b_u], upper)
 
@@ -94,7 +94,7 @@ def test_get_lower_box(n, floatx, decimal, helpers):
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, _, _, l_c, W_l, b_l, _, _ = inputs
 
-    lower = get_lower(x_0, W_l, b_l, {})
+    lower = get_lower(x_0, W_l, b_l)
 
     f_lower = K.function(inputs, lower)
     f_l = K.function(inputs, l_c)
@@ -123,8 +123,8 @@ def test_get_lower_upper_box(n, floatx, decimal, helpers):
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, W_u, b_u, _, W_l, b_l, _, _ = inputs
 
-    lower = get_lower(x_0, W_l, b_l, {})
-    upper = get_upper(x_0, W_u, b_u, {})
+    lower = get_lower(x_0, W_l, b_l)
+    upper = get_upper(x_0, W_u, b_u)
 
     f_lower = K.function(inputs, lower)
     f_upper = K.function(inputs, upper)


### PR DESCRIPTION
- `convex_domain` becomes `perturbation_domain`;
- `ConvexDomainType` is replaced by the fact of deriving of `PerturbationDomain` class;
- We move `PerturbationDomain` and `Slope` to decomon.core to avoid circular imports issues.