### PR TITLE
Stop triggering binder build on gke

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -32,10 +32,8 @@ jobs:
         run: |
           binder_env_full_ref=${{ inputs.binder-env-fullref }}
           echo Triggering binder environment build for ${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://gke.mybinder.org/build/gh/${binder_env_full_ref}
           bash scripts/trigger_binder.sh https://ovh.mybinder.org/build/gh/${binder_env_full_ref}
           bash scripts/trigger_binder.sh https://ovh2.mybinder.org/build/gh/${binder_env_full_ref}
-          bash scripts/trigger_binder.sh https://turing.mybinder.org/build/gh/${binder_env_full_ref}
           bash scripts/trigger_binder.sh https://gesis.mybinder.org/build/gh/${binder_env_full_ref}
 
   deploy-doc:


### PR DESCRIPTION
gke is not part of the mybinder federation anymore: https://blog.jupyter.org/mybinder-org-reducing-capacity-c93ccfc6413f
