### PR TITLE
Force using tf<2.13 in github actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -64,7 +64,7 @@ jobs:
         python-version: ["3.8", "3.9"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         nodeellip: [ false, true ]
-        tf212: [ false, true ]
+        tf212: [ true ]
         exclude:
           - os: "windows-latest"
             nodeellip: true
@@ -73,17 +73,6 @@ jobs:
           - os: "ubuntu-latest"
             nodeellip: true
             python-version: 3.9
-          - os: "windows-latest"
-            tf212: true
-          - os: "macos-latest"
-            tf212: true
-          - os: "ubuntu-latest"
-            tf212: true
-            python-version: 3.9
-          - os: "ubuntu-latest"
-            tf212: true
-            nodeellip: false
-            python-version: 3.8
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,11 @@ description =
     without deel-lip
     tf212: with tensorflow<2.13
 
-[testenv:py39-linux]
+[testenv:py39-linux-tf212]
 # coverage in only one env
 deps =
     pytest
+    tensorflow<2.13
     deel-lip
     pytest-cov
 commands =
@@ -46,6 +47,7 @@ commands =
 description =
     pytest environment
     without deel-lip
+    tf212: with tensorflow<2.13
     with coverage
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@ envlist =
     pre-commit
     convert-doc-to-test
     type
-    py{38,39}-{linux,macos,win}
-    py{38,39}-{linux,macos,win}-nodeellip
-    py{38,39}-{linux,macos,win}-nodeellip-tf212
+    py{38,39}-{linux,macos,win}{-nodeellip,}{-tf212,}
 
 [testenv]
 platform = linux: linux
@@ -15,18 +13,22 @@ platform = linux: linux
            win: win32
 deps =
     pytest
+    tf212: tensorflow<2.13
     deel-lip
 commands =
     pytest -v {posargs}
+description =
+    pytest environment
+    tf212: with tensorflow<2.13
 
-[testenv:py{38,39}-{linux,macos,win}-nodeellip]
+[testenv:py{38,39}-{linux,macos,win}-nodeellip{-tf212,}]
 deps =
     pytest
-
-[testenv:py{38,39}-{linux,macos,win}-nodeellip-tf212]
-deps =
-    pytest
-    tensorflow<2.13
+    tf212: tensorflow<2.13
+description =
+    pytest environment
+    without deel-lip
+    tf212: with tensorflow<2.13
 
 [testenv:py39-linux]
 # coverage in only one env
@@ -41,6 +43,10 @@ commands =
       --cov-report html:coverage_html \
       --cov-report term \
       {posargs}
+description =
+    pytest environment
+    without deel-lip
+    with coverage
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
This is a temporary patch to avoid having tests much too long (>5hours!)
This is related to this issue: https://github.com/keras-team/keras/issues/18301