### PR TITLE
Add methods get_lower/get_upper/get_x_input_shape to PerturbationDomain

### DIFF
--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -12,8 +12,6 @@ from decomon.core import (
     InputsOutputsSpec,
     PerturbationDomain,
     Slope,
-    get_lower,
-    get_upper,
 )
 from decomon.utils import (
     get_linear_hull_relu,

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -7,7 +7,7 @@ from tensorflow.keras.layers import Flatten, Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import backward_max_, get_identity_lirpa
-from decomon.core import ForwardMode, PerturbationDomain, get_lower, get_upper
+from decomon.core import ForwardMode, PerturbationDomain
 
 
 class BackwardMaxPooling2D(BackwardLayer):

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -14,10 +14,6 @@ from decomon.core import (
     Slope,
     get_affine,
     get_ibp,
-    get_lower,
-    get_lower_box,
-    get_upper,
-    get_upper_box,
 )
 from decomon.layers.utils import sort
 from decomon.utils import get_linear_hull_relu, maximum, minus, relu_, subtract
@@ -100,6 +96,8 @@ def backward_linear_prod(
     Returns:
 
     """
+    if perturbation_domain is None:
+        perturbation_domain = BoxDomain()
 
     z_value = K.cast(0.0, x_0.dtype)
     o_value = K.cast(1.0, x_0.dtype)
@@ -114,7 +112,7 @@ def backward_linear_prod(
         b_u_i = K.reshape(b_u_i, (-1, n_dim))
         b_l_i = K.reshape(b_l_i, (-1, n_dim))
 
-    x_max = get_upper(x_0, w_u_i - w_l_i, b_u_i - b_l_i, perturbation_domain=perturbation_domain)
+    x_max = perturbation_domain.get_upper(x_0, w_u_i - w_l_i, b_u_i - b_l_i)
     mask_b = o_value - K.sign(x_max)
     mask_a = o_value - mask_b
 

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -63,10 +63,12 @@ def backward_add(
     l_c_0 = op_flat(l_c_0)
     l_c_1 = op_flat(l_c_1)
 
-    upper_0 = get_upper_box(l_c_0, u_c_0, w_u_out, b_u_out)
-    upper_1 = get_upper_box(l_c_1, u_c_1, w_u_out, b_u_out)
-    lower_0 = get_lower_box(l_c_0, u_c_0, w_l_out, b_l_out)
-    lower_1 = get_lower_box(l_c_1, u_c_1, w_l_out, b_l_out)
+    x_0 = K.concatenate([K.expand_dims(l_c_0, 1), K.expand_dims(u_c_0, 1)], 1)
+    x_1 = K.concatenate([K.expand_dims(l_c_1, 1), K.expand_dims(u_c_1, 1)], 1)
+    upper_0 = BoxDomain().get_upper(x_0, w_u_out, b_u_out)
+    upper_1 = BoxDomain().get_upper(x_1, w_u_out, b_u_out)
+    lower_0 = BoxDomain().get_lower(x_0, w_l_out, b_l_out)
+    lower_1 = BoxDomain().get_lower(x_1, w_l_out, b_l_out)
 
     w_u_out_0 = w_u_out
     b_u_out_0 = upper_1

--- a/src/decomon/layers/__init__.py
+++ b/src/decomon/layers/__init__.py
@@ -1,2 +1,0 @@
-from ..core import ForwardMode, InputsOutputsSpec, get_lower, get_upper
-from .utils import maximum, minimum

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -14,8 +14,6 @@ from decomon.core import (
     Slope,
     get_affine,
     get_ibp,
-    get_lower,
-    get_upper,
 )
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import exp, expand_dims, frac_pos, multiply, softplus_, sum

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -133,14 +133,8 @@ def _prepare_input_tensors(
     original_input_shapes = get_layer_input_shape(layer)
     decomon_input_shapes: List[List[Optional[int]]] = [list(input_shape[1:]) for input_shape in original_input_shapes]
     n_input = len(decomon_input_shapes)
-
-    if isinstance(perturbation_domain, BoxDomain):
-        x_input = Input((2, input_dim), dtype=layer.dtype)
-    elif isinstance(perturbation_domain, BallDomain):
-        x_input = Input((input_dim,), dtype=layer.dtype)
-    else:
-        raise NotImplementedError(f"Not implemented for perturbation domain type {type(perturbation_domain)}")
-
+    x_input_shape = perturbation_domain.get_x_input_shape(input_dim)
+    x_input = Input(x_input_shape, dtype=layer.dtype)
     w_input = [Input(tuple([input_dim] + decomon_input_shapes[i])) for i in range(n_input)]
     y_input = [Input(tuple(decomon_input_shapes[i])) for i in range(n_input)]
 

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -18,10 +18,8 @@ from tensorflow.keras.layers import (
     Layer,
 )
 from tensorflow.python.keras.utils import conv_utils
-from tensorflow.python.keras.utils.generic_utils import to_list
 
-from decomon.core import ForwardMode, PerturbationDomain, Slope, get_lower, get_upper
-from decomon.keras_utils import get_weight_index
+from decomon.core import ForwardMode, PerturbationDomain, Slope
 from decomon.layers import activations
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import (
@@ -225,7 +223,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
 
             else:
                 # check for linearity
-                x_max = get_upper(x, w_u - w_l, b_u - b_l, self.perturbation_domain)
+                x_max = self.perturbation_domain.get_upper(x, w_u - w_l, b_u - b_l)
                 mask_b = o_value - K.sign(x_max)
 
                 def step_pos(x: tf.Tensor, _: List[tf.Tensor]) -> Tuple[tf.Tensor, List[tf.Tensor]]:

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -6,7 +6,7 @@ import tensorflow.keras.backend as K
 from tensorflow.keras.backend import conv2d
 from tensorflow.keras.layers import InputSpec, MaxPooling2D
 
-from decomon.core import ForwardMode, PerturbationDomain, get_lower, get_upper
+from decomon.core import ForwardMode, PerturbationDomain
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import max_
 

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -17,8 +17,6 @@ from decomon.core import (
     Slope,
     get_affine,
     get_ibp,
-    get_lower,
-    get_upper,
 )
 from decomon.utils import add, get_linear_softplus_hull, maximum, minimum, minus, relu_
 

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -10,9 +10,6 @@ from decomon.core import (
     InputsOutputsSpec,
     PerturbationDomain,
     get_affine,
-    get_ibp,
-    get_lower,
-    get_upper,
 )
 
 # step 1: compute (x_i, y_i) such that x_i[j]=l_j if j==i else u_j

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -10,9 +10,7 @@ from decomon.core import (
     BoxDomain,
     ForwardMode,
     PerturbationDomain,
-    get_lower,
     get_mode,
-    get_upper,
 )
 from decomon.layers.activations import softmax as softmax_
 from decomon.layers.core import DecomonLayer
@@ -120,7 +118,7 @@ def get_upper_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
 
     def upper_affine(x: tf.Tensor, w_u: tf.Tensor, b_u: tf.Tensor, u_ref: tf.Tensor) -> tf.Tensor:
 
-        upper = get_upper(x, w_u, b_u, perturbation_domain=perturbation_domain)
+        upper = perturbation_domain.get_upper(x, w_u, b_u)
 
         return K.max(upper - u_ref, -1)
 
@@ -193,7 +191,7 @@ def get_lower_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
 
     def lower_affine(x: tf.Tensor, w_l: tf.Tensor, b_l: tf.Tensor, l_ref: tf.Tensor) -> tf.Tensor:
 
-        lower = get_lower(x, w_l, b_l, perturbation_domain=perturbation_domain)
+        lower = perturbation_domain.get_lower(x, w_l, b_l)
 
         return K.max(l_ref - lower, -1)
 
@@ -285,7 +283,7 @@ def get_adv_loss(
         w_adv = w_u_reshaped - w_l_reshaped
         b_adv = K.expand_dims(b_u, -1) - K.expand_dims(b_l, 1)
 
-        upper = get_upper(x, w_adv, b_adv, perturbation_domain=perturbation_domain)
+        upper = perturbation_domain.get_upper(x, w_adv, b_adv)
 
         t_tensor = 1 - y_tensor
         s_tensor = y_tensor

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -102,14 +102,7 @@ def get_upper_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
     mode = get_mode(ibp, affine)
     perturbation_domain = model.perturbation_domain
 
-    if affine:
-        if isinstance(perturbation_domain, BoxDomain):
-            n_comp = 2
-        elif isinstance(perturbation_domain, BallDomain):
-            n_comp = 1
-        else:
-            raise NotImplementedError(f"Not implemented for perturbation domain type {type(perturbation_domain)}")
-
+    n_comp = perturbation_domain.get_nb_x_components()
     n_out = np.prod(model.output[-1].shape[1:])
 
     def upper_ibp(u_c: tf.Tensor, u_ref: tf.Tensor) -> tf.Tensor:
@@ -175,14 +168,7 @@ def get_lower_loss(model: DecomonModel) -> Callable[[tf.Tensor, tf.Tensor], tf.T
     mode = get_mode(ibp, affine)
     perturbation_domain = model.perturbation_domain
 
-    if affine:
-        if isinstance(perturbation_domain, BoxDomain):
-            n_comp = 2
-        elif isinstance(perturbation_domain, BallDomain):
-            n_comp = 1
-        else:
-            raise NotImplementedError(f"Not implemented for perturbation domain type {type(perturbation_domain)}")
-
+    n_comp = perturbation_domain.get_nb_x_components()
     n_out = np.prod(model.output[-1].shape[1:])
 
     def lower_ibp(l_c: tf.Tensor, l_ref: tf.Tensor) -> tf.Tensor:
@@ -250,14 +236,7 @@ def get_adv_loss(
     mode = get_mode(ibp, affine)
     perturbation_domain = model.perturbation_domain
 
-    if affine:
-        if isinstance(perturbation_domain, BoxDomain):
-            n_comp = 2
-        elif isinstance(perturbation_domain, BallDomain):
-            n_comp = 1
-        else:
-            raise NotImplementedError(f"Not implemented for perturbation domain type {type(perturbation_domain)}")
-
+    n_comp = perturbation_domain.get_nb_x_components()
     n_out = np.prod(model.output[-1].shape[1:])
 
     def adv_ibp(u_c: tf.Tensor, l_c: tf.Tensor, y_tensor: tf.Tensor) -> tf.Tensor:

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -18,9 +18,7 @@ from decomon.core import (
     PerturbationDomain,
     Slope,
     get_affine,
-    get_lower,
     get_mode,
-    get_upper,
 )
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.crown import Convert2BackwardMode, Fuse, MergeWithPrevious

--- a/src/decomon/models/crown.py
+++ b/src/decomon/models/crown.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 import tensorflow.keras.backend as K
 from tensorflow.keras.layers import InputSpec, Layer
 
-from decomon.core import ForwardMode, PerturbationDomain, get_lower, get_upper
+from decomon.core import ForwardMode, PerturbationDomain
 
 
 class Fuse(Layer):
@@ -51,8 +51,8 @@ class Convert2BackwardMode(Layer):
             x_0 = K.concatenate([K.expand_dims(l_c, 1), K.expand_dims(u_c, 1)], 1)
 
         if self.mode in [ForwardMode.IBP, ForwardMode.HYBRID]:
-            u_c_out = get_upper(x_0, w_u_out, b_u_out, perturbation_domain=self.perturbation_domain)
-            l_c_out = get_lower(x_0, w_l_out, b_l_out, perturbation_domain=self.perturbation_domain)
+            u_c_out = self.perturbation_domain.get_upper(x_0, w_u_out, b_u_out)
+            l_c_out = self.perturbation_domain.get_lower(x_0, w_l_out, b_l_out)
         else:
             u_c_out, l_c_out = empty_tensor, empty_tensor
 

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -24,9 +24,7 @@ from decomon.core import (
     ForwardMode,
     InputsOutputsSpec,
     PerturbationDomain,
-    get_lower,
     get_mode,
-    get_upper,
 )
 from decomon.layers.utils import is_a_merge_layer
 
@@ -163,8 +161,8 @@ def get_input_tensors(
                 if affine:
                     outputs += [W, b]
                 if ibp:
-                    u_c_out = get_upper(z, W, b, perturbation_domain)
-                    l_c_out = get_lower(z, W, b, perturbation_domain)
+                    u_c_out = perturbation_domain.get_upper(z, W, b)
+                    l_c_out = perturbation_domain.get_lower(z, W, b)
                     outputs += [u_c_out, l_c_out]
                 return outputs
 

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -102,14 +102,7 @@ def get_input_tensors(
     inputs_outputs_spec = InputsOutputsSpec(dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain)
     empty_tensor = inputs_outputs_spec.get_empty_tensor()
 
-    input_shape_x: Tuple[int, ...]
-    if isinstance(perturbation_domain, BoxDomain):
-        input_shape_x = (2, input_dim)
-    elif isinstance(perturbation_domain, BallDomain):
-        input_shape_x = (input_dim,)
-    else:
-        raise NotImplementedError(f"Not implemented for perturbation domain type {type(perturbation_domain)}")
-
+    input_shape_x = perturbation_domain.get_x_input_shape(input_dim)
     z_tensor = Input(shape=input_shape_x, dtype=model.layers[0].dtype)
     u_c_tensor, l_c_tensor, W, b, h, g = (
         empty_tensor,

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras import backend as K
-from tensorflow.keras.layers import Lambda, Layer
 from tensorflow.math import greater_equal
 from tensorflow.types.experimental import TensorLike
 
@@ -16,10 +15,6 @@ from decomon.core import (
     Slope,
     get_affine,
     get_ibp,
-    get_lower,
-    get_lower_box,
-    get_upper,
-    get_upper_box,
 )
 
 TensorFunction = Callable[[TensorLike], tf.Tensor]
@@ -112,7 +107,7 @@ def convert_lower_search_2_subset_sum(x: tf.Tensor, W: tf.Tensor, b: tf.Tensor, 
         W = K.reshape(W, (-1, W.shape[1], np.prod(W.shape[2:])))
         b = K.reshape(b, (-1, np.prod(b.shape[1:])))
 
-    const = get_lower(x, W, b)
+    const = BoxDomain().get_lower(x, W, b)
 
     weights = K.abs(W) * K.expand_dims((x_max - x_min) / n, -1)
     return weights, const

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 import tensorflow.keras.backend as K
 from numpy.testing import assert_allclose, assert_almost_equal
 
-from decomon.core import ForwardMode, get_lower, get_upper
+from decomon.core import BoxDomain, ForwardMode
 from decomon.layers.utils import add, max_, maximum, minus, relu_
 from decomon.utils import subtract
 
@@ -24,7 +24,7 @@ def test_get_upper_multi_box(odd, floatx, decimal, helpers):
     x_max_ = x_0_[:, 1][:, :, None]
     upper_pred = np.sum(np.minimum(W_u_, 0) * x_min_ + np.maximum(W_u_, 0) * x_max_, 1) + b_u_
 
-    upper = get_upper(x_0, W_u, b_u)
+    upper = BoxDomain().get_upper(x_0, W_u, b_u)
 
     f_upper = K.function([x_0, W_u, b_u], upper)
 
@@ -48,7 +48,7 @@ def test_get_upper_box_numpy(n, floatx, decimal, helpers):
     upper_pred = np.sum(W_u_ * x_expand, 1) + b_u_
     upper_pred = upper_pred.max(0)
 
-    upper = get_upper(x_0, W_u, b_u)
+    upper = BoxDomain().get_upper(x_0, W_u, b_u)
 
     f_upper = K.function([x_0, W_u, b_u], upper)
     upper_ = f_upper([x_0_, W_u_, b_u_]).max()
@@ -63,7 +63,7 @@ def test_get_upper_box(n, floatx, decimal, helpers):
     x, y, x_0, u_c, W_u, b_u, _, _, _, _, _ = inputs
     _, _, x_0_, u_c_, W_u_, b_u_, _, _, _, _, _ = inputs_
 
-    upper = get_upper(x_0, W_u, b_u)
+    upper = BoxDomain().get_upper(x_0, W_u, b_u)
 
     f_upper = K.function([x_0, W_u, b_u], upper)
 
@@ -94,7 +94,7 @@ def test_get_lower_box(n, floatx, decimal, helpers):
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, _, _, l_c, W_l, b_l, _, _ = inputs
 
-    lower = get_lower(x_0, W_l, b_l)
+    lower = BoxDomain().get_lower(x_0, W_l, b_l)
 
     f_lower = K.function(inputs, lower)
     f_l = K.function(inputs, l_c)
@@ -123,8 +123,8 @@ def test_get_lower_upper_box(n, floatx, decimal, helpers):
     inputs_ = helpers.get_standard_values_1d_box(n)
     x, y, x_0, _, W_u, b_u, _, W_l, b_l, _, _ = inputs
 
-    lower = get_lower(x_0, W_l, b_l)
-    upper = get_upper(x_0, W_u, b_u)
+    lower = BoxDomain().get_lower(x_0, W_l, b_l)
+    upper = BoxDomain().get_upper(x_0, W_u, b_u)
 
     f_lower = K.function(inputs, lower)
     f_upper = K.function(inputs, upper)
@@ -217,8 +217,8 @@ def test_relu_1D_box(n, mode, floatx, decimal, helpers):
     ) = inputs_  # numpy values
 
     # lower and upper bounds from affine coefficients
-    lower = get_lower(z_tensor, W_l_tensor, b_l_tensor)
-    upper = get_upper(z_tensor, W_u_tensor, b_u_tensor)
+    lower = BoxDomain().get_lower(z_tensor, W_l_tensor, b_l_tensor)
+    upper = BoxDomain().get_upper(z_tensor, W_u_tensor, b_u_tensor)
     f_lower = K.function(inputs, lower)
     f_upper = K.function(inputs, upper)
     lower_ = np.min(f_lower(inputs_))
@@ -493,8 +493,8 @@ def test_relu_1D_box_nodc(n, helpers):
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
     output = relu_(inputs_for_mode, dc_decomp=dc_decomp, mode=mode)
-    lower = get_lower(z, W_l, b_l)
-    upper = get_upper(z, W_u, b_u)
+    lower = BoxDomain().get_lower(z, W_l, b_l)
+    upper = BoxDomain().get_upper(z, W_u, b_u)
 
     f_lower = K.function(inputs, lower)
     f_upper = K.function(inputs, upper)


### PR DESCRIPTION
- We replace get_upper/get_lower functions by call to perturbation_domain.get_upper/get_lower
- This allowed to detect places where the perturbation domain was not specified
- We unify definition of x input shape by using the new method instead of having tests on perturbation domain class