### PR TITLE
Fix BackwardBatchNormalization.call()

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -525,7 +525,7 @@ class BackwardBatchNormalization(BackwardLayer):
 
     def call(self, inputs: List[tf.Tensor], **kwargs: Any) -> List[tf.Tensor]:
 
-        y = inputs[0]
+        y = inputs[-1]
         w_u_out, b_u_out, w_l_out, b_l_out = inputs[-4:]
 
         n_dim = y.shape[1:]


### PR DESCRIPTION
The dimension should be deduced from last input tensor instead of first one so that it works for all modes.