### PR TITLE
Transition from tf.keras to keras 3

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -60,6 +60,7 @@ jobs:
 
   tests:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -61,10 +61,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         nodeellip: [ false, true ]
-        tf212: [ true ]
         exclude:
           - os: "windows-latest"
             nodeellip: true
@@ -72,7 +71,7 @@ jobs:
             nodeellip: true
           - os: "ubuntu-latest"
             nodeellip: true
-            python-version: 3.9
+            python-version: 3.11
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -94,9 +93,8 @@ jobs:
         with:
           path: .tox
           key:
-            tox-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.tf212 }}-${{ hashFiles('pyproject.toml') }}
+            tox-${{ matrix.python-version }}-${{ matrix.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys:
-            tox-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.tf212 }}
             tox-${{ matrix.python-version }}-${{ matrix.os }}
       - name: Pick proper tox env
         shell: python
@@ -112,8 +110,6 @@ jobs:
           toxenv = f"{pythonversion}-{platformversion}"
           if "${{ matrix.nodeellip }}" == "true":
               toxenv += "-nodeellip"
-          if "${{ matrix.tf212 }}" == "true":
-              toxenv += "-tf212"
           set_toxenv_cmd = f"TOXENV={toxenv}"
           print(f"Picked: {toxenv}")
           with Path(os.environ["GITHUB_ENV"]).open("ta") as file_handler:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -64,15 +64,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        nodeellip: [ false, true ]
-        exclude:
-          - os: "windows-latest"
-            nodeellip: true
-          - os: "macos-latest"
-            nodeellip: true
-          - os: "ubuntu-latest"
-            nodeellip: true
-            python-version: 3.11
+        nodeellip: [ true ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -9,8 +9,8 @@ within a box domain.
 ````python
 # Imports
 import numpy as np
-from tensorflow.keras.layers import Dense
-from tensorflow.keras.models import Sequential
+from keras.layers import Dense
+from keras.models import Sequential
 
 from decomon import get_lower_box, get_upper_box
 from decomon.models import clone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies =[
     "tensorflow >=2.13.0",
     "matplotlib",
     "numpy >=1.21",
-    "keras-core",
+    "keras-nightly",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 authors = [
     {email ="ai.decomon@gmail.com"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies =[
-    "tensorflow >=2.6.0",
+    "tensorflow >=2.13.0",
     "matplotlib",
     "numpy >=1.21",
     "keras-core",
@@ -23,7 +23,7 @@ documentation = "https://airbus.github.io/decomon"
 repository = "https://github.com/airbus/decomon"
 
 [project.optional-dependencies]
-dev = ["pytest>=6.2.2", "black", "tox>=3.20.1"]
+dev = ["tox>=4.6.4"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -40,7 +40,7 @@ addopts = [
 
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ['py39']
 include = '\.pyi?$'
 exclude = '''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ disallow_untyped_defs = true
 module = [
     "tensorflow.*",
     "keras.*",
-    "deel.lip.*"
+    "deel.lip.*",
+    "keras_core.*"
 ]
 ignore_missing_imports = true

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -1,10 +1,10 @@
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.layers import Layer
+from keras.layers import Layer
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -80,7 +80,7 @@ def backward_relu(
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         input_shape = inputs_outputs_spec.get_input_shape(inputs)
         bounds = get_linear_hull_relu(upper=u_c, lower=l_c, slope=slope, **kwargs)
-        dim = np.prod(input_shape[1:])
+        dim = int(np.prod(input_shape[1:]))
         return [K.reshape(elem, (-1, dim)) for elem in bounds]
 
     raise NotImplementedError()
@@ -354,7 +354,7 @@ def backward_softsign(
     bounds = get_linear_hull_s_shape(
         inputs, func=K.softsign, f_prime=softsign_prime, perturbation_domain=perturbation_domain, mode=mode
     )
-    shape = np.prod(inputs[-1].shape[1:])
+    shape = int(np.prod(inputs[-1].shape[1:]))
     return [K.reshape(elem, (-1, shape)) for elem in bounds]
 
 

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -78,7 +78,7 @@ def backward_relu(
         # default values: return relu_(x) = max(x, 0)
         inputs_outputs_spec = InputsOutputsSpec(dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain)
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
-        input_shape = inputs_outputs_spec.get_input_shape(inputs)
+        input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
         bounds = get_linear_hull_relu(upper=u_c, lower=l_c, slope=slope, **kwargs)
         dim = int(np.prod(input_shape[1:]))
         return [K.reshape(elem, (-1, dim)) for elem in bounds]

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -1,7 +1,6 @@
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import keras
 import keras.ops as K
 import numpy as np
 from keras.layers import Layer
@@ -13,6 +12,7 @@ from decomon.core import (
     PerturbationDomain,
     Slope,
 )
+from decomon.types import Tensor
 from decomon.utils import (
     get_linear_hull_relu,
     get_linear_hull_s_shape,
@@ -39,7 +39,7 @@ LINEAR = "linear"
 
 
 def backward_relu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     alpha: float = 0.0,
@@ -48,7 +48,7 @@ def backward_relu(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of relu
 
     Args:
@@ -87,13 +87,13 @@ def backward_relu(
 
 
 def backward_sigmoid(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of sigmoid
 
     Args:
@@ -118,13 +118,13 @@ def backward_sigmoid(
 
 
 def backward_tanh(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of tanh
 
     Args:
@@ -149,13 +149,13 @@ def backward_tanh(
 
 
 def backward_hard_sigmoid(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of hard sigmoid
 
     Args:
@@ -178,13 +178,13 @@ def backward_hard_sigmoid(
 
 
 def backward_elu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of Exponential Linear Unit
 
     Args:
@@ -208,13 +208,13 @@ def backward_elu(
 
 
 def backward_selu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPA of Scaled Exponential Linear Unit (SELU)
 
     Args:
@@ -238,13 +238,13 @@ def backward_selu(
 
 
 def backward_linear(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPA of linear
 
     Args:
@@ -265,13 +265,13 @@ def backward_linear(
 
 
 def backward_exponential(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPAof exponential
 
     Args:
@@ -294,13 +294,13 @@ def backward_exponential(
 
 
 def backward_softplus(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPA of softplus
 
     Args:
@@ -325,13 +325,13 @@ def backward_softplus(
 
 
 def backward_softsign(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPA of softsign
 
     Args:
@@ -359,16 +359,16 @@ def backward_softsign(
 
 
 def backward_softsign_(
-    inputs: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     w_u_0, b_u_0, w_l_0, b_l_0 = get_linear_hull_s_shape(
@@ -391,14 +391,14 @@ def backward_softsign_(
 
 
 def backward_softmax(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward LiRPA of softmax
 
     Args:
@@ -422,7 +422,7 @@ def backward_softmax(
     raise NotImplementedError()
 
 
-def deserialize(name: str) -> Callable[..., List[keras.KerasTensor]]:
+def deserialize(name: str) -> Callable[..., List[Tensor]]:
     """Get the activation from name.
 
     Args:
@@ -457,7 +457,7 @@ def deserialize(name: str) -> Callable[..., List[keras.KerasTensor]]:
     raise ValueError("Could not interpret " "activation function identifier:", name)
 
 
-def get(identifier: Any) -> Callable[..., List[keras.KerasTensor]]:
+def get(identifier: Any) -> Callable[..., List[Tensor]]:
     """Get the `identifier` activation function.
 
     Args:

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -80,7 +80,7 @@ def backward_relu(
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
         bounds = get_linear_hull_relu(upper=u_c, lower=l_c, slope=slope, **kwargs)
-        dim = int(np.prod(input_shape[1:]))
+        dim = int(np.prod(input_shape[1:]))  # type: ignore
         return [K.reshape(elem, (-1, dim)) for elem in bounds]
 
     raise NotImplementedError()

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -170,14 +170,14 @@ class BackwardConv2D(BackwardLayer):
         if self.layer.data_format == "channels_last":
             b_out_u_ = K.reshape(K.zeros(output_shape, dtype=self.layer.dtype), (-1, output_shape[-1]))
         else:
-            b_out_u_ = K.permute_dimensions(
+            b_out_u_ = K.transpose(
                 K.reshape(K.zeros(output_shape, dtype=self.layer.dtype), (-1, output_shape[0])), (1, 0)
             )
 
         if self.layer.use_bias:
             bias_ = K.cast(self.layer.bias, self.layer.dtype)
             b_out_u_ = b_out_u_ + bias_[None]
-        b_out_u_ = K.flatten(b_out_u_)
+        b_out_u_ = K.ravel(b_out_u_)
 
         z_value = K.cast(0.0, self.dtype)
         y_ = inputs[-1]
@@ -271,7 +271,7 @@ class BackwardActivation(BackwardLayer):
                     )
                     alpha_b_l = np.zeros((3, input_dim))
                     alpha_b_l[0] = 1
-                    K.set_value(self.alpha_b_l, alpha_b_l)
+                    self.alpha_b_l.assign(alpha_b_l)
                     self.finetune_param.append(self.alpha_b_l)
 
             else:
@@ -284,7 +284,7 @@ class BackwardActivation(BackwardLayer):
                 )
                 alpha_b_l = np.ones((input_dim,))
                 # alpha_b_l[0] = 1
-                K.set_value(self.alpha_b_l, alpha_b_l)
+                self.alpha_b_l.assign(alpha_b_l)
 
                 if self.activation_name[:4] != "relu":
                     self.alpha_b_u = self.add_weight(
@@ -496,8 +496,8 @@ class BackwardPermute(BackwardLayer):
 
         dims = [0] + list(self.dims) + [len(y.shape)]
         dims = list(np.argsort(dims))
-        w_u_out = K.reshape(K.permute_dimensions(w_u_out, dims), (-1, n_dim, n_out))
-        w_l_out = K.reshape(K.permute_dimensions(w_l_out, dims), (-1, n_dim, n_out))
+        w_u_out = K.reshape(K.transpose(w_u_out, dims), (-1, n_dim, n_out))
+        w_l_out = K.reshape(K.transpose(w_l_out, dims), (-1, n_dim, n_out))
 
         return [w_u_out, b_u_out, w_l_out, b_l_out]
 

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -163,9 +163,11 @@ class BackwardConv2D(BackwardLayer):
         """
 
         w_out_u_ = get_toeplitz(self.layer, True)
-        output_shape = self.layer.get_output_shape_at(0)
-        if isinstance(output_shape, list):
-            output_shape = output_shape[-1]
+        output = self.layer.output
+        if isinstance(output, keras.KerasTensor):
+            output_shape = output.shape
+        else:  # list of outputs
+            output_shape = output[-1].shape
         output_shape = output_shape[1:]
         if self.layer.data_format == "channels_last":
             b_out_u_ = K.reshape(K.zeros(output_shape, dtype=self.layer.dtype), (-1, output_shape[-1]))

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -181,8 +181,8 @@ class BackwardConv2D(BackwardLayer):
 
         z_value = K.cast(0.0, self.dtype)
         y_ = inputs[-1]
-        shape = np.prod(y_.shape[1:])
-        y_flatten = K.reshape(z_value * y_, (-1, np.prod(shape)))  # (None, n_in)
+        shape = int(np.prod(y_.shape[1:]))
+        y_flatten = K.reshape(z_value * y_, (-1, int(np.prod(shape))))  # (None, n_in)
         w_out_ = K.sum(y_flatten, -1)[:, None, None] + w_out_u_
         b_out_ = K.sum(y_flatten, -1)[:, None] + b_out_u_
 
@@ -254,7 +254,7 @@ class BackwardActivation(BackwardLayer):
         Returns:
 
         """
-        input_dim = np.prod(input_shape[-1][1:])
+        input_dim = int(np.prod(input_shape[-1][1:]))
 
         if self.finetune and self.activation_name != "linear":
             if isinstance(self.perturbation_domain, GridDomain):
@@ -580,7 +580,7 @@ class BackwardBatchNormalization(BackwardLayer):
         w = K.expand_dims(K.expand_dims(w, -1), 1)
         b = K.expand_dims(K.expand_dims(b, -1), 1)
 
-        n_dim = np.prod(y.shape[1:])
+        n_dim = int(np.prod(y.shape[1:]))
         w_u_b = K.reshape(w_u_out * w, (-1, n_dim, n_out))
         w_l_b = K.reshape(w_l_out * w, (-1, n_dim, n_out))
         axis = [i for i in range(2, len(b.shape) - 1)]

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.layers import Flatten, Layer
+from keras.layers import Flatten, Layer
 
 from decomon.backward_layers.activations import get
 from decomon.backward_layers.core import BackwardLayer

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -79,7 +79,7 @@ class BackwardDense(BackwardLayer):
             b_u_out, b_l_out = [z_value * w_u_out[:, 0]] * 2
         return [w_u_out, b_u_out, w_l_out, b_l_out]
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape
@@ -248,7 +248,7 @@ class BackwardActivation(BackwardLayer):
         )
         return config
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -257,7 +257,7 @@ class BackwardActivation(BackwardLayer):
         Returns:
 
         """
-        input_dim = int(np.prod(input_shape[-1][1:]))
+        input_dim = int(np.prod(input_shape[-1][1:]))  # type: ignore
 
         if self.finetune and self.activation_name != "linear":
             if isinstance(self.perturbation_domain, GridDomain):

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -565,11 +565,16 @@ class BackwardBatchNormalization(BackwardLayer):
 
         n_dim = len(y.shape)
         shape = [1] * n_dim
-        for i, ax in enumerate(self.axis):
-            shape[ax] = self.layer.moving_mean.shape[i]
+        shape[self.axis] = self.layer.moving_mean.shape[0]
 
-        gamma = K.reshape(self.layer.gamma + 0.0, shape)
-        beta = K.reshape(self.layer.beta + 0.0, shape)
+        if not hasattr(self.layer, "gamma") or self.layer.gamma is None:  # scale = False
+            gamma = K.ones(shape)
+        else:  # scale = True
+            gamma = K.reshape(self.layer.gamma + 0.0, shape)
+        if not hasattr(self.layer, "beta") or self.layer.beta is None:  # center = False
+            beta = K.zeros(shape)
+        else:  # center = True
+            beta = K.reshape(self.layer.beta + 0.0, shape)
         moving_mean = K.reshape(self.layer.moving_mean + 0.0, shape)
         moving_variance = K.reshape(self.layer.moving_variance + 0.0, shape)
 

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -19,6 +19,7 @@ from decomon.core import (
     get_affine,
     get_ibp,
 )
+from decomon.keras_utils import BatchedDiagLike
 from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer
 from decomon.layers.decomon_layers import DecomonBatchNormalization
@@ -375,9 +376,9 @@ class BackwardActivation(BackwardLayer):
             w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         if len(w_u_out.shape) == 2:
-            w_u_out = tf.linalg.diag(w_u_out)
+            w_u_out = BatchedDiagLike()(w_u_out)
         if len(w_l_out.shape) == 2:
-            w_l_out = tf.linalg.diag(w_l_out)
+            w_l_out = BatchedDiagLike()(w_l_out)
 
         return [w_u_out, b_u_out, w_l_out, b_l_out]
 

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -151,7 +151,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         input_shape_channelreduced = list(inputs[0].shape[1:])
         n_axis = input_shape_channelreduced[axis]
         input_shape_channelreduced[axis] = 1
-        n_dim = np.prod(input_shape_channelreduced)
+        n_dim = int(np.prod(input_shape_channelreduced))
 
         # create diagonal matrix
         id_list = [tf.linalg.diag(K.ones_like(op_flat(elem[0][None]))) for elem in K.split(y, input_shape[axis], axis)]
@@ -160,7 +160,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         w_list = [self.internal_op(identity_mat) for identity_mat in id_list]
 
         # flatten
-        weights = [K.reshape(op_flat(weights), (n_dim, -1, np.prod(self.pool_size))) for weights in w_list]
+        weights = [K.reshape(op_flat(weights), (n_dim, -1, int(np.prod(self.pool_size)))) for weights in w_list]
 
         n_0 = weights[0].shape[1]
         n_1 = weights[0].shape[2]

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -64,11 +64,16 @@ class BackwardMaxPooling2D(BackwardLayer):
         w_u_out_new = K.concatenate([K.expand_dims(K.expand_dims(0 * (op_flat(y)), 1), -1)] * n_out, -1)
         w_l_out_new = w_u_out_new
 
+        z_value = K.cast(0.0, dtype=w_u_out.dtype)
         b_u_out_new = (
-            K.sum(K.maximum(w_u_out, 0) * b_u_pooled, 2) + K.sum(K.minimum(w_u_out, 0) * b_l_pooled, 2) + b_u_out
+            K.sum(K.maximum(w_u_out, z_value) * b_u_pooled, 2)
+            + K.sum(K.minimum(w_u_out, z_value) * b_l_pooled, 2)
+            + b_u_out
         )
         b_l_out_new = (
-            K.sum(K.maximum(w_l_out, 0) * b_l_pooled, 2) + K.sum(K.minimum(w_l_out, 0) * b_u_pooled, 2) + b_l_out
+            K.sum(K.maximum(w_l_out, z_value) * b_l_pooled, 2)
+            + K.sum(K.minimum(w_l_out, z_value) * b_u_pooled, 2)
+            + b_l_out
         )
 
         return [w_u_out_new, b_u_out_new, w_l_out_new, b_l_out_new]

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -51,8 +51,8 @@ class BackwardMaxPooling2D(BackwardLayer):
 
         op_flat = Flatten()
 
-        b_u_pooled = K.pool2d(u_c, self.pool_size, self.strides, self.padding, self.data_format, pool_mode="max")
-        b_l_pooled = K.pool2d(l_c, self.pool_size, self.strides, self.padding, self.data_format, pool_mode="max")
+        b_u_pooled = K.max_pool(u_c, self.pool_size, self.strides, self.padding, self.data_format)
+        b_l_pooled = K.max_pool(l_c, self.pool_size, self.strides, self.padding, self.data_format)
 
         b_u_pooled = K.expand_dims(K.expand_dims(op_flat(b_u_pooled), 1), -1)
         b_l_pooled = K.expand_dims(K.expand_dims(op_flat(b_l_pooled), 1), -1)
@@ -95,7 +95,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         dtype = x.dtype
         empty_tensor = self.inputs_outputs_spec.get_empty_tensor(dtype=dtype)
         y = inputs[-1]
-        input_shape = K.int_shape(y)
+        input_shape = y.shape
 
         if self.data_format in [None, "channels_last"]:
             axis = -1

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -1,15 +1,14 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras
 import keras.ops as K
 import numpy as np
-import tensorflow as tf
 from keras.layers import Flatten, Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import backward_max_, get_identity_lirpa
 from decomon.core import ForwardMode, PerturbationDomain
 from decomon.keras_utils import BatchedIdentityLike
+from decomon.types import BackendTensor
 
 
 class BackwardMaxPooling2D(BackwardLayer):
@@ -42,12 +41,12 @@ class BackwardMaxPooling2D(BackwardLayer):
 
     def _pooling_function_fast(
         self,
-        inputs: List[keras.KerasTensor],
-        w_u_out: keras.KerasTensor,
-        b_u_out: keras.KerasTensor,
-        w_l_out: keras.KerasTensor,
-        b_l_out: keras.KerasTensor,
-    ) -> List[keras.KerasTensor]:
+        inputs: List[BackendTensor],
+        w_u_out: BackendTensor,
+        b_u_out: BackendTensor,
+        w_l_out: BackendTensor,
+        b_l_out: BackendTensor,
+    ) -> List[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
 
         op_flat = Flatten()
@@ -80,12 +79,12 @@ class BackwardMaxPooling2D(BackwardLayer):
 
     def _pooling_function_not_fast(
         self,
-        inputs: List[keras.KerasTensor],
-        w_u_out: keras.KerasTensor,
-        b_u_out: keras.KerasTensor,
-        w_l_out: keras.KerasTensor,
-        b_l_out: keras.KerasTensor,
-    ) -> List[keras.KerasTensor]:
+        inputs: List[BackendTensor],
+        w_u_out: BackendTensor,
+        b_u_out: BackendTensor,
+        w_l_out: BackendTensor,
+        b_l_out: BackendTensor,
+    ) -> List[BackendTensor]:
         """
         Args:
             inputs
@@ -185,7 +184,7 @@ class BackwardMaxPooling2D(BackwardLayer):
 
         return [w_u_out, b_u_out, w_l_out, b_l_out]
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
         if self.fast:
             return self._pooling_function_fast(

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -9,6 +9,7 @@ from keras.layers import Flatten, Layer
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import backward_max_, get_identity_lirpa
 from decomon.core import ForwardMode, PerturbationDomain
+from decomon.keras_utils import BatchedIdentityLike
 
 
 class BackwardMaxPooling2D(BackwardLayer):
@@ -154,7 +155,7 @@ class BackwardMaxPooling2D(BackwardLayer):
         n_dim = int(np.prod(input_shape_channelreduced))
 
         # create diagonal matrix
-        id_list = [tf.linalg.diag(K.ones_like(op_flat(elem[0][None]))) for elem in K.split(y, input_shape[axis], axis)]
+        id_list = [BatchedIdentityLike()(op_flat(elem[0][None])) for elem in K.split(y, input_shape[axis], axis)]
 
         id_list = [K.reshape(identity_mat, [-1] + input_shape_channelreduced) for identity_mat in id_list]
         w_list = [self.internal_op(identity_mat) for identity_mat in id_list]

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.layers import Flatten, Layer
+from keras.layers import Flatten, Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.backward_layers.utils import backward_max_, get_identity_lirpa

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -34,6 +34,7 @@ from decomon.layers.decomon_merge_layers import (
     DecomonSubtract,
 )
 from decomon.layers.utils import broadcast, multiply, permute_dimensions, split
+from decomon.types import BackendTensor
 
 
 class BackwardMerge(ABC, Wrapper):
@@ -89,7 +90,7 @@ class BackwardMerge(ABC, Wrapper):
         return config
 
     @abstractmethod
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         """
         Args:
             inputs
@@ -150,7 +151,7 @@ class BackwardAdd(BackwardMerge):
             mode=self.mode, perturbation_domain=self.perturbation_domain, dc_decomp=self.dc_decomp
         ).call
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -197,7 +198,7 @@ class BackwardAverage(BackwardMerge):
         )
         self.op = DecomonAdd(mode=self.mode, perturbation_domain=self.perturbation_domain, dc_decomp=False).call
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -206,8 +207,8 @@ class BackwardAverage(BackwardMerge):
         if n_elem == 1:  # nothing to merge
             return [[w_u_out, b_u_out, w_l_out, b_l_out]]
         else:
-            bounds: List[List[keras.KerasTensor]] = []
-            input_bounds: List[List[keras.KerasTensor]] = []
+            bounds: List[List[BackendTensor]] = []
+            input_bounds: List[List[BackendTensor]] = []
 
             for j in range(n_elem - 1, 0, -1):
                 inputs_1 = inputs_list[j]
@@ -260,7 +261,7 @@ class BackwardSubtract(BackwardMerge):
         if not isinstance(layer, DecomonSubtract):
             raise KeyError()
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -305,7 +306,7 @@ class BackwardMaximum(BackwardMerge):
         if not isinstance(layer, DecomonMaximum):
             raise KeyError()
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -350,7 +351,7 @@ class BackwardMinimum(BackwardMerge):
         if not isinstance(layer, DecomonMinimum):
             raise KeyError()
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -397,7 +398,7 @@ class BackwardConcatenate(BackwardMerge):
 
         self.axis = self.layer.axis
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -440,7 +441,7 @@ class BackwardMultiply(BackwardMerge):
         if not isinstance(layer, DecomonMultiply):
             raise KeyError()
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
@@ -490,7 +491,7 @@ class BackwardDot(BackwardMerge):
 
         raise NotImplementedError()
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[List[keras.KerasTensor]]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[List[BackendTensor]]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -99,7 +99,7 @@ class BackwardMerge(ABC, Wrapper):
         """
         pass
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -402,7 +402,7 @@ class BackwardConcatenate(BackwardMerge):
 
         inputs_list = self.inputs_outputs_spec.split_inputsformode_to_merge(inputs)
         n_elem = len(inputs_list)
-        n_list = [self.inputs_outputs_spec.get_input_shape(subinputs)[self.axis] for subinputs in inputs_list]
+        n_list = [self.inputs_outputs_spec.get_kerasinputshape(subinputs)[self.axis] for subinputs in inputs_list]
         indices_split = np.cumsum(n_list[:-1])
         axis_w = self.axis
         if axis_w != -1:

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -580,15 +580,15 @@ class BackwardDot(BackwardMerge):
         index_1[axes[1] + 1] = 2
 
         bounds_m_0 = [
-            K.permute_dimensions(bounds_m_0[0], index_0),
+            K.transpose(bounds_m_0[0], index_0),
             bounds_m_0[1],
-            K.permute_dimensions(bounds_m_0[2], index_0),
+            K.transpose(bounds_m_0[2], index_0),
             bounds_m_0[3],
         ]
         bounds_m_1 = [
-            K.permute_dimensions(bounds_m_1[0], index_1),
+            K.transpose(bounds_m_1[0], index_1),
             bounds_m_1[1],
-            K.permute_dimensions(bounds_m_1[2], index_1),
+            K.transpose(bounds_m_1[2], index_1),
             bounds_m_1[3],
         ]
 

--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 from itertools import chain
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.layers import Layer, Wrapper
+from keras.layers import Layer, Wrapper
 
 from decomon.backward_layers.utils import (
     backward_add,

--- a/src/decomon/backward_layers/convert.py
+++ b/src/decomon/backward_layers/convert.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
-from keras_core.layers import Layer
+from keras.layers import Layer
 
 import decomon.backward_layers.backward_layers
 import decomon.backward_layers.backward_maxpooling

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -13,6 +13,7 @@ from decomon.core import (
     get_ibp,
 )
 from decomon.layers.core import DecomonLayer
+from decomon.types import BackendTensor
 
 
 class BackwardLayer(ABC, Wrapper):
@@ -68,7 +69,7 @@ class BackwardLayer(ABC, Wrapper):
         return config
 
     @abstractmethod
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         """
         Args:
             inputs

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-from keras_core.layers import Layer, Wrapper
+import keras
+from keras.layers import Layer, Wrapper
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -78,7 +78,7 @@ class BackwardLayer(ABC, Wrapper):
         """
         pass
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape

--- a/src/decomon/backward_layers/deel_lip.py
+++ b/src/decomon/backward_layers/deel_lip.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Optional, Union
 
-from keras_core.layers import Layer
+from keras.layers import Layer
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.core import ForwardMode, PerturbationDomain, get_affine, get_ibp

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -1,6 +1,5 @@
 from typing import Any, List, Optional, Tuple, Union
 
-import keras
 import keras.ops as K
 import numpy as np
 from keras.config import floatx
@@ -18,20 +17,21 @@ from decomon.core import (
 )
 from decomon.keras_utils import BatchedIdentityLike
 from decomon.layers.utils import sort
+from decomon.types import Tensor
 from decomon.utils import maximum, minus, relu_, subtract
 
 
 def backward_add(
-    inputs_0: List[keras.KerasTensor],
-    inputs_1: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs_0: List[Tensor],
+    inputs_1: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[keras.KerasTensor]]:
+) -> List[List[Tensor]]:
     """Backward  LiRPA of inputs_0+inputs_1
 
     Args:
@@ -83,11 +83,11 @@ def backward_add(
 
 
 def backward_linear_prod(
-    x_0: keras.KerasTensor,
-    bounds_x: List[keras.KerasTensor],
-    back_bounds: List[keras.KerasTensor],
+    x_0: Tensor,
+    bounds_x: List[Tensor],
+    back_bounds: List[Tensor],
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of a subroutine prod
 
     Args:
@@ -158,17 +158,17 @@ def backward_linear_prod(
 
 
 def backward_maximum(
-    inputs_0: List[keras.KerasTensor],
-    inputs_1: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs_0: List[Tensor],
+    inputs_1: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[List[keras.KerasTensor]]:
+) -> List[List[Tensor]]:
     """Backward  LiRPA of maximum(inputs_0, inputs_1)
 
     Args:
@@ -228,17 +228,17 @@ def backward_maximum(
 
 # convex hull of the maximum between two functions
 def backward_max_(
-    inputs: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of max
 
     Args:
@@ -350,17 +350,17 @@ def backward_max_(
 
 
 def backward_minimum(
-    inputs_0: List[keras.KerasTensor],
-    inputs_1: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs_0: List[Tensor],
+    inputs_1: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[List[keras.KerasTensor]]:
+) -> List[List[Tensor]]:
     """Backward  LiRPA of minimum(inputs_0, inputs_1)
 
     Args:
@@ -403,11 +403,11 @@ def backward_minimum(
 
 
 def backward_minus(
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
-) -> List[keras.KerasTensor]:
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
+) -> List[Tensor]:
     """Backward  LiRPA of -x
 
     Args:
@@ -426,11 +426,11 @@ def backward_minus(
 
 def backward_scale(
     scale_factor: float,
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
-) -> List[keras.KerasTensor]:
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
+) -> List[Tensor]:
     """Backward  LiRPA of scale_factor*x
 
     Args:
@@ -453,16 +453,16 @@ def backward_scale(
 
 
 def backward_subtract(
-    inputs_0: List[keras.KerasTensor],
-    inputs_1: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs_0: List[Tensor],
+    inputs_1: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[keras.KerasTensor]]:
+) -> List[List[Tensor]]:
     """Backward  LiRPA of inputs_0 - inputs_1
 
     Args:
@@ -499,16 +499,16 @@ def backward_subtract(
 
 
 def backward_multiply(
-    inputs_0: List[keras.KerasTensor],
-    inputs_1: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs_0: List[Tensor],
+    inputs_1: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[keras.KerasTensor]]:
+) -> List[List[Tensor]]:
     """Backward  LiRPA of element-wise multiply inputs_0*inputs_1
 
     Args:
@@ -582,16 +582,16 @@ def backward_multiply(
 
 
 def backward_sort(
-    inputs: List[keras.KerasTensor],
-    w_u_out: keras.KerasTensor,
-    b_u_out: keras.KerasTensor,
-    w_l_out: keras.KerasTensor,
-    b_l_out: keras.KerasTensor,
+    inputs: List[Tensor],
+    w_u_out: Tensor,
+    b_u_out: Tensor,
+    w_l_out: Tensor,
+    b_l_out: Tensor,
     axis: int = -1,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Backward  LiRPA of sort
 
     Args:
@@ -646,7 +646,7 @@ def backward_sort(
     return [w_u_out, b_u_out, w_l_out, b_l_out]
 
 
-def get_identity_lirpa(inputs: List[keras.KerasTensor]) -> List[keras.KerasTensor]:
+def get_identity_lirpa(inputs: List[Tensor]) -> List[Tensor]:
     y = inputs[-1]
     shape = int(np.prod(y.shape[1:]))
 

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -263,7 +263,7 @@ def backward_max_(
         inputs, tight=False, compute_ibp_from_affine=False
     )
     dtype = x.dtype
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
     max_dim = input_shape[axis]
     empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
     empty_tensor_list = [empty_tensor] * max_dim

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -107,7 +107,7 @@ def backward_linear_prod(
     w_u, b_u, w_l, b_l = back_bounds
 
     if len(w_u_i.shape) > 3:
-        n_dim = w_u_i.get_input_shape_at(0)[1]
+        n_dim = w_u_i.shape[1]
         w_u_i = K.reshape(w_u_i, (-1, n_dim, n_dim))
         w_l_i = K.reshape(w_l_i, (-1, n_dim, n_dim))
         b_u_i = K.reshape(b_u_i, (-1, n_dim))

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -3,7 +3,6 @@ from typing import Any, List, Optional, Tuple, Union
 import keras
 import keras.ops as K
 import numpy as np
-import tensorflow as tf
 from keras.config import floatx
 from keras.layers import Flatten
 
@@ -17,6 +16,7 @@ from decomon.core import (
     get_lower_box,
     get_upper_box,
 )
+from decomon.keras_utils import BatchedIdentityLike
 from decomon.layers.utils import sort
 from decomon.utils import maximum, minus, relu_, subtract
 
@@ -648,14 +648,10 @@ def get_identity_lirpa(inputs: List[keras.KerasTensor]) -> List[keras.KerasTenso
     y = inputs[-1]
     shape = int(np.prod(y.shape[1:]))
 
-    z_value = K.cast(0.0, y.dtype)
-    o_value = K.cast(1.0, y.dtype)
     y_flat = K.reshape(y, [-1, shape])
 
-    w_u_out, w_l_out = [o_value + z_value * y_flat] * 2
-    b_u_out, b_l_out = [z_value * y_flat] * 2
-    w_u_out = tf.linalg.diag(w_u_out)
-    w_l_out = tf.linalg.diag(w_l_out)
+    w_u_out, w_l_out = [BatchedIdentityLike()(y_flat)] * 2
+    b_u_out, b_l_out = [K.zeros_like(y_flat)] * 2
 
     return [w_u_out, b_u_out, w_l_out, b_l_out]
 

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -1,11 +1,11 @@
 from typing import Any, List, Optional, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.config import floatx
-from keras_core.layers import Flatten
+from keras.config import floatx
+from keras.layers import Flatten
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import keras
 import keras.ops as K
@@ -658,3 +658,14 @@ def get_identity_lirpa(inputs: List[keras.KerasTensor]) -> List[keras.KerasTenso
     w_l_out = tf.linalg.diag(w_l_out)
 
     return [w_u_out, b_u_out, w_l_out, b_l_out]
+
+
+def get_identity_lirpa_shapes(input_shapes: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    y_shape = input_shapes[-1]
+    batch_size = y_shape[0]
+    flatten_dim = int(np.prod(y_shape[1:]))
+
+    b_shape = batch_size, flatten_dim
+    w_shape = batch_size, flatten_dim, flatten_dim
+
+    return [w_shape, b_shape, w_shape, b_shape]

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -265,6 +265,8 @@ def backward_max_(
     dtype = x.dtype
     input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
     max_dim = input_shape[axis]
+    if max_dim is None:
+        raise ValueError(f"Dimension {axis} corresponding to `axis` cannot be None")
     empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
     empty_tensor_list = [empty_tensor] * max_dim
     z_value = K.cast(0.0, dtype=dtype)
@@ -659,7 +661,7 @@ def get_identity_lirpa(inputs: List[keras.KerasTensor]) -> List[keras.KerasTenso
 def get_identity_lirpa_shapes(input_shapes: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
     y_shape = input_shapes[-1]
     batch_size = y_shape[0]
-    flatten_dim = int(np.prod(y_shape[1:]))
+    flatten_dim = int(np.prod(y_shape[1:]))  # type: ignore
 
     b_shape = batch_size, flatten_dim
     w_shape = batch_size, flatten_dim, flatten_dim

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -536,7 +536,7 @@ def backward_multiply(
 
     z_value = K.cast(0.0, u_c_0.dtype)
 
-    n = np.prod(u_c_0.shape[1:])
+    n = int(np.prod(u_c_0.shape[1:]))
     n_shape = [-1, n]
     # broadcast dimensions if needed
     n_out = len(w_u_out.shape[1:])
@@ -614,7 +614,7 @@ def backward_sort(
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
 
     # build fake inputs with no linearity
-    n_dim = np.prod(u_c.shape[1:])
+    n_dim = int(np.prod(u_c.shape[1:]))
     w_tmp = z_value * K.concatenate([u_c[:, None] * n_dim], 1)
 
     inputs_tmp = [x, u_c, w_tmp, u_c, l_c, w_tmp, l_c]
@@ -646,7 +646,7 @@ def backward_sort(
 
 def get_identity_lirpa(inputs: List[keras.KerasTensor]) -> List[keras.KerasTensor]:
     y = inputs[-1]
-    shape = np.prod(y.shape[1:])
+    shape = int(np.prod(y.shape[1:]))
 
     z_value = K.cast(0.0, y.dtype)
     o_value = K.cast(1.0, y.dtype)

--- a/src/decomon/backward_layers/utils_conv.py
+++ b/src/decomon/backward_layers/utils_conv.py
@@ -73,10 +73,10 @@ def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> kera
     shape = np.arange(len(diag_patches_.shape))
     shape[-1] -= 1
     shape[-2] += 1
-    diag_patches_ = K.permute_dimensions(diag_patches_, shape)
+    diag_patches_ = K.transpose(diag_patches_, shape)
     kernel = conv_layer.kernel  # (filter_size, filter_size, c_in, c_out)
 
-    kernel = K.permute_dimensions(K.reshape(kernel, (filter_size**2, c_in, c_out)), (1, 2, 0))[
+    kernel = K.transpose(K.reshape(kernel, (filter_size**2, c_in, c_out)), (1, 2, 0))[
         None, None, None, None, None
     ]  # (1,1,c_in, c_out, filter_size^2)
 
@@ -136,10 +136,10 @@ def get_toeplitz_channels_first(conv_layer: Conv2D, flatten: bool = True) -> ker
     shape = np.arange(len(diag_patches_.shape))
     shape[-1] -= 1
     shape[-2] += 1
-    diag_patches_ = K.permute_dimensions(diag_patches_, shape)
+    diag_patches_ = K.transpose(diag_patches_, shape)
     kernel = conv_layer.kernel  # (filter_size, filter_size, c_in, c_out)
 
-    kernel = K.permute_dimensions(K.reshape(kernel, (filter_size**2, c_in, c_out)), (1, 2, 0))[
+    kernel = K.transpose(K.reshape(kernel, (filter_size**2, c_in, c_out)), (1, 2, 0))[
         None, None, None, None, None
     ]  # (1,1,c_in, c_out, filter_size^2)
 

--- a/src/decomon/backward_layers/utils_conv.py
+++ b/src/decomon/backward_layers/utils_conv.py
@@ -61,11 +61,10 @@ def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> kera
     stride_rows, stride_cols = conv_layer.strides
     rates_rows, rates_cols = conv_layer.dilation_rate
 
-    diag = tf.linalg.diag(K.ones((1, w_in * h_in * c_in)))
-    diag_ = K.reshape(diag, (w_in * h_in * c_in, w_in, h_in, c_in))
+    diag = K.reshape(K.identity(w_in * h_in * c_in), (w_in * h_in * c_in, w_in, h_in, c_in))
 
     diag_patches = tf.image.extract_patches(
-        diag_,
+        diag,
         [1, filter_size, filter_size, 1],
         strides=[1, stride_rows, stride_cols, 1],
         rates=[1, rates_rows, rates_cols, 1],
@@ -132,11 +131,10 @@ def get_toeplitz_channels_first(conv_layer: Conv2D, flatten: bool = True) -> ker
     kernel_filter = conv_layer.kernel
     filter_size = kernel_filter.shape[0]
 
-    diag = tf.linalg.diag(K.ones((1, w_in * h_in * c_in)))
-    diag_ = K.reshape(diag, (w_in * h_in * c_in, w_in, h_in, c_in))
+    diag = K.reshape(K.identity(w_in * h_in * c_in), (w_in * h_in * c_in, w_in, h_in, c_in))
 
     diag_patches = tf.image.extract_patches(
-        diag_, [1, filter_size, filter_size, 1], [1, 1, 1, 1], [1, 1, 1, 1], padding=padding
+        diag, [1, filter_size, filter_size, 1], [1, 1, 1, 1], [1, 1, 1, 1], padding=padding
     )
 
     diag_patches_ = K.reshape(diag_patches, (w_in, h_in, c_in, w_out, h_out, filter_size**2, c_in))

--- a/src/decomon/backward_layers/utils_conv.py
+++ b/src/decomon/backward_layers/utils_conv.py
@@ -6,8 +6,10 @@ import numpy as np
 from keras.layers import Conv2D, Input
 from keras.ops.image import extract_patches
 
+from decomon.types import BackendTensor
 
-def get_toeplitz(conv_layer: Conv2D, flatten: bool = True) -> keras.KerasTensor:
+
+def get_toeplitz(conv_layer: Conv2D, flatten: bool = True) -> BackendTensor:
     """Express formally the affine component of the convolution
     Conv is a linear operator but its affine component is implicit
     we use im2col and extract_patches to express the affine matrix
@@ -28,7 +30,7 @@ def get_toeplitz(conv_layer: Conv2D, flatten: bool = True) -> keras.KerasTensor:
         return get_toeplitz_channels_first(conv_layer, flatten)
 
 
-def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> keras.KerasTensor:
+def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> BackendTensor:
     """Express formally the affine component of the convolution for data_format=channels_last
     Conv is a linear operator but its affine component is implicit
     we use im2col and extract_patches to express the affine matrix
@@ -98,7 +100,7 @@ def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> kera
         return w
 
 
-def get_toeplitz_channels_first(conv_layer: Conv2D, flatten: bool = True) -> keras.KerasTensor:
+def get_toeplitz_channels_first(conv_layer: Conv2D, flatten: bool = True) -> BackendTensor:
     """Express formally the affine component of the convolution for data_format=channels_first
     Conv is a linear operator but its affine component is implicit
     we use im2col and extract_patches to express the affine matrix

--- a/src/decomon/backward_layers/utils_conv.py
+++ b/src/decomon/backward_layers/utils_conv.py
@@ -1,10 +1,10 @@
 import warnings
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.layers import Conv2D, Input
+from keras.layers import Conv2D, Input
 
 
 def get_toeplitz(conv_layer: Conv2D, flatten: bool = True) -> keras.KerasTensor:

--- a/src/decomon/backward_layers/utils_conv.py
+++ b/src/decomon/backward_layers/utils_conv.py
@@ -42,14 +42,18 @@ def get_toeplitz_channels_last(conv_layer: Conv2D, flatten: bool = True) -> kera
          the affine operator W: conv(x)= Wx + bias
     """
 
-    input_shape = conv_layer.get_input_shape_at(0)
-    if isinstance(input_shape, list):
-        input_shape = input_shape[-1]
+    input = conv_layer.input
+    if isinstance(input, keras.KerasTensor):
+        input_shape = input.shape
+    else:  # list of inputs
+        input_shape = input[-1].shape
     _, w_in, h_in, c_in = input_shape
     padding = conv_layer.padding.upper()
-    output_shape = conv_layer.get_output_shape_at(0)
-    if isinstance(output_shape, list):
-        output_shape = output_shape[-1]
+    output = conv_layer.output
+    if isinstance(output, keras.KerasTensor):
+        output_shape = output.shape
+    else:  # list of outputs
+        output_shape = output[-1].shape
     _, w_out, h_out, c_out = output_shape
 
     kernel_filter = conv_layer.kernel
@@ -112,14 +116,18 @@ def get_toeplitz_channels_first(conv_layer: Conv2D, flatten: bool = True) -> ker
         the affine operator W: conv(x)= Wx + bias
     """
 
-    input_shape = conv_layer.get_input_shape_at(0)
-    if isinstance(input_shape, list):
-        input_shape = input_shape[-1]
+    input = conv_layer.input
+    if isinstance(input, keras.KerasTensor):
+        input_shape = input.shape
+    else:  # list of inputs
+        input_shape = input[-1].shape
     _, c_in, w_in, h_in = input_shape
     padding = conv_layer.padding.upper()
-    output_shape = conv_layer.get_output_shape_at(0)
-    if isinstance(output_shape, list):
-        output_shape = output_shape[-1]
+    output = conv_layer.output
+    if isinstance(output, keras.KerasTensor):
+        output_shape = output.shape
+    else:  # list of outputs
+        output_shape = output[-1].shape
     _, c_out, w_out, h_out = output_shape
     kernel_filter = conv_layer.kernel
     filter_size = kernel_filter.shape[0]

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -465,7 +465,7 @@ def get_lq_norm(x: keras.KerasTensor, p: float, axis: int = -1) -> keras.KerasTe
     if p == 1:
         x_q = K.max(K.abs(x), axis)
     elif p == 2:
-        x_q = K.sqrt(K.sum(K.pow(x, p), axis))
+        x_q = K.sqrt(K.sum(K.power(x, p), axis))
     else:
         raise NotImplementedError("p must be equal to 1 or 2")
 

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -210,20 +210,20 @@ class InputsOutputsSpec:
     def affine(self) -> bool:
         return get_affine(self.mode)
 
-    def get_kerasinputshape(self, inputsformode: List[keras.KerasTensor]) -> Tuple[Optional[int]]:
+    def get_kerasinputshape(self, inputsformode: List[keras.KerasTensor]) -> Tuple[Optional[int], ...]:
         return inputsformode[-1].shape
 
     def get_kerasinputshape_from_inputshapesformode(
-        self, inputshapesformode: List[Tuple[Optional[int]]]
-    ) -> Tuple[Optional[int]]:
+        self, inputshapesformode: List[Tuple[Optional[int], ...]]
+    ) -> Tuple[Optional[int], ...]:
         return inputshapesformode[-1]
 
     def get_fullinputshapes_from_inputshapesformode(
         self,
-        inputshapesformode: List[Tuple[Optional[int]]],
-    ) -> List[Tuple[Optional[int]]]:
+        inputshapesformode: List[Tuple[Optional[int], ...]],
+    ) -> List[Tuple[Optional[int], ...]]:
         nb_tensors = self.nb_tensors
-        empty_shape: Tuple[Optional[int]] = tuple()
+        empty_shape: Tuple[Optional[int], ...] = tuple()
         if self.dc_decomp:
             if self.mode == ForwardMode.HYBRID:
                 (
@@ -437,8 +437,8 @@ class InputsOutputsSpec:
         return inputsformode
 
     def extract_inputshapesformode_from_fullinputshapes(
-        self, inputshapes: List[Tuple[Optional[int]]]
-    ) -> List[Tuple[Optional[int]]]:
+        self, inputshapes: List[Tuple[Optional[int], ...]]
+    ) -> List[Tuple[Optional[int], ...]]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputshapes
         if self.mode == ForwardMode.HYBRID:
             inputshapesformode = [x, u_c, w_u, b_u, l_c, w_l, b_l]

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -634,6 +634,7 @@ def get_lower_ball_finetune(
         alpha = kwargs["finetune_lower"]
         # assume alpha is the same shape as w, minus the batch dimension
         n_shape = len(w.shape) - 2
+        z_value = K.cast(0.0, dtype=w.dtype)
 
         if "upper" and "lower" in kwargs:
             upper = kwargs["upper"]  # flatten vector
@@ -645,8 +646,8 @@ def get_lower_ball_finetune(
             w_alpha = w * alpha[None]
             w_alpha_bar = w * (1 - alpha)
 
-            score_box = K.sum(K.maximum(0.0, w_alpha_bar) * lower_reshaped, 1) + K.sum(
-                K.minimum(0.0, w_alpha_bar) * upper_reshaped, 1
+            score_box = K.sum(K.maximum(z_value, w_alpha_bar) * lower_reshaped, 1) + K.sum(
+                K.minimum(z_value, w_alpha_bar) * upper_reshaped, 1
             )
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
@@ -656,10 +657,10 @@ def get_lower_ball_finetune(
             upper = kwargs["upper"]  # flatten vector
             upper_reshaped = np.reshape(upper, [1, -1] + [1] * n_shape)
 
-            w_alpha = K.minimum(0, w) * alpha[None] + K.maximum(0.0, w)
-            w_alpha_bar = K.minimum(0, w) * (1 - alpha[None])
+            w_alpha = K.minimum(z_value, w) * alpha[None] + K.maximum(z_value, w)
+            w_alpha_bar = K.minimum(z_value, w) * (1 - alpha[None])
 
-            score_box = K.sum(K.minimum(0.0, w_alpha_bar) * upper_reshaped, 1)
+            score_box = K.sum(K.minimum(z_value, w_alpha_bar) * upper_reshaped, 1)
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
             return score_box + score_ball
@@ -668,10 +669,10 @@ def get_lower_ball_finetune(
             lower = kwargs["lower"]  # flatten vector
             lower_reshaped = np.reshape(lower, [1, -1] + [1] * n_shape)
 
-            w_alpha = K.maximum(0, w) * alpha[None] + K.minimum(0.0, w)
-            w_alpha_bar = K.maximum(0, w) * (1 - alpha[None])
+            w_alpha = K.maximum(z_value, w) * alpha[None] + K.minimum(z_value, w)
+            w_alpha_bar = K.maximum(z_value, w) * (1 - alpha[None])
 
-            score_box = K.sum(K.maximum(0.0, w_alpha_bar) * lower_reshaped, 1)
+            score_box = K.sum(K.maximum(z_value, w_alpha_bar) * lower_reshaped, 1)
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
             return score_box + score_ball
@@ -686,6 +687,7 @@ def get_upper_ball_finetune(
         alpha = kwargs["finetune_upper"]
         # assume alpha is the same shape as w, minus the batch dimension
         n_shape = len(w.shape) - 2
+        z_value = K.cast(0.0, dtype=w.dtype)
 
         if "upper" and "lower" in kwargs:
             upper = kwargs["upper"]  # flatten vector
@@ -697,8 +699,8 @@ def get_upper_ball_finetune(
             w_alpha = w * alpha[None]
             w_alpha_bar = w * (1 - alpha)
 
-            score_box = K.sum(K.maximum(0.0, w_alpha_bar) * upper_reshaped, 1) + K.sum(
-                K.minimum(0.0, w_alpha_bar) * lower_reshaped, 1
+            score_box = K.sum(K.maximum(z_value, w_alpha_bar) * upper_reshaped, 1) + K.sum(
+                K.minimum(z_value, w_alpha_bar) * lower_reshaped, 1
             )
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
@@ -708,10 +710,10 @@ def get_upper_ball_finetune(
             upper = kwargs["upper"]  # flatten vector
             upper_reshaped = np.reshape(upper, [1, -1] + [1] * n_shape)
 
-            w_alpha = K.minimum(0, w) * alpha[None] + K.maximum(0.0, w)
-            w_alpha_bar = K.minimum(0, w) * (1 - alpha[None])
+            w_alpha = K.minimum(z_value, w) * alpha[None] + K.maximum(z_value, w)
+            w_alpha_bar = K.minimum(z_value, w) * (1 - alpha[None])
 
-            score_box = K.sum(K.maximum(0.0, w_alpha_bar) * upper_reshaped, 1)
+            score_box = K.sum(K.maximum(z_value, w_alpha_bar) * upper_reshaped, 1)
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
             return score_box + score_ball
@@ -720,10 +722,10 @@ def get_upper_ball_finetune(
             lower = kwargs["lower"]  # flatten vector
             lower_reshaped = np.reshape(lower, [1, -1] + [1] * n_shape)
 
-            w_alpha = K.maximum(0, w) * alpha[None] + K.minimum(0.0, w)
-            w_alpha_bar = K.maximum(0, w) * (1 - alpha[None])
+            w_alpha = K.maximum(z_value, w) * alpha[None] + K.minimum(z_value, w)
+            w_alpha_bar = K.maximum(z_value, w) * (1 - alpha[None])
 
-            score_box = K.sum(K.minimum(0.0, w_alpha_bar) * lower_reshaped, 1)
+            score_box = K.sum(K.minimum(z_value, w_alpha_bar) * lower_reshaped, 1)
             score_ball = get_lower_ball(x_0, eps, p, w_alpha, b)
 
             return score_box + score_ball

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -357,7 +357,7 @@ class InputsOutputsSpec:
 
         return [inputs_x, inputs_u_c, inputs_w_u, inputs_b_u, inputs_l_c, inputs_w_l, inputs_b_l, inputs_h, inputs_g]
 
-    def split_inputsformode_to_merge(self, inputsformode: List[keras.KerasTensor]) -> List[List[keras.KerasTensor]]:
+    def split_inputsformode_to_merge(self, inputsformode: List[Any]) -> List[List[Any]]:
         n_comp = self.nb_tensors
         return [inputsformode[n_comp * i : n_comp * (i + 1)] for i in range(len(inputsformode) // n_comp)]
 

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.config import floatx
+from keras.config import floatx
 
 
 class Option(str, Enum):

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -1,5 +1,5 @@
-import keras_core as keras
-from keras_core.layers import Layer
+import keras
+from keras.layers import Layer
 
 
 def get_weight_index(layer: Layer, weight: keras.Variable) -> int:

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import keras
 from keras.layers import Layer
 
@@ -43,3 +45,41 @@ def get_weight_index_from_name(layer: Layer, weight_name: str) -> int:
         return get_weight_index(layer=layer, weight=weight)
     except IndexError:
         raise IndexError(f"The weight {weight_name} is not tracked by the layer {layer}.")
+
+
+def reset_layer(new_layer: Layer, original_layer: Layer, weight_names: List[str]) -> None:
+    """Reset some weights of a layer by using the weights of another layer.
+
+    Args:
+        new_layer: the decomon layer whose weights will be updated
+        original_layer: the layer used to update the weights
+        weight_names: the names of the weights to update
+
+    Returns:
+
+    """
+    if not original_layer.built:
+        raise ValueError(f"the layer {original_layer.name} has not been built yet")
+    if not new_layer.built:
+        raise ValueError(f"the layer {new_layer.name} has not been built yet")
+    else:
+        new_params = new_layer.get_weights()
+        original_params = original_layer.get_weights()
+        for weight_name in weight_names:
+            new_params[get_weight_index_from_name(new_layer, weight_name)] = original_params[
+                get_weight_index_from_name(original_layer, weight_name)
+            ]
+        new_layer.set_weights(new_params)
+
+
+def reset_layer_all_weights(new_layer: Layer, original_layer: Layer) -> None:
+    """Reset all the weights of a layer by using the weights of another layer.
+
+    Args:
+        new_layer: the decomon layer whose weights will be updated
+        original_layer: the layer used to update the weights
+
+    Returns:
+
+    """
+    reset_layer(new_layer=new_layer, original_layer=original_layer, weight_names=[w.name for w in new_layer.weights])

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 import keras
 from keras.layers import Layer
@@ -83,3 +83,21 @@ def reset_layer_all_weights(new_layer: Layer, original_layer: Layer) -> None:
 
     """
     reset_layer(new_layer=new_layer, original_layer=original_layer, weight_names=[w.name for w in new_layer.weights])
+
+
+def check_if_single_shape(shape: Any) -> bool:
+    """
+
+    Args:
+        input_shape:
+
+    Returns:
+
+    """
+    if isinstance(shape, list) and shape and isinstance(shape[0], (int, type(None))):
+        return True
+
+    if not isinstance(shape, (list, tuple, dict)):
+        shape = tuple(shape)
+
+    return isinstance(shape, tuple) and shape and isinstance(shape[0], (int, type(None)))

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -16,7 +16,7 @@ class BatchedIdentityLike(keras.Operation):
 
     """
 
-    def call(self, x: Tensor) -> Tensor:
+    def call(self, x: BackendTensor) -> Tensor:
         if is_symbolic_tensor(x):
             return self.compute_output_spec(x)
         else:
@@ -50,7 +50,7 @@ class BatchedDiagLike(keras.Operation):
 
     """
 
-    def call(self, x: Tensor) -> Tensor:
+    def call(self, x: BackendTensor) -> Tensor:
         if is_symbolic_tensor(x):
             return self.compute_output_spec(x)
         else:

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -492,8 +492,10 @@ def softmax(
         outputs, compute_ibp_from_affine=False
     )
     if ibp:
-        u_c = K.minimum(u_c, 1.0)
-        l_c = K.maximum(l_c, 0.0)
+        o_value = K.cast(1.0, dtype=u_c.dtype)
+        z_value = K.cast(0.0, dtype=u_c.dtype)
+        u_c = K.minimum(u_c, o_value)
+        l_c = K.maximum(l_c, z_value)
 
     return inputs_outputs_spec.extract_outputsformode_from_fulloutputs([x, u_c, w_u, b_u, l_c, w_l, b_l, h, g])
 

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -131,7 +131,7 @@ def linear_hull_s_shape(
         )
         if len(w_u.shape) == len(b_u.shape):
             # it happens with the convert function to spare memory footprint
-            n_dim = np.prod(w_u.shape[1:])
+            n_dim = int(np.prod(w_u.shape[1:]))
             M = np.reshape(
                 np.diag([K.cast(1, dtype=w_u_0.dtype)] * n_dim), [1, n_dim] + list(w_u.shape[1:])
             )  # usage de numpy pb pour les types

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -1,8 +1,8 @@
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 
 from decomon.core import (

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -1,7 +1,6 @@
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import keras
 import keras.ops as K
 import numpy as np
 
@@ -16,6 +15,7 @@ from decomon.core import (
 )
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import exp, expand_dims, frac_pos, multiply, softplus_, sum
+from decomon.types import Tensor
 from decomon.utils import (
     get_linear_hull_s_shape,
     minus,
@@ -40,7 +40,7 @@ GROUP_SORT_2 = "GroupSort2"
 
 
 def relu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     alpha: float = 0.0,
@@ -49,7 +49,7 @@ def relu(
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """
     Args:
         inputs: list of input tensors
@@ -82,14 +82,14 @@ def relu(
 
 
 def linear_hull_s_shape(
-    inputs: List[keras.KerasTensor],
-    func: Callable[[keras.KerasTensor], keras.KerasTensor] = K.sigmoid,
-    f_prime: Callable[[keras.KerasTensor], keras.KerasTensor] = sigmoid_prime,
+    inputs: List[Tensor],
+    func: Callable[[Tensor], Tensor] = K.sigmoid,
+    f_prime: Callable[[Tensor], Tensor] = sigmoid_prime,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Computing the linear hull of s-shape functions
 
     Args:
@@ -158,13 +158,13 @@ def linear_hull_s_shape(
 
 
 def sigmoid(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Sigmoid activation function .
     `1 / (1 + exp(-x))`.
 
@@ -190,13 +190,13 @@ def sigmoid(
 
 
 def tanh(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Hyperbolic activation function.
     `tanh(x)=2*sigmoid(2*x)+1`
 
@@ -223,13 +223,13 @@ def tanh(
 
 
 def hard_sigmoid(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Hard sigmoid activation function.
        Faster to compute than sigmoid activation.
 
@@ -255,13 +255,13 @@ def hard_sigmoid(
 
 
 def elu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Exponential linear unit.
 
     Args:
@@ -286,13 +286,13 @@ def elu(
 
 
 def selu(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Scaled Exponential Linear Unit (SELU).
 
     SELU is equal to: `scale * elu(x, alpha)`, where alpha and scale
@@ -323,13 +323,13 @@ def selu(
 
 
 def linear(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA foe Linear (i.e. identity) activation function.
 
     Args:
@@ -348,13 +348,13 @@ def linear(
 
 
 def exponential(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Exponential activation function.
 
     Args:
@@ -376,13 +376,13 @@ def exponential(
 
 
 def softplus(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Softplus activation function `log(exp(x) + 1)`.
 
     Args:
@@ -406,13 +406,13 @@ def softplus(
 
 
 def softsign(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Softsign activation function `x / (abs(x) + 1)`.
 
     Args:
@@ -438,7 +438,7 @@ def softsign(
 
 
 def softmax(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -446,7 +446,7 @@ def softmax(
     clip: bool = True,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """LiRPA for Softmax activation function.
 
     Args:
@@ -501,21 +501,21 @@ def softmax(
 
 
 def group_sort_2(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     data_format: str = "channels_last",
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
     raise NotImplementedError()
 
 
-def deserialize(name: str) -> Callable[..., List[keras.KerasTensor]]:
+def deserialize(name: str) -> Callable[..., List[Tensor]]:
     """Get the activation from name.
 
     Args:
@@ -553,7 +553,7 @@ def deserialize(name: str) -> Callable[..., List[keras.KerasTensor]]:
         raise ValueError(f"Could not interpret activation function identifier: {name}")
 
 
-def get(identifier: Any) -> Callable[..., List[keras.KerasTensor]]:
+def get(identifier: Any) -> Callable[..., List[Tensor]]:
     """Get the `identifier` activation function.
 
     Args:

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-from keras_core.layers import Activation, Input, Layer
+import keras
+from keras.layers import Activation, Input, Layer
 
 import decomon.layers.decomon_layers
 import decomon.layers.decomon_merge_layers

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -183,7 +183,7 @@ def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:
         RuntimeError: if called in Eager mode.
     """
 
-    if not layer.inbound_nodes:
+    if not layer._inbound_nodes:
         raise AttributeError(
             f'The layer "{layer.name}" has never been called '
             "and thus has no defined input shape. Note that the "
@@ -191,10 +191,10 @@ def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:
             "Functional and Sequential models."
         )
     all_input_shapes = set(
-        [str(get_input_shapes_as_a_list_of_input_shape(node.input_shapes)) for node in layer.inbound_nodes]
+        [str(get_input_shapes_as_a_list_of_input_shape(node.input_shapes)) for node in layer._inbound_nodes]
     )
     if len(all_input_shapes) == 1:
-        return get_input_shapes_as_a_list_of_input_shape(layer.inbound_nodes[0].input_shapes)
+        return get_input_shapes_as_a_list_of_input_shape(layer._inbound_nodes[0].input_shapes)
     else:
         raise AttributeError(
             'The layer "' + str(layer.name) + '" has multiple inbound nodes, '

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -152,7 +152,7 @@ def _prepare_input_tensors(
     return flatten_input_list
 
 
-SingleInputShapeType = Tuple[Optional[int]]
+SingleInputShapeType = Tuple[Optional[int], ...]
 
 
 def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -155,15 +155,6 @@ def _prepare_input_tensors(
 SingleInputShapeType = Tuple[Optional[int]]
 
 
-def get_input_shapes_as_a_list_of_input_shape(
-    input_shapes: Union[List[SingleInputShapeType], SingleInputShapeType]
-) -> List[SingleInputShapeType]:
-    if not isinstance(input_shapes, list):
-        return [input_shapes]
-    else:
-        return input_shapes
-
-
 def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:
     """Retrieves the input shape(s) of a layer.
 
@@ -184,23 +175,14 @@ def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:
     """
 
     if not layer._inbound_nodes:
-        raise AttributeError(
-            f'The layer "{layer.name}" has never been called '
-            "and thus has no defined input shape. Note that the "
-            "`input_shape` property is only available for "
-            "Functional and Sequential models."
-        )
-    all_input_shapes = set(
-        [str(get_input_shapes_as_a_list_of_input_shape(node.input_shapes)) for node in layer._inbound_nodes]
-    )
+        raise AttributeError(f'The layer "{layer.name}" has never been called ' "and thus has no defined input shape.")
+    all_input_shapes = set([str([tensor.shape for tensor in node.input_tensors]) for node in layer._inbound_nodes])
     if len(all_input_shapes) == 1:
-        return get_input_shapes_as_a_list_of_input_shape(layer._inbound_nodes[0].input_shapes)
+        return [tensor.shape for tensor in layer._inbound_nodes[0].input_tensors]
     else:
         raise AttributeError(
             'The layer "' + str(layer.name) + '" has multiple inbound nodes, '
             "with different input shapes. Hence "
             'the notion of "input shape" is '
             "ill-defined for the layer. "
-            "Use `get_input_shape_at(node_index)` "
-            "instead."
         )

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import keras_core as keras
-from keras_core.layers import Layer
+import keras
+from keras.layers import Layer
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -12,7 +12,7 @@ from decomon.core import (
     get_affine,
     get_ibp,
 )
-from decomon.keras_utils import get_weight_index_from_name
+from decomon.keras_utils import reset_layer
 
 
 class DecomonLayer(ABC, Layer):
@@ -130,7 +130,7 @@ class DecomonLayer(ABC, Layer):
         """
         weight_names = self.keras_weights_names
         if len(weight_names) > 0:
-            reset_layer(decomon_layer=self, keras_layer=layer, weight_names=weight_names)
+            reset_layer(new_layer=self, original_layer=layer, weight_names=weight_names)
 
     @property
     def keras_weights_names(self) -> List[str]:
@@ -175,28 +175,3 @@ class DecomonLayer(ABC, Layer):
 
     def set_back_bounds(self, has_backward_bounds: bool) -> None:
         pass
-
-
-def reset_layer(decomon_layer: DecomonLayer, keras_layer: Layer, weight_names: List[str]) -> None:
-    """Reset the weights of a decomon layer by using the weights of another (a priori non-decomon) layer.
-
-    Args:
-        decomon_layer: the decomon layer whose weights will be updated
-        keras_layer: the layer used to update the weights
-        weight_names: the names of the weights to update
-
-    Returns:
-
-    """
-    if not keras_layer.built:
-        raise ValueError(f"the layer {keras_layer.name} has not been built yet")
-    if not decomon_layer.built:
-        raise ValueError(f"the layer {decomon_layer.name} has not been built yet")
-    else:
-        decomon_params = decomon_layer.get_weights()
-        original_params = keras_layer.get_weights()
-        for weight_name in weight_names:
-            decomon_params[get_weight_index_from_name(decomon_layer, weight_name)] = original_params[
-                get_weight_index_from_name(keras_layer, weight_name)
-            ]
-        decomon_layer.set_weights(decomon_params)

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -108,14 +108,21 @@ class DecomonLayer(ABC, Layer):
         """
 
     def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
-        """
+        """Compute expected output shape according to input shape
+
+        Used by symbolic calls on Keras Tensors. By default, return same shape(s).
+
         Args:
             input_shape
 
         Returns:
 
         """
-        return self.original_keras_layer_class.compute_output_shape(self, input_shape)
+        return input_shape
+
+    def compute_output_spec(self, *args, **kwargs):
+        """Compute output spec from output shape in case of symbolic call."""
+        return Layer.compute_output_spec(self, *args, **kwargs)
 
     def reset_layer(self, layer: Layer) -> None:
         """Reset the weights by using the weights of another (a priori non-decomon) layer.

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -137,8 +137,10 @@ class DecomonLayer(ABC, Layer):
                 # no compute_output_shape implemented (e.g. InputLayer)
                 return input_shape
 
+        # we know from here that we got a list of input shapes. Mypy does not.
+        input_shapes: List[Tuple[Optional[int], ...]] = input_shape  # type: ignore
         y_shape = self.inputs_outputs_spec.get_kerasinputshape_from_inputshapesformode(
-            input_shape
+            input_shapes
         )  # input shape for the original layer
         try:
             y_out_shape = self.original_keras_layer_class.compute_output_shape(
@@ -159,7 +161,7 @@ class DecomonLayer(ABC, Layer):
                 b_l_shape,
                 h_shape,
                 g_shape,
-            ) = self.inputs_outputs_spec.get_fullinputshapes_from_inputshapesformode(input_shape)
+            ) = self.inputs_outputs_spec.get_fullinputshapes_from_inputshapesformode(input_shapes)
             y_out_shape_wo_batchsize = y_out_shape[1:]
             if self.inputs_outputs_spec.affine:
                 model_inputdim = x_shape[-1]
@@ -180,7 +182,7 @@ class DecomonLayer(ABC, Layer):
             ]
             return self.inputs_outputs_spec.extract_inputshapesformode_from_fullinputshapes(fulloutputshapes)
 
-    def compute_output_spec(self, *args, **kwargs):
+    def compute_output_spec(self, *args: Any, **kwargs: Any) -> keras.KerasTensor:
         """Compute output spec from output shape in case of symbolic call."""
         return Layer.compute_output_spec(self, *args, **kwargs)
 

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -13,6 +13,7 @@ from decomon.core import (
     get_ibp,
 )
 from decomon.keras_utils import check_if_single_shape, reset_layer
+from decomon.types import BackendTensor
 
 
 class DecomonLayer(ABC, Layer):
@@ -98,7 +99,7 @@ class DecomonLayer(ABC, Layer):
         self.original_keras_layer_class.build(self, y_input_shape)
 
     @abstractmethod
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         """
         Args:
             inputs
@@ -210,7 +211,7 @@ class DecomonLayer(ABC, Layer):
         """
         return []
 
-    def join(self, bounds: List[keras.KerasTensor]) -> List[keras.KerasTensor]:
+    def join(self, bounds: List[BackendTensor]) -> List[BackendTensor]:
         """
         Args:
             bounds

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -85,7 +85,7 @@ class DecomonLayer(ABC, Layer):
         )
         return config
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape
@@ -108,8 +108,8 @@ class DecomonLayer(ABC, Layer):
         """
 
     def compute_output_shape(
-        self, input_shape: Union[Tuple[Optional[int]], List[Tuple[Optional[int]]]]
-    ) -> Union[Tuple[Optional[int]], List[Tuple[Optional[int]]]]:
+        self, input_shape: Union[Tuple[Optional[int], ...], List[Tuple[Optional[int], ...]]]
+    ) -> Union[Tuple[Optional[int], ...], List[Tuple[Optional[int], ...]]]:
         """Compute expected output shape according to input shape
 
         Will be called by symbolic calls on Keras Tensors.

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -830,14 +830,13 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
 
         n_dim = len(y.shape)
         shape = [1] * n_dim
-        for i, ax in enumerate(self.axis):
-            shape[ax] = self.moving_mean.shape[i]
+        shape[self.axis] = self.moving_mean.shape[0]
 
-        if self.gamma is None:  # scale = False
+        if not hasattr(self, "gamma") or self.gamma is None:  # scale = False
             gamma = K.ones(shape)
         else:  # scale = True
             gamma = K.reshape(self.gamma + z_value, shape)
-        if self.beta is None:  # center = False
+        if not hasattr(self, "beta") or self.beta is None:  # center = False
             beta = K.zeros(shape)
         else:  # center = True
             beta = K.reshape(self.beta + z_value, shape)

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -151,9 +151,6 @@ class DecomonConv2D(DecomonLayer, Conv2D):
         z_value = K.cast(0.0, self.dtype)
         o_value = K.cast(1.0, self.dtype)
 
-        if not isinstance(inputs, list):
-            raise ValueError("A merge layer should be called on a list of inputs.")
-
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(
             inputs, compute_ibp_from_affine=False
         )
@@ -432,9 +429,6 @@ class DecomonDense(DecomonLayer, Dense):
             raise RuntimeError("self.kernel cannot be None when calling call()")
 
         z_value = K.cast(0.0, self.dtype)
-
-        if not isinstance(inputs, list):
-            raise ValueError("A merge layer should be called " "on a list of inputs.")
 
         if self.has_backward_bounds:
             back_bound = inputs[-1]

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -90,7 +90,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
 
         self.diag_op = Lambda(tf.linalg.diag)
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape
@@ -325,10 +325,10 @@ class DecomonDense(DecomonLayer, Dense):
             **kwargs,
         )
         self.input_spec = [InputSpec(min_ndim=2) for _ in range(self.nb_tensors)]
-        self.input_shape_build: Optional[List[Tuple[Optional[int]]]] = None
+        self.input_shape_build: Optional[List[Tuple[Optional[int], ...]]] = None
         self.op_dot = K.dot
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape
@@ -569,7 +569,7 @@ class DecomonActivation(DecomonLayer, Activation):
         self.activation = activations.get(activation)
         self.activation_name = activation
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         if self.finetune and self.mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
             shape = input_shape[-1][1:]
 
@@ -706,7 +706,7 @@ class DecomonFlatten(DecomonLayer, Flatten):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
             self
@@ -807,7 +807,7 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
             **kwargs,
         )
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
@@ -925,7 +925,7 @@ class DecomonDropout(DecomonLayer, Dropout):
             **kwargs,
         )
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.layers import (
+from keras.layers import (
     Activation,
     BatchNormalization,
     Conv2D,
@@ -17,7 +17,7 @@ from keras_core.layers import (
     Lambda,
     Layer,
 )
-from keras_core.src.backend import rnn
+from keras.src.backend import rnn
 
 from decomon.core import ForwardMode, PerturbationDomain, Slope
 from decomon.layers import activations

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -943,15 +943,18 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
 
     original_keras_layer_class = InputLayer
 
+    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+        return inputs
+
     def __init__(
         self,
-        input_shape: Optional[Tuple[int, ...]] = None,
+        shape: Optional[Tuple[int, ...]] = None,
         batch_size: Optional[int] = None,
         dtype: Optional[str] = None,
-        input_tensor: Optional[keras.KerasTensor] = None,
         sparse: Optional[bool] = None,
+        batch_shape: Optional[Tuple[Optional[int], ...]] = None,
+        input_tensor: Optional[keras.KerasTensor] = None,
         name: Optional[str] = None,
-        ragged: Optional[bool] = None,
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -961,13 +964,13 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
         **kwargs: Any,
     ):
         super().__init__(
-            input_shape=input_shape,
+            shape=shape,
             batch_size=batch_size,
             dtype=dtype,
             input_tensor=input_tensor,
             sparse=sparse,
             name=name,
-            ragged=ragged,
+            batch_shape=batch_shape,
             perturbation_domain=perturbation_domain,
             dc_decomp=dc_decomp,
             mode=mode,
@@ -976,6 +979,3 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
             fast=fast,
             **kwargs,
         )
-
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
-        return inputs

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -88,8 +88,6 @@ class DecomonConv2D(DecomonLayer, Conv2D):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=4), InputSpec(min_ndim=4)]
 
-        self.diag_op = Lambda(tf.linalg.diag)
-
     def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:
@@ -200,10 +198,8 @@ class DecomonConv2D(DecomonLayer, Conv2D):
             )
 
             if len(w_u.shape) == len(b_u.shape):
-                identity_tensor = self.diag_op(z_value * Flatten()(b_u[0][None]) + o_value)
-
-                identity_tensor = K.reshape(identity_tensor, [-1] + list(b_u.shape[1:]))
-
+                flatdim = int(np.prod(b_u.shape[1:]))
+                identity_tensor = K.reshape(K.identity(flatdim, dtype=self.dtype), (-1,) + tuple(b_u.shape[1:]))
                 w_u_out = K.conv(
                     identity_tensor,
                     self.kernel,

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -809,7 +809,7 @@ class DecomonFlatten(DecomonLayer, Flatten):
             b_u_out = op(b_u)
             b_l_out = op(b_l)
             input_dim = x.shape[-1]
-            output_shape = np.prod(list(K.int_shape(b_u_out))[1:])
+            output_shape = int(np.prod(list(K.int_shape(b_u_out))[1:]))
             w_u_out = K.reshape(w_u, (-1, input_dim, output_shape))
             w_l_out = K.reshape(w_l, (-1, input_dim, output_shape))
         else:

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -906,12 +906,7 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
             output += [output_shape, output_shape]
         return output
 
-    def call(
-        self, inputs: List[keras.KerasTensor], training: Optional[bool] = None, **kwargs: Any
-    ) -> List[keras.KerasTensor]:
-        if training is None:
-            training = K.learning_phase()
-
+    def call(self, inputs: List[keras.KerasTensor], training: bool = False, **kwargs: Any) -> List[keras.KerasTensor]:
         z_value = K.cast(0.0, self.dtype)
 
         if training:
@@ -1033,12 +1028,7 @@ class DecomonDropout(DecomonLayer, Dropout):
         super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
-    def call(
-        self, inputs: List[keras.KerasTensor], training: Optional[bool] = None, **kwargs: Any
-    ) -> List[keras.KerasTensor]:
-        if training is None:
-            training = K.learning_phase()
-
+    def call(self, inputs: List[keras.KerasTensor], training: bool = False, **kwargs: Any) -> List[keras.KerasTensor]:
         if training:
             raise NotImplementedError("not working during training")
 

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -8,6 +8,7 @@ from keras_core.layers import (
     Concatenate,
     Dot,
     Lambda,
+    Layer,
     Maximum,
     Minimum,
     Multiply,
@@ -26,7 +27,16 @@ class DecomonMerge(DecomonLayer):
     """Base class for Decomon layers based on Mergind Keras layers."""
 
     def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
-        return input_shape
+        """Compute output shapes from input shapes.
+
+        By default, we assume that all inputs will be merged into "one" (still a list of tensors though).
+
+        """
+        input_shapes_list = self.inputs_outputs_spec.split_inputsformode_to_merge(input_shape)
+        return input_shapes_list[0]
+
+    def compute_output_spec(self, *args, **kwargs):
+        return Layer.compute_output_spec(self, *args, **kwargs)
 
     def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
         n_comp = self.nb_tensors

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -35,9 +35,6 @@ class DecomonMerge(DecomonLayer):
         input_shapes_list = self.inputs_outputs_spec.split_inputsformode_to_merge(input_shape)
         return input_shapes_list[0]
 
-    def compute_output_spec(self, *args, **kwargs):
-        return Layer.compute_output_spec(self, *args, **kwargs)
-
     def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
         n_comp = self.nb_tensors
         input_shape_y = input_shape[n_comp - 1 :: n_comp]

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras
 import keras.ops as K
 from keras.layers import (
     Add,
@@ -18,6 +17,7 @@ from keras.layers import (
 from decomon.core import ForwardMode, PerturbationDomain
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import broadcast, multiply, permute_dimensions
+from decomon.types import BackendTensor
 from decomon.utils import maximum, minus, subtract
 
 ##### Merge Layer ####
@@ -115,7 +115,7 @@ class DecomonAdd(DecomonMerge, Add):
             **kwargs,
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -186,7 +186,7 @@ class DecomonAverage(DecomonMerge, Average):
         )
         self.op = Lambda(lambda x: sum(x) / len(x))
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -256,7 +256,7 @@ class DecomonSubtract(DecomonMerge, Subtract):
             **kwargs,
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -305,7 +305,7 @@ class DecomonMinimum(DecomonMerge, Minimum):
             **kwargs,
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -368,7 +368,7 @@ class DecomonMaximum(DecomonMerge, Maximum):
             **kwargs,
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -428,7 +428,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
             **kwargs,
         )
 
-        def func(inputs: List[keras.KerasTensor]) -> keras.KerasTensor:
+        def func(inputs: List[BackendTensor]) -> BackendTensor:
             return Concatenate.call(self, inputs)
 
         self.op = func
@@ -437,7 +437,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
         else:
             self.op_w = Concatenate(axis=self.axis + 1)
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -507,7 +507,7 @@ class DecomonMultiply(DecomonMerge, Multiply):
             **kwargs,
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -571,7 +571,7 @@ class DecomonDot(DecomonMerge, Dot):
         else:
             self.axes = axes
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -540,8 +540,8 @@ class DecomonDot(DecomonMerge, Dot):
         else:
             raise NotImplementedError("This layer is not implemented to merge more than 2 layers.")
 
-        input_shape_0 = self.inputs_outputs_spec.get_input_shape(inputs_0)
-        input_shape_1 = self.inputs_outputs_spec.get_input_shape(inputs_1)
+        input_shape_0 = self.inputs_outputs_spec.get_kerasinputshape(inputs_0)
+        input_shape_1 = self.inputs_outputs_spec.get_kerasinputshape(inputs_1)
         n_0 = len(input_shape_0) - 2
         n_1 = len(input_shape_1) - 2
 

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
-from keras_core.layers import (
+import keras
+import keras.ops as K
+from keras.layers import (
     Add,
     Average,
     Concatenate,

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -26,7 +26,7 @@ from decomon.utils import maximum, minus, subtract
 class DecomonMerge(DecomonLayer):
     """Base class for Decomon layers based on Mergind Keras layers."""
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:  # type: ignore
         """Compute output shapes from input shapes.
 
         By default, we assume that all inputs will be merged into "one" (still a list of tensors though).

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -26,7 +26,7 @@ from decomon.utils import maximum, minus, subtract
 class DecomonMerge(DecomonLayer):
     """Base class for Decomon layers based on Mergind Keras layers."""
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
         """Compute output shapes from input shapes.
 
         By default, we assume that all inputs will be merged into "one" (still a list of tensors though).
@@ -81,7 +81,7 @@ class DecomonMerge(DecomonLayer):
             ]
             return self.inputs_outputs_spec.extract_inputshapesformode_from_fullinputshapes(fulloutputshapes)
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         n_comp = self.nb_tensors
         input_shape_y = input_shape[n_comp - 1 :: n_comp]
         self.original_keras_layer_class.build(self, input_shape_y)

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import keras_core as keras
 import keras_core.ops as K
 from keras_core.layers import InputSpec, Layer, Permute, Reshape
+from keras_core.src.backend import rnn
 
 from decomon.core import ForwardMode, PerturbationDomain, get_affine, get_ibp
 from decomon.layers.core import DecomonLayer
@@ -106,8 +107,8 @@ class DecomonReshape(DecomonLayer, Reshape):
                 ) -> Tuple[keras.KerasTensor, List[keras.KerasTensor]]:
                     return op(x), _
 
-                w_u_out = K.rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
-                w_l_out = K.rnn(step_function=step_func, inputs=w_l, initial_states=[], unroll=False)[1]
+                w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
+                w_l_out = rnn(step_function=step_func, inputs=w_l, initial_states=[], unroll=False)[1]
         else:
             w_u_out, b_u_out, w_l_out, b_l_out = empty_tensor, empty_tensor, empty_tensor, empty_tensor
 
@@ -215,8 +216,8 @@ class DecomonPermute(DecomonLayer, Permute):
                 ) -> Tuple[keras.KerasTensor, List[keras.KerasTensor]]:
                     return op(x), _
 
-                w_u_out = K.rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
-                w_l_out = K.rnn(step_function=step_func, inputs=w_l, initial_states=[], unroll=False)[1]
+                w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
+                w_l_out = rnn(step_function=step_func, inputs=w_l, initial_states=[], unroll=False)[1]
         else:
             w_u_out, b_u_out, w_l_out, b_l_out = empty_tensor, empty_tensor, empty_tensor, empty_tensor
 

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -1,12 +1,11 @@
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import keras
-import keras.ops as K
 from keras.layers import InputSpec, Layer, Permute, Reshape
 from keras.src.backend import rnn
 
 from decomon.core import ForwardMode, PerturbationDomain, get_affine, get_ibp
 from decomon.layers.core import DecomonLayer
+from decomon.types import BackendTensor
 
 
 class DecomonReshape(DecomonLayer, Reshape):
@@ -70,8 +69,8 @@ class DecomonReshape(DecomonLayer, Reshape):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
-        def op(x: keras.KerasTensor) -> keras.KerasTensor:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+        def op(x: BackendTensor) -> BackendTensor:
             return Reshape.call(self, x)
 
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(
@@ -102,9 +101,7 @@ class DecomonReshape(DecomonLayer, Reshape):
 
             else:
 
-                def step_func(
-                    x: keras.KerasTensor, _: List[keras.KerasTensor]
-                ) -> Tuple[keras.KerasTensor, List[keras.KerasTensor]]:
+                def step_func(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
                     return op(x), _
 
                 w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
@@ -180,8 +177,8 @@ class DecomonPermute(DecomonLayer, Permute):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
-        def op(x: keras.KerasTensor) -> keras.KerasTensor:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+        def op(x: BackendTensor) -> BackendTensor:
             return Permute.call(self, x)
 
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(
@@ -211,9 +208,7 @@ class DecomonPermute(DecomonLayer, Permute):
                 w_l_out = op(w_l)
             else:
 
-                def step_func(
-                    x: keras.KerasTensor, _: List[keras.KerasTensor]
-                ) -> Tuple[keras.KerasTensor, List[keras.KerasTensor]]:
+                def step_func(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
                     return op(x), _
 
                 w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import keras_core as keras
-import keras_core.ops as K
-from keras_core.layers import InputSpec, Layer, Permute, Reshape
-from keras_core.src.backend import rnn
+import keras
+import keras.ops as K
+from keras.layers import InputSpec, Layer, Permute, Reshape
+from keras.src.backend import rnn
 
 from decomon.core import ForwardMode, PerturbationDomain, get_affine, get_ibp
 from decomon.layers.core import DecomonLayer

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -69,7 +69,7 @@ else:
             )
             return config
 
-        def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+        def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
             if (self.n is None) or (self.n > input_shape[-1][self.channel_axis]):
                 self.n = input_shape[-1][self.channel_axis]
                 if self.n is None:  # for mypy
@@ -201,7 +201,7 @@ else:
             output = self.op_concat(inputs_min + inputs_max)
             return self.op_reshape_out(output)
 
-        def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+        def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
             input_shape = input_shape[-1]
 
             if self.data_format == "channels_last":

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -123,9 +123,6 @@ else:
                 shape_in, mode=self.mode, perturbation_domain=self.perturbation_domain, dc_decomp=self.dc_decomp
             ).call(outputs)
 
-        def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
-            return input_shape
-
     class DecomonGroupSort2(DecomonLayer):
         original_keras_layer_class = GroupSort2
 
@@ -172,9 +169,6 @@ else:
                 }
             )
             return config
-
-        def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
-            return input_shape
 
         def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
             inputs_reshaped = self.op_reshape_in(inputs)

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-from keras_core.layers import Layer
+import keras
+from keras.layers import Layer
 
 from decomon.core import ForwardMode, PerturbationDomain
 from decomon.layers.core import DecomonLayer

--- a/src/decomon/layers/deel_lip.py
+++ b/src/decomon/layers/deel_lip.py
@@ -9,6 +9,7 @@ from decomon.layers.core import DecomonLayer
 from decomon.layers.decomon_merge_layers import DecomonConcatenate
 from decomon.layers.decomon_reshape import DecomonReshape
 from decomon.layers.utils import ClipAlpha, expand_dims, max_, min_, sort
+from decomon.types import BackendTensor
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ else:
                 (-1, self.n), mode=self.mode, perturbation_domain=self.perturbation_domain, dc_decomp=self.dc_decomp
             ).call
 
-        def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+        def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
             shape_in = tuple(inputs[-1].shape[1:])
             inputs_reshaped = self.reshape(inputs)
             if self.n == 2:
@@ -174,7 +175,7 @@ else:
             )
             return config
 
-        def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+        def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
             inputs_reshaped = self.op_reshape_in(inputs)
             inputs_max = expand_dims(
                 max_(

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.layers import InputSpec, MaxPooling2D
+from keras.layers import InputSpec, MaxPooling2D
 
 from decomon.core import ForwardMode, PerturbationDomain
 from decomon.layers.core import DecomonLayer

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -121,37 +121,6 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
         self.internal_op = conv_
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> List[Tuple[Optional[int]]]:
-        """
-        Args:
-            input_shape
-
-        Returns:
-
-        """
-
-        if self.grad_bounds:
-            raise NotImplementedError()
-
-        output_shape_keras = MaxPooling2D.compute_output_shape(self, input_shape[0])
-        input_dim = input_shape[-1][1]
-        if self.mode == ForwardMode.IBP:
-            output_shape = [output_shape_keras] * 2
-        elif self.mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
-            x_shape = input_shape[1]
-            w_shape = tuple([output_shape_keras[0], input_dim] + list(output_shape_keras)[1:])
-            if self.mode == ForwardMode.AFFINE:
-                output_shape = [x_shape] + [w_shape, output_shape_keras] * 2
-            else:
-                output_shape = [x_shape] + [output_shape_keras, w_shape, output_shape_keras] * 2
-        else:
-            raise ValueError(f"Unknown mode {self.mode}")
-
-        if self.dc_decomp:
-            output_shape += [output_shape_keras] * 2
-
-        return output_shape
-
     def _pooling_function_fast(
         self,
         inputs: List[keras.KerasTensor],

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import keras_core as keras
 import keras_core.ops as K
 import numpy as np
-from keras.backend import conv2d
 from keras_core.layers import InputSpec, MaxPooling2D
 
 from decomon.core import ForwardMode, PerturbationDomain
@@ -94,10 +93,10 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             if self.data_format in [None, "channels_last"]:
                 return K.cast(
                     K.expand_dims(
-                        conv2d(
+                        K.conv(
                             x,
                             self.filters,
-                            strides=self.strides,
+                            strides=list(self.strides),
                             padding=self.padding,
                             data_format=self.data_format,
                         ),
@@ -108,10 +107,10 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             else:
                 return K.cast(
                     K.expand_dims(
-                        conv2d(
+                        K.conv(
                             x,
                             self.filters,
-                            strides=self.strides,
+                            strides=list(self.strides),
                             padding=self.padding,
                             data_format=self.data_format,
                         ),
@@ -161,8 +160,8 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
         dtype = x.dtype
         empty_tensor = self.inputs_outputs_spec.get_empty_tensor(dtype=dtype)
 
-        l_c_out = K.pool2d(l_c, self.pool_size, self.strides, self.padding, self.data_format, pool_mode="max")
-        u_c_out = K.pool2d(u_c, self.pool_size, self.strides, self.padding, self.data_format, pool_mode="max")
+        l_c_out = K.max_pool(l_c, self.pool_size, self.strides, self.padding, self.data_format)
+        u_c_out = K.max_pool(u_c, self.pool_size, self.strides, self.padding, self.data_format)
 
         if self.affine:
             n_in = x.shape[-1]

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -190,7 +190,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
         )
         dtype = x.dtype
         empty_tensor = self.inputs_outputs_spec.get_empty_tensor(dtype=dtype)
-        input_shape = self.inputs_outputs_spec.get_input_shape(inputs)
+        input_shape = self.inputs_outputs_spec.get_kerasinputshape(inputs)
         n_split = input_shape[-1]
 
         if self.dc_decomp:

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras
 import keras.ops as K
 import numpy as np
 from keras.layers import InputSpec, MaxPooling2D
@@ -8,6 +7,7 @@ from keras.layers import InputSpec, MaxPooling2D
 from decomon.core import ForwardMode, PerturbationDomain
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import max_
+from decomon.types import BackendTensor
 
 
 # step 1: compute the maximum
@@ -92,7 +92,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
         self.filters_w = self.filters[None]
         self.strides_w = (1,) + self.strides
 
-        def conv_(x: keras.KerasTensor) -> keras.KerasTensor:
+        def conv_(x: BackendTensor) -> BackendTensor:
             if self.data_format in [None, "channels_last"]:
                 return K.cast(
                     K.expand_dims(
@@ -122,7 +122,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
                     self.dtype,
                 )
 
-        def conv_w_(x: keras.KerasTensor) -> keras.KerasTensor:
+        def conv_w_(x: BackendTensor) -> BackendTensor:
             if self.data_format in [None, "channels_last"]:
                 return K.cast(
                     K.expand_dims(
@@ -157,8 +157,8 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
     def _pooling_function_fast(
         self,
-        inputs: List[keras.KerasTensor],
-    ) -> List[keras.KerasTensor]:
+        inputs: List[BackendTensor],
+    ) -> List[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         dtype = x.dtype
         empty_tensor = self.inputs_outputs_spec.get_empty_tensor(dtype=dtype)
@@ -186,8 +186,8 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
     def _pooling_function_not_fast(
         self,
-        inputs: List[keras.KerasTensor],
-    ) -> List[keras.KerasTensor]:
+        inputs: List[BackendTensor],
+    ) -> List[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(
             inputs, compute_ibp_from_affine=False
         )
@@ -230,7 +230,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             outputs, axis=-1, dc_decomp=self.dc_decomp, mode=self.mode, perturbation_domain=self.perturbation_domain
         )
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         if self.fast:
             return self._pooling_function_fast(inputs)
         else:

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -83,7 +83,9 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             self.input_spec += [InputSpec(ndim=4), InputSpec(ndim=4)]
 
         # express maxpooling with convolutions
-        self.filters = np.zeros((self.pool_size[0], self.pool_size[1], 1, np.prod(self.pool_size)), dtype=self.dtype)
+        self.filters = np.zeros(
+            (self.pool_size[0], self.pool_size[1], 1, int(np.prod(self.pool_size))), dtype=self.dtype
+        )
         for i in range(self.pool_size[0]):
             for j in range(self.pool_size[1]):
                 self.filters[i, j, 0, i * self.pool_size[0] + j] = 1

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -272,7 +272,7 @@ def max_(
     inputs_outputs_spec = InputsOutputsSpec(dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain)
     inputs_outputs_spec_no_dc = InputsOutputsSpec(dc_decomp=False, mode=mode, perturbation_domain=perturbation_domain)
 
-    input_shape = K.int_shape(inputs[-1])
+    input_shape = inputs[-1].shape
     max_dim = input_shape[axis]
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(
         inputs, tight=False, compute_ibp_from_affine=False
@@ -563,15 +563,15 @@ def permute_dimensions(
     index_w = np.insert(np.delete(index_w, axis), axis_perm + 1, axis)
 
     if ibp:
-        u_c_out = K.permute_dimensions(u_c, index)
-        l_c_out = K.permute_dimensions(l_c, index)
+        u_c_out = K.transpose(u_c, index)
+        l_c_out = K.transpose(l_c, index)
     else:
         u_c_out, l_c_out = empty_tensor, empty_tensor
     if affine:
-        w_u_out = K.permute_dimensions(w_u, index_w)
-        b_u_out = K.permute_dimensions(b_u, index)
-        w_l_out = K.permute_dimensions(w_l, index_w)
-        b_l_out = K.permute_dimensions(b_l, index)
+        w_u_out = K.transpose(w_u, index_w)
+        b_u_out = K.transpose(b_u, index)
+        w_l_out = K.transpose(w_l, index_w)
+        b_l_out = K.transpose(b_l, index)
     else:
         w_u_out, b_u_out, w_l_out, b_l_out = empty_tensor, empty_tensor, empty_tensor, empty_tensor
 
@@ -936,7 +936,7 @@ def frac_pos_hull(
 
     l_c = K.maximum(l_c, 1.0)
     z = (u_c + l_c) / 2.0
-    w_l = -1 / K.pow(z)
+    w_l = -1 / K.power(z)
     b_l = 2 / z
     w_u = (1.0 / u_c - 1.0 / l_c) / (u_c - l_c)
     b_u = 1.0 / u_c - w_u * u_c

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -89,7 +89,9 @@ class Project_initializer_pos(Initializer):
         super().__init__(**kwargs)
         self.initializer = initializer
 
-    def __call__(self, shape: Tuple[Optional[int]], dtype: Optional[str] = None, **kwargs: Any) -> keras.KerasTensor:
+    def __call__(
+        self, shape: Tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any
+    ) -> keras.KerasTensor:
         w = self.initializer.__call__(shape, dtype)
         return K.maximum(0.0, w)
 
@@ -101,7 +103,9 @@ class Project_initializer_neg(Initializer):
         super().__init__(**kwargs)
         self.initializer = initializer
 
-    def __call__(self, shape: Tuple[Optional[int]], dtype: Optional[str] = None, **kwargs: Any) -> keras.KerasTensor:
+    def __call__(
+        self, shape: Tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any
+    ) -> keras.KerasTensor:
         w = self.initializer.__call__(shape, dtype)
         return K.minimum(0.0, w)
 

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -553,7 +553,7 @@ def permute_dimensions(
     dtype = x.dtype
     empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
 
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
     if len(input_shape) <= 2:
         # not enough dim to permute
         return inputs
@@ -664,7 +664,7 @@ def split(
     ibp = get_ibp(mode)
     inputs_outputs_spec = InputsOutputsSpec(dc_decomp=dc_decomp, mode=mode, perturbation_domain=perturbation_domain)
 
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
     if axis == -1:
         n = input_shape[-1]
         axis = len(input_shape) - 1
@@ -743,7 +743,7 @@ def sort(
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(
         inputs, tight=False, compute_ibp_from_affine=False
     )
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
     dtype = x.dtype
     empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
 

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -1,12 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.config import epsilon
-from keras_core.constraints import Constraint
-from keras_core.initializers import Initializer
-from keras_core.layers import Layer
+from keras.config import epsilon
+from keras.constraints import Constraint
+from keras.initializers import Initializer
+from keras.layers import Layer
 
 from decomon.core import (
     BallDomain,

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -213,16 +213,16 @@ def frac_pos(
     dtype = x.dtype
     empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
 
-    u_c_out = 1.0 / l_c
-    l_c_out = 1.0 / u_c
+    u_c_out = K.cast(1.0, dtype=l_c.dtype) / l_c
+    l_c_out = K.cast(1.0, dtype=u_c.dtype) / u_c
 
     if affine:
         w_u_0 = (u_c_out - l_c_out) / K.maximum(u_c - l_c, epsilon())
         b_u_0 = l_c_out - w_u_0 * l_c
 
         y = (u_c + l_c) / 2.0
-        b_l_0 = 2.0 / y
-        w_l_0 = -1 / y**2
+        b_l_0 = K.cast(2.0, dtype=y.dtype) / y
+        w_l_0 = -K.cast(1.0, dtype=y.dtype) / y**2
 
         w_u_out = w_u_0[:, None] * w_l
         b_u_out = b_u_0 * b_l + b_u_0
@@ -936,10 +936,10 @@ def frac_pos_hull(
 
     l_c = K.maximum(l_c, 1.0)
     z = (u_c + l_c) / 2.0
-    w_l = -1 / K.power(z)
-    b_l = 2 / z
-    w_u = (1.0 / u_c - 1.0 / l_c) / (u_c - l_c)
-    b_u = 1.0 / u_c - w_u * u_c
+    w_l = -K.cast(1.0, dtype=z.dtype) / K.power(z)
+    b_l = K.cast(2.0, dtype=z.dtype) / z
+    w_u = (K.cast(1.0, dtype=u_c.dtype) / u_c - K.cast(1.0, dtype=l_c.dtype) / l_c) / (u_c - l_c)
+    b_u = K.cast(1.0, dtype=u_c.dtype) / u_c - w_u * u_c
 
     return [w_u, b_u, w_l, b_l]
 
@@ -1080,7 +1080,7 @@ def log(
         w_l_0 = (u_c_out - l_c_out) / K.maximum(u_c - l_c, epsilon())
         b_l_0 = l_c_out - w_l_0 * l_c
 
-        w_u_0 = 1 / y
+        w_u_0 = K.cast(1, dtype=y.dtype) / y
         b_u_0 = K.log(y) - 1
 
         w_u_out = w_u_0[:, None] * w_u
@@ -1144,7 +1144,7 @@ def exp(
         b_u_0 = l_c_out - w_u_0 * l_c
 
         w_l_0 = K.exp(y)
-        b_l_0 = w_l_0 * (1 - y)
+        b_l_0 = w_l_0 * (-y + 1)
 
         w_u_out = w_u_0[:, None] * w_u
         b_u_out = w_u_0 * b_u + b_u_0

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -675,6 +675,9 @@ def split(
         axis = len(input_shape) - 1
     else:
         n = input_shape[axis]
+    if n is None:
+        raise ValueError(f"Dimension {axis} corresponding to `axis` cannot be None")
+
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(
         inputs, tight=False, compute_ibp_from_affine=False
     )
@@ -757,6 +760,8 @@ def sort(
         axis = len(input_shape) - 1
     else:
         n = input_shape[axis]
+    if n is None:
+        raise ValueError(f"Dimension {axis} corresponding to `axis` cannot be None")
 
     empty_tensor_list = [empty_tensor] * n
 

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -115,13 +115,13 @@ def get_upper_linear_hull_max(
     if dtype != dtype32:
         w_hull = K.cast(w_hull, dtype=dtype)
 
-    shape_prev = np.prod(inputs[-1].shape[1:axis]).astype("int")
+    shape_prev = int(np.prod(inputs[-1].shape[1:axis]))
     if axis == -1:
         shape_after = 1
     else:
-        shape_after = np.prod(inputs[-1].shape[axis + 1 :]).astype("int")
+        shape_after = int(np.prod(inputs[-1].shape[axis + 1 :]))
     # (-1, shape_prev, axis, shape_after, n_dim+1)
-    flatten_dim = np.prod(w_hull.shape[1:-2])
+    flatten_dim = int(np.prod(w_hull.shape[1:-2]))
     w_hull_flat = K.reshape(w_hull, (-1, flatten_dim, n_dim + 1))
     w_u = K.reshape(w_hull_flat[:, :, :-1], (-1, shape_prev, shape_after, n_dim))  # (-1, shape_, n_dim)
     w_u = K.reshape(K.permute_dimensions(w_u, (0, 1, 3, 2)), [-1] + list(inputs[-1].shape[1:]))

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -62,7 +62,7 @@ def get_upper_linear_hull_max(
     n_dim = input_shape[axis]
 
     # expand dim/broadcast
-    mask = tf.linalg.diag(K.ones((n_dim), dtype=dtype))  # (n_dim, n_dim)
+    mask = K.identity(n_dim, dtype=dtype)  # (n_dim, n_dim)
     mask_shape = np.ones(len(u_c.shape) + 1)
     mask_shape[-1] = n_dim
     if axis != -1:

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional, Union
 
-import keras
 import keras.ops as K
 import numpy as np
 import tensorflow as tf
@@ -12,19 +11,20 @@ from decomon.core import (
     PerturbationDomain,
     get_affine,
 )
+from decomon.types import BackendTensor, Tensor
 
 # step 1: compute (x_i, y_i) such that x_i[j]=l_j if j==i else u_j
 # dataset of size n+1 on which we can compute an affine bound
 
 
 def get_upper_linear_hull_max(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Compute the linear hull that overapproximates max along the axis dimension
 
     Args:
@@ -135,14 +135,14 @@ def get_upper_linear_hull_max(
 
 
 def get_lower_linear_hull_max(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
-    finetune_lower: Optional[keras.KerasTensor] = None,
+    finetune_lower: Optional[BackendTensor] = None,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     """Compute the linear hull that overapproximates max along the axis dimension
 
     Args:

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
 

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -60,6 +60,8 @@ def get_upper_linear_hull_max(
 
     # get the shape of the dimension
     n_dim = input_shape[axis]
+    if n_dim is None:
+        raise ValueError(f"Dimension {axis} corresponding to `axis` cannot be None")
 
     # expand dim/broadcast
     mask = K.identity(n_dim, dtype=dtype)  # (n_dim, n_dim)

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -47,7 +47,7 @@ def get_upper_linear_hull_max(
 
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
     dtype = x.dtype
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
 
     # attention if axis=-1 or axis=n
     dtype32 = "float32"
@@ -164,7 +164,7 @@ def get_lower_linear_hull_max(
 
     x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
     dtype = x.dtype
-    input_shape = inputs_outputs_spec.get_input_shape(inputs)
+    input_shape = inputs_outputs_spec.get_kerasinputshape(inputs)
 
     o_value = K.cast(1.0, dtype)
     z_value = K.cast(0.0, dtype)

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -105,7 +105,7 @@ def get_upper_linear_hull_max(
     else:
         dim_permutation = np.concatenate([dimensions[:-2], dimensions[-1:], [dimensions[-2]]])
 
-    corners_collapse = K.permute_dimensions(corners_collapse, dim_permutation)
+    corners_collapse = K.transpose(corners_collapse, dim_permutation)
     # tf.linalg.solve works only for float32
     if dtype != dtype32:
         corners_collapse = K.cast(corners_collapse, dtype32)
@@ -124,7 +124,7 @@ def get_upper_linear_hull_max(
     flatten_dim = int(np.prod(w_hull.shape[1:-2]))
     w_hull_flat = K.reshape(w_hull, (-1, flatten_dim, n_dim + 1))
     w_u = K.reshape(w_hull_flat[:, :, :-1], (-1, shape_prev, shape_after, n_dim))  # (-1, shape_, n_dim)
-    w_u = K.reshape(K.permute_dimensions(w_u, (0, 1, 3, 2)), [-1] + list(inputs[-1].shape[1:]))
+    w_u = K.reshape(K.transpose(w_u, (0, 1, 3, 2)), [-1] + list(inputs[-1].shape[1:]))
     # reshape w_u
     shape_max = K.max(inputs[-1], axis).shape[1:]
     b_u = K.reshape(w_hull_flat[:, :, -1], [-1] + list(shape_max))  # (-1, shape_)

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -92,11 +92,11 @@ def get_upper_linear_hull_max(
 
     # include bias in corners
     if axis != -1:
-        bias_corner = o_value + tf.math.reduce_sum(z_value * corners, axis, keepdims=True)
+        bias_corner = o_value + K.sum(z_value * corners, axis, keepdims=True)
         corners_collapse = K.concatenate([corners_collapse, bias_corner], axis=axis)  # (None, shape_, n_dim+1, n_dim+1)
 
     else:
-        bias_corner = o_value + tf.math.reduce_sum(z_value * corners, -2, keepdims=True)
+        bias_corner = o_value + K.sum(z_value * corners, -2, keepdims=True)
         corners_collapse = K.concatenate([corners_collapse, bias_corner], axis=-2)
 
     dimensions = np.arange(len(corners.shape))

--- a/src/decomon/metrics/complexity.py
+++ b/src/decomon/metrics/complexity.py
@@ -11,7 +11,7 @@ def get_graph_complexity(model: keras.Model) -> int:
     for depth in depth_keys:
         nodes = model._nodes_by_depth[depth]
         for node in nodes:
-            if isinstance(node.outbound_layer, (InputLayer, Lambda)):
+            if isinstance(node.operation, (InputLayer, Lambda)):
                 continue
 
             nb_nodes += 1

--- a/src/decomon/metrics/complexity.py
+++ b/src/decomon/metrics/complexity.py
@@ -1,5 +1,5 @@
-import keras_core as keras
-from keras_core.layers import InputLayer, Lambda
+import keras
+from keras.layers import InputLayer, Lambda
 
 
 def get_graph_complexity(model: keras.Model) -> int:

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -46,7 +46,7 @@ def get_model(model: DecomonModel) -> DecomonModel:
             if len(x_0.shape) == 2:
                 x_0_reshaped = x_0[:, :, None]
             else:
-                x_0_reshaped = K.permute_dimensions(x_0, (0, 2, 1))
+                x_0_reshaped = K.transpose(x_0, (0, 2, 1))
             x_fake = K.sum(x_0_reshaped, 1)[:, None]
             x_0_reshaped = K.concatenate([x_0_reshaped, x_fake], 1)  # (None, n_in+1, n_comp)
 
@@ -66,7 +66,7 @@ def get_model(model: DecomonModel) -> DecomonModel:
             if len(x_0.shape) == 2:
                 x_0_reshaped = x_0[:, :, None]
             else:
-                x_0_reshaped = K.permute_dimensions(x_0, (0, 2, 1))
+                x_0_reshaped = K.transpose(x_0, (0, 2, 1))
             x_fake = K.sum(x_0_reshaped, 1)[:, None]
             x_0_reshaped = K.concatenate([x_0_reshaped, x_fake, x_fake], 1)  # (None, n_in+2, n_comp)
 
@@ -123,7 +123,7 @@ def get_upper_loss(model: DecomonModel) -> Callable[[keras.KerasTensor, keras.Ke
 
         elif mode == ForwardMode.AFFINE:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-1, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-1, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-1, 0]
 
@@ -132,7 +132,7 @@ def get_upper_loss(model: DecomonModel) -> Callable[[keras.KerasTensor, keras.Ke
 
         elif mode == ForwardMode.HYBRID:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-2, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-2, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-2, 0]
 
@@ -187,7 +187,7 @@ def get_lower_loss(model: DecomonModel) -> Callable[[keras.KerasTensor, keras.Ke
 
         elif mode == ForwardMode.AFFINE:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-1, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-1, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-1, 0]
 
@@ -196,7 +196,7 @@ def get_lower_loss(model: DecomonModel) -> Callable[[keras.KerasTensor, keras.Ke
 
         elif mode == ForwardMode.HYBRID:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-2, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-2, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-2, 0]
 
@@ -285,7 +285,7 @@ def get_adv_loss(
 
         elif mode == ForwardMode.AFFINE:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-1, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-1, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-1, 0]
 
@@ -301,7 +301,7 @@ def get_adv_loss(
 
         elif mode == ForwardMode.HYBRID:
             if len(y_pred.shape) == 3:
-                x_0 = K.permute_dimensions(y_pred[:, :-2, :n_comp], (0, 2, 1))
+                x_0 = K.transpose(y_pred[:, :-2, :n_comp], (0, 2, 1))
             else:
                 x_0 = y_pred[:, :-2, 0]
 

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -1,11 +1,11 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core.config import epsilon
-from keras_core.layers import Lambda, Layer
+from keras.config import epsilon
+from keras.layers import Lambda, Layer
 
 from decomon.core import (
     BallDomain,

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -435,10 +435,10 @@ class DecomonLossFusion(DecomonLayer):
         else:
             return self.call_no_backward(inputs, **kwargs)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> Tuple[Optional[int]]:
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> Tuple[Optional[int], ...]:
         return input_shape[-1]
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         return None
 
 
@@ -552,10 +552,10 @@ class DecomonRadiusRobust(DecomonLayer):
         else:
             return self.call_no_backward(inputs, **kwargs)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int]]]) -> Tuple[Optional[int]]:
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> Tuple[Optional[int], ...]:
         return input_shape[-1]
 
-    def build(self, input_shape: List[Tuple[Optional[int]]]) -> None:
+    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         return None
 
 

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -234,7 +234,7 @@ def get_adv_loss(
     n_out = np.prod(model.output[-1].shape[1:])
 
     def adv_ibp(u_c: Tensor, l_c: Tensor, y_tensor: Tensor) -> Tensor:
-        t_tensor = 1 - y_tensor
+        t_tensor: Tensor = 1 - y_tensor
         s_tensor = y_tensor
 
         t_tensor = t_tensor[:, :, None]
@@ -261,7 +261,7 @@ def get_adv_loss(
 
         upper = perturbation_domain.get_upper(x, w_adv, b_adv)
 
-        t_tensor = 1 - y_tensor
+        t_tensor: Tensor = 1 - y_tensor
         s_tensor = y_tensor
 
         t_tensor = t_tensor[:, :, None]

--- a/src/decomon/metrics/loss.py
+++ b/src/decomon/metrics/loss.py
@@ -443,7 +443,7 @@ class DecomonLossFusion(DecomonLayer):
         else:
             return self.call_no_backward(inputs, **kwargs)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> Tuple[Optional[int], ...]:
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> Tuple[Optional[int], ...]:  # type: ignore
         return input_shape[-1]
 
     def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
@@ -564,7 +564,7 @@ class DecomonRadiusRobust(DecomonLayer):
         else:
             return self.call_no_backward(inputs, **kwargs)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> Tuple[Optional[int], ...]:
+    def compute_output_shape(self, input_shape: Union[List[Tuple[Optional[int], ...]],]) -> Tuple[Optional[int], ...]:  # type: ignore
         return input_shape[-1]
 
     def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:

--- a/src/decomon/metrics/metric.py
+++ b/src/decomon/metrics/metric.py
@@ -410,7 +410,7 @@ def _get_affine_score(
     target_tensor: Optional[Tensor] = None,
 ) -> Tensor:
     if target_tensor is None:
-        target_tensor = 1.0 - source_tensor
+        target_tensor = 1 - source_tensor
 
     n_dim = w_u.shape[1]
     shape = int(np.prod(b_u.shape[1:]))
@@ -423,8 +423,10 @@ def _get_affine_score(
     b_u_f = b_l_reshaped - b_u_reshaped
 
     # add penalties on biases
-    b_u_f = b_u_f - 1e6 * (1 - target_tensor)[:, None, :]
-    b_u_f = b_u_f - 1e6 * (1 - source_tensor)[:, :, None]
+    oneminus_target_tensor: Tensor = 1 - target_tensor  # for mypy
+    oneminus_source_tensor: Tensor = 1 - source_tensor  # for mypy
+    b_u_f = b_u_f - 1e6 * oneminus_target_tensor[:, None, :]
+    b_u_f = b_u_f - 1e6 * oneminus_source_tensor[:, :, None]
 
     upper = perturbation_domain.get_upper(z_tensor, w_u_f, b_u_f)
     return K.max(upper, (-1, -2))

--- a/src/decomon/metrics/metric.py
+++ b/src/decomon/metrics/metric.py
@@ -387,7 +387,7 @@ def _get_ibp_score(
     if target_tensor is None:
         target_tensor = 1.0 - source_tensor
 
-    shape = np.prod(u_c.shape[1:])
+    shape = int(np.prod(u_c.shape[1:]))
     u_c_reshaped = K.reshape(u_c, (-1, shape))
     l_c_reshaped = K.reshape(l_c, (-1, shape))
 
@@ -414,7 +414,7 @@ def _get_affine_score(
         target_tensor = 1.0 - source_tensor
 
     n_dim = w_u.shape[1]
-    shape = np.prod(b_u.shape[1:])
+    shape = int(np.prod(b_u.shape[1:]))
     w_u_reshaped = K.reshape(w_u, (-1, n_dim, shape, 1))
     w_l_reshaped = K.reshape(w_l, (-1, n_dim, 1, shape))
     b_u_reshaped = K.reshape(b_u, (-1, shape, 1))

--- a/src/decomon/metrics/metric.py
+++ b/src/decomon/metrics/metric.py
@@ -2,11 +2,11 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.layers import Input, Layer
-from keras_core.models import Model
+from keras.layers import Input, Layer
+from keras.models import Model
 
 from decomon.core import BoxDomain, PerturbationDomain
 from decomon.models.models import DecomonModel

--- a/src/decomon/metrics/utils.py
+++ b/src/decomon/metrics/utils.py
@@ -1,20 +1,19 @@
 from typing import Any, Dict, List, Optional, Union
 
-import keras
-
 from decomon.core import BoxDomain, ForwardMode, PerturbationDomain
 from decomon.layers.utils import exp, expand_dims, log, sum
+from decomon.types import Tensor
 from decomon.utils import add, minus
 
 # compute categorical cross entropy
 
 
 def categorical_cross_entropy(
-    inputs: List[keras.KerasTensor],
+    inputs: List[Tensor],
     dc_decomp: bool = False,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[keras.KerasTensor]:
+) -> List[Tensor]:
     # step 1: exponential
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()

--- a/src/decomon/metrics/utils.py
+++ b/src/decomon/metrics/utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-import keras_core as keras
+import keras
 
 from decomon.core import BoxDomain, ForwardMode, PerturbationDomain
 from decomon.layers.utils import exp, expand_dims, log, sum

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -27,6 +27,7 @@ from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.crown import Convert2BackwardMode, Fuse, MergeWithPrevious
 from decomon.models.forward_cloning import OutputMapDict
 from decomon.models.utils import Convert2Mode, ensure_functional_model, get_depth_dict
+from decomon.types import BackendTensor, Tensor
 
 
 def get_disconnected_input(
@@ -41,7 +42,7 @@ def get_disconnected_input(
     if dtype is None:
         dtype = floatx()
 
-    def disco_priv(inputs: List[keras.KerasTensor]) -> List[keras.KerasTensor]:
+    def disco_priv(inputs: List[Tensor]) -> List[Tensor]:
         x, u_c, w_f_u, b_f_u, l_c, w_f_l, b_f_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         dtype = x.dtype
         empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -1,14 +1,14 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import tensorflow as tf
-from keras_core.config import floatx
-from keras_core.layers import Concatenate, Lambda, Layer
-from keras_core.models import Model
-from keras_core.src.ops.node import Node
-from keras_core.src.utils.python_utils import to_list
+from keras.config import floatx
+from keras.layers import Concatenate, Lambda, Layer
+from keras.models import Model
+from keras.src.ops.node import Node
+from keras.src.utils.python_utils import to_list
 
 from decomon.backward_layers.backward_merge import BackwardMerge
 from decomon.backward_layers.convert import to_backward

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -22,6 +22,7 @@ from decomon.core import (
     get_affine,
     get_mode,
 )
+from decomon.keras_utils import BatchedIdentityLike
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.crown import Convert2BackwardMode, Fuse, MergeWithPrevious
 from decomon.models.forward_cloning import OutputMapDict
@@ -47,8 +48,8 @@ def get_disconnected_input(
 
         if affine:
             x = K.concatenate([K.expand_dims(l_c, 1), K.expand_dims(u_c, 1)], 1)
-            w_u = tf.linalg.diag(K.cast(0.0, x.dtype) * u_c + K.cast(1.0, x.dtype))
-            b_u = K.cast(0.0, x.dtype) * u_c
+            w_u = BatchedIdentityLike()(u_c)
+            b_u = K.zeros_like(u_c)
         else:
             w_u, b_u = empty_tensor, empty_tensor
 

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -25,7 +25,7 @@ from decomon.core import (
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.crown import Convert2BackwardMode, Fuse, MergeWithPrevious
 from decomon.models.forward_cloning import OutputMapDict
-from decomon.models.utils import Convert2Mode, get_depth_dict
+from decomon.models.utils import Convert2Mode, ensure_functional_model, get_depth_dict
 
 
 def get_disconnected_input(
@@ -409,6 +409,7 @@ def convert_backward(
     final_affine: bool = False,
     **kwargs: Any,
 ) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], Dict[int, BackwardLayer], None]:
+    model = ensure_functional_model(model)
     if back_bounds is None:
         back_bounds = []
     if forward_map is None:

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -66,7 +66,7 @@ def retrieve_layer(
     if id(node) in backward_map:
         backward_layer = backward_map[id(node)]
     else:
-        backward_layer = layer_fn(node.outbound_layer)
+        backward_layer = layer_fn(node.operation)
         if joint:
             backward_map[id(node)] = backward_layer
     return backward_layer
@@ -113,12 +113,12 @@ def crown_(
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
 
-    if isinstance(node.outbound_layer, Model):
+    if isinstance(node.operation, Model):
         inputs_tensors = get_disconnected_input(get_mode(ibp, affine), perturbation_domain, dtype=inputs[0].dtype)(
             inputs
         )
         _, backward_bounds, _, _ = crown_model(
-            model=node.outbound_layer,
+            model=node.operation,
             input_tensors=inputs_tensors,
             backward_bounds=backward_bounds,
             ibp=ibp,
@@ -232,7 +232,7 @@ def get_input_nodes(
     for depth in keys:
         nodes = dico_nodes[depth]
         for node in nodes:
-            layer = node.outbound_layer
+            layer = node.operation
 
             parents = node.parent_nodes
             if not len(parents):
@@ -361,11 +361,11 @@ def crown_model(
     output = []
     output_nodes = dico_nodes[0]
     # the ordering may change
-    output_names = [tensor._keras_history.layer.name for tensor in to_list(model.output)]
+    output_names = [tensor._keras_history.operation.name for tensor in to_list(model.output)]
     fuse_layer = None
     for output_name in output_names:
         for node in output_nodes:
-            if node.outbound_layer.name == output_name:
+            if node.operation.name == output_name:
                 # compute with crown
                 output_crown, fuse_layer = crown_(
                     node=node,

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -49,7 +49,7 @@ def _clone_keras_model(model: Model, layer_fn: Callable[[Layer], List[Layer]]) -
                 output_map[id(node)] = node.output_tensors
                 layer_map[id(node)] = node.operation
 
-    _, output, _, _ = convert_forward_functional_model(
+    _, output, _, _, _ = convert_forward_functional_model(
         model=model,
         input_tensors=model.inputs,
         softmax_to_linear=False,

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -22,6 +22,7 @@ from decomon.models.utils import (
     Convert2Mode,
     ConvertMethod,
     FeedDirection,
+    check_model2convert_inputs,
     convert_deellip_to_keras,
     get_direction,
     get_ibp_affine_from_method,
@@ -203,6 +204,9 @@ def clone(
     if finetune:
         finetune_forward = True
         finetune_backward = True
+
+    # Check hypotheses: 1 flattened input
+    check_model2convert_inputs(model)
 
     z_tensor, input_tensors = get_input_tensors(
         model=model,

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-from keras_core.layers import InputLayer, Layer
-from keras_core.models import Model
+import keras
+from keras.layers import InputLayer, Layer
+from keras.models import Model
 
 from decomon.backward_layers.core import BackwardLayer
 from decomon.core import BoxDomain, PerturbationDomain, Slope, get_mode

--- a/src/decomon/models/crown.py
+++ b/src/decomon/models/crown.py
@@ -1,11 +1,11 @@
 # extra layers necessary for backward LiRPA
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import tensorflow as tf
-from keras_core.layers import InputSpec, Layer
-from keras_core.src.layers.merging.dot import batch_dot
+from keras.layers import InputSpec, Layer
+from keras.src.layers.merging.dot import batch_dot
 
 from decomon.core import ForwardMode, PerturbationDomain
 

--- a/src/decomon/models/crown.py
+++ b/src/decomon/models/crown.py
@@ -8,6 +8,7 @@ from keras.layers import InputSpec, Layer
 from keras.src.layers.merging.dot import batch_dot
 
 from decomon.core import ForwardMode, PerturbationDomain
+from decomon.keras_utils import BatchedDiagLike
 
 
 class Fuse(Layer):
@@ -121,16 +122,16 @@ def merge_with_previous(inputs: List[keras.KerasTensor]) -> List[keras.KerasTens
     # result (None, n_h_in, n_out)
 
     if len(w_u_out.shape) == 2:
-        w_u_out = tf.linalg.diag(w_u_out)
+        w_u_out = BatchedDiagLike()(w_u_out)
 
     if len(w_l_out.shape) == 2:
-        w_l_out = tf.linalg.diag(w_l_out)
+        w_l_out = BatchedDiagLike()(w_l_out)
 
     if len(w_b_u.shape) == 2:
-        w_b_u = tf.linalg.diag(w_b_u)
+        w_b_u = BatchedDiagLike()(w_b_u)
 
     if len(w_b_l.shape) == 2:
-        w_b_l = tf.linalg.diag(w_b_l)
+        w_b_l = BatchedDiagLike()(w_b_l)
 
     # import pdb; pdb.set_trace()
 

--- a/src/decomon/models/crown.py
+++ b/src/decomon/models/crown.py
@@ -5,6 +5,7 @@ import keras_core as keras
 import keras_core.ops as K
 import tensorflow as tf
 from keras_core.layers import InputSpec, Layer
+from keras_core.src.layers.merging.dot import batch_dot
 
 from decomon.core import ForwardMode, PerturbationDomain
 
@@ -139,9 +140,9 @@ def merge_with_previous(inputs: List[keras.KerasTensor]) -> List[keras.KerasTens
     w_b_l_pos = K.maximum(w_b_l, z_value)
     w_b_l_neg = K.minimum(w_b_l, z_value)
 
-    w_u = K.batch_dot(w_u_out, w_b_u_pos, (-1, -2)) + K.batch_dot(w_l_out, w_b_u_neg, (-1, -2))
-    w_l = K.batch_dot(w_l_out, w_b_l_pos, (-1, -2)) + K.batch_dot(w_u_out, w_b_l_neg, (-1, -2))
-    b_u = K.batch_dot(b_u_out, w_b_u_pos, (-1, -2)) + K.batch_dot(b_l_out, w_b_u_neg, (-1, -2)) + b_b_u
-    b_l = K.batch_dot(b_l_out, w_b_l_pos, (-1, -2)) + K.batch_dot(b_u_out, w_b_l_neg, (-1, -2)) + b_b_l
+    w_u = batch_dot(w_u_out, w_b_u_pos, (-1, -2)) + batch_dot(w_l_out, w_b_u_neg, (-1, -2))
+    w_l = batch_dot(w_l_out, w_b_l_pos, (-1, -2)) + batch_dot(w_u_out, w_b_l_neg, (-1, -2))
+    b_u = batch_dot(b_u_out, w_b_u_pos, (-1, -2)) + batch_dot(b_l_out, w_b_u_neg, (-1, -2)) + b_b_u
+    b_l = batch_dot(b_l_out, w_b_l_pos, (-1, -2)) + batch_dot(b_u_out, w_b_l_neg, (-1, -2)) + b_b_l
 
     return [w_u, b_u, w_l, b_l]

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -17,6 +17,7 @@ from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.utils import (
+    ensure_functional_model,
     get_depth_dict,
     get_inner_layers,
     get_input_dim,
@@ -110,6 +111,8 @@ def convert_forward(
     if not isinstance(model, Model):
         raise ValueError("Expected `model` argument " "to be a `Model` instance, got ", model)
 
+    model = ensure_functional_model(model)
+
     if input_dim == -1:
         input_dim = get_input_dim(model)
 
@@ -148,7 +151,8 @@ def convert_forward_functional_model(
     if softmax_to_linear:
         model, has_softmax = softmax_2_linear(model)
 
-    # create input tensors
+    # ensure the model is functional (to be able to use get_depth_dict), convert sequential ones into functional ones
+    model = ensure_functional_model(model)
 
     # sort nodes from input to output
     dico_nodes = get_depth_dict(model)

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -167,7 +167,7 @@ def convert_forward_functional_model(
     for depth in keys:
         nodes = dico_nodes[depth]
         for node in nodes:
-            layer = node.outbound_layer
+            layer = node.operation
             parents = node.parent_nodes
             if id(node) in output_map.keys() and joint:
                 continue
@@ -201,10 +201,10 @@ def convert_forward_functional_model(
     output = []
     output_nodes = dico_nodes[0]
     # the ordering may change
-    output_names = [tensor._keras_history.layer.name for tensor in to_list(model.output)]
+    output_names = [tensor._keras_history.operation.name for tensor in to_list(model.output)]
     for output_name in output_names:
         for node in output_nodes:
-            if node.outbound_layer.name == output_name:
+            if node.operation.name == output_name:
                 output += output_map[id(node)]
 
     return input_tensors, output, layer_map, output_map

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -102,7 +102,6 @@ def convert_forward(
     finetune: bool = False,
     shared: bool = True,
     softmax_to_linear: bool = True,
-    joint: bool = True,
     **kwargs: Any,
 ) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], LayerMapDict, OutputMapDict]:
     if perturbation_domain is None:
@@ -132,7 +131,6 @@ def convert_forward(
         input_tensors=input_tensors,
         layer_fn=layer_fn_to_list,
         softmax_to_linear=softmax_to_linear,
-        joint=joint,
     )
 
     return f_output
@@ -144,7 +142,6 @@ def convert_forward_functional_model(
     input_tensors: List[keras.KerasTensor],
     softmax_to_linear: bool = True,
     count: int = 0,
-    joint: bool = True,
     output_map: Optional[OutputMapDict] = None,
     layer_map: Optional[LayerMapDict] = None,
 ) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], LayerMapDict, OutputMapDict]:
@@ -169,7 +166,7 @@ def convert_forward_functional_model(
         for node in nodes:
             layer = node.operation
             parents = node.parent_nodes
-            if id(node) in output_map.keys() and joint:
+            if id(node) in output_map.keys():
                 continue
             if len(parents):
                 output = []

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -207,7 +207,7 @@ def convert_forward_functional_model(
                     converted_layers = layer_fn(layer)
                     layer2layer_map[id(layer)] = converted_layers
                 for converted_layer in converted_layers:
-                    converted_layer._name = f"{converted_layer.name}_{count}"
+                    converted_layer.name = f"{converted_layer.name}_{count}"
                     count += 1
                     output = converted_layer(prepare_inputs_for_layer(output))
                     if len(converted_layers) > 1:

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import keras
-from keras.layers import Layer
+from keras.layers import InputLayer, Layer
 from keras.models import Model
 from keras.src.utils.python_utils import to_list
 
@@ -176,7 +176,10 @@ def convert_forward_functional_model(
                 for parent in parents:
                     output += output_map[id(parent)]
 
-            if isinstance(layer, Model):
+            if isinstance(layer, InputLayer):
+                # no conversion, no transformation for output (instead of trying to pass in identity layer)
+                layer_map[id(node)] = layer
+            elif isinstance(layer, Model):
                 _, output, layer_map_submodel, output_map_submodel = convert_forward_functional_model(
                     model=layer,
                     input_tensors=output,

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -185,8 +185,9 @@ def convert_forward_functional_model(
                     count=count,
                 )
                 count = count + get_inner_layers(layer)
+                layer_map.update(layer_map_submodel)
+                output_map.update(output_map_submodel)
                 layer_map[id(node)] = layer_map_submodel
-                output_map[id(node)] = output_map_submodel
             else:
                 converted_layers = layer_fn(layer)
                 for converted_layer in converted_layers:

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -7,10 +7,10 @@ import inspect
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-from keras_core.layers import Layer
-from keras_core.models import Model
-from keras_core.src.utils.python_utils import to_list
+import keras
+from keras.layers import Layer
+from keras.models import Model
+from keras.src.utils.python_utils import to_list
 
 from decomon.core import BoxDomain, PerturbationDomain, Slope
 from decomon.layers.convert import to_decomon

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-import keras_core as keras
+import keras
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Any, Dict, List, Optional, Union
 
 import keras_core as keras
@@ -11,15 +10,6 @@ from decomon.core import (
     PerturbationDomain,
 )
 from decomon.models.utils import ConvertMethod
-
-try:
-    from keras_core.src.engine.functional import (
-        get_network_config,  # new path starting from keras 2.13
-    )
-except ImportError:
-    from keras_core.engine.functional import (
-        get_network_config,  # old path until keras 2.12
-    )
 
 
 class DecomonModel(keras.Model):
@@ -80,11 +70,6 @@ class DecomonModel(keras.Model):
         for layer in self.layers:
             if hasattr(layer, "reset_finetuning"):
                 layer.reset_finetuning()
-
-    def get_config(self) -> Dict[str, Any]:
-        # Continue adding configs into what the super class has added.
-        config = super().get_config()
-        return copy.deepcopy(get_network_config(self, config=config))
 
 
 def _check_domain(

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 import keras
+import numpy as np
 
 from decomon.core import (
     BoxDomain,
@@ -70,6 +71,29 @@ class DecomonModel(keras.Model):
         for layer in self.layers:
             if hasattr(layer, "reset_finetuning"):
                 layer.reset_finetuning()
+
+    def predict_on_single_batch_np(
+        self, inputs: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        """Make predictions on numpy arrays fitting in one batch
+
+        Avoid using `self.predict()` known to be not designed for small arrays,
+        and leading to memory leaks when used in loops.
+
+        See https://keras.io/api/models/model_training_apis/#predict-method and
+        https://github.com/tensorflow/tensorflow/issues/44711
+
+        Args:
+            inputs:
+
+        Returns:
+
+        """
+        output_tensors = self(inputs)
+        if isinstance(output_tensors, list):
+            return [output.numpy() for output in output_tensors]
+        else:
+            return output_tensors.numpy()
 
 
 def _check_domain(

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -179,16 +179,6 @@ def get_input_tensors(
     return z_tensor, input_tensors
 
 
-def get_input_tensors_keras_only(
-    model: Model,
-    input_shape: Tuple[int, ...],
-) -> List[keras.KerasTensor]:
-    input_tensors = []
-    for i in range(len(model._input_layers)):
-        input_tensors.append(Input(input_shape[1:], dtype=model.layers[0].dtype))
-    return input_tensors
-
-
 def get_input_dim(layer: Layer) -> int:
     if isinstance(layer.input_shape, list):
         return np.prod(layer.input_shape[0][1:])

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -243,7 +243,7 @@ def split_activation(
                 activation_layer = layer.activation
                 # update the name to starts with main layer name
                 activation_layer_name = f"{layer.name}_activation_{layer.activation.name}"
-                activation_layer._name = activation_layer_name
+                activation_layer.name = activation_layer_name
             else:
                 raise RuntimeError("Cannot construct activation layer from layer.activation!")
         else:

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -29,6 +29,7 @@ from decomon.core import (
 )
 from decomon.keras_utils import BatchedIdentityLike, reset_layer_all_weights
 from decomon.layers.utils import is_a_merge_layer
+from decomon.types import BackendTensor
 
 try:
     from deel.lip.layers import LipschitzLayer
@@ -341,7 +342,7 @@ class Convert2Mode(Layer):
         self.mode_to = ForwardMode(mode_to)
         self.perturbation_domain = perturbation_domain
 
-    def call(self, inputs: List[keras.KerasTensor], **kwargs: Any) -> List[keras.KerasTensor]:
+    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         mode_from = self.mode_from
         mode_to = self.mode_to
         perturbation_domain = self.perturbation_domain

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -231,7 +231,7 @@ def split_activation(
         share_some_attributes(layer_wo_activation, layer)  # share (deel-lip) attributes
         # build the layer
         inputs = Input(
-            shape=layer.input.shape,
+            shape=layer.input.shape[1:],  # shape without batch_size
             dtype=layer.input.dtype,
         )
         outputs = layer_wo_activation(inputs)
@@ -263,7 +263,7 @@ def convert_deellip_to_keras(layer: Layer) -> Layer:
         new_layer = layer.vanilla_export()
         # build layer
         inputs = Input(
-            shape=layer.input.shape,
+            shape=layer.input.shape[1:],  # shape without batch_size
             dtype=layer.input.dtype,
         )
         new_layer(inputs)

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -305,6 +305,10 @@ def preprocess_layer(layer: Layer) -> List[Layer]:
     return [convert_deellip_to_keras(l) for l in layers]
 
 
+def is_input_node(node: Node) -> bool:
+    return len(node.input_tensors) == 0
+
+
 def get_depth_dict(model: Model) -> Dict[int, List[Node]]:
     depth_keys = list(model._nodes_by_depth.keys())
     depth_keys.sort(reverse=True)

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -179,9 +179,9 @@ def get_input_tensors(
 
 def get_input_dim(layer: Layer) -> int:
     if isinstance(layer.input_shape, list):
-        return np.prod(layer.input_shape[0][1:])
+        return int(np.prod(layer.input_shape[0][1:]))
     else:
-        return np.prod(layer.input_shape[1:])
+        return int(np.prod(layer.input_shape[1:]))
 
 
 def prepare_inputs_for_layer(

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -1,12 +1,12 @@
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import tensorflow as tf
-from keras_core import Model, Sequential
-from keras_core.layers import (
+from keras import Model, Sequential
+from keras.layers import (
     Activation,
     Concatenate,
     Flatten,
@@ -16,8 +16,8 @@ from keras_core.layers import (
     Maximum,
     Minimum,
 )
-from keras_core.src import Functional
-from keras_core.src.ops.node import Node
+from keras.src import Functional
+from keras.src.ops.node import Node
 
 from decomon.core import (
     BallDomain,

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -30,13 +30,6 @@ from decomon.core import (
 from decomon.layers.utils import is_a_merge_layer
 
 try:
-    from keras.src.backend import (
-        observe_object_name,  # new path starting from keras 2.13
-    )
-except ImportError:
-    from keras_core.backend import observe_object_name  # old path until keras 2.12
-
-try:
     from deel.lip.layers import LipschitzLayer
 except ImportError:
     LipschitzLayer = type(None)
@@ -260,7 +253,6 @@ def split_activation(
                 activation_layer = layer.activation
                 # update the name to starts with main layer name
                 activation_layer_name = f"{layer.name}_activation_{layer.activation.name}"
-                observe_object_name(activation_layer_name)
                 activation_layer._name = activation_layer_name
             else:
                 raise RuntimeError("Cannot construct activation layer from layer.activation!")

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -229,8 +229,6 @@ def split_activation(
         layer_wo_activation = layer.__class__.from_config(config)
         share_some_attributes(layer_wo_activation, layer)  # share (deel-lip) attributes
         # build the layer
-        if not hasattr(layer, "input_shape"):
-            raise RuntimeError("The layer should properly initialized so that layer.input_shape is defined.")
         inputs = Input(
             shape=layer.input.shape,
             dtype=layer.input.dtype,
@@ -270,8 +268,6 @@ def convert_deellip_to_keras(layer: Layer) -> Layer:
     if isinstance(layer, LipschitzLayer) or hasattr(layer, "vanilla_export"):
         layer.is_lipschitz = True
     if hasattr(layer, "vanilla_export"):
-        if not hasattr(layer, "input_shape"):
-            raise RuntimeError("The layer should properly initialized so that layer.input_shape is defined.")
         new_layer = layer.vanilla_export()
         # build layer
         inputs = Input(

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -27,6 +27,7 @@ from decomon.core import (
     PerturbationDomain,
     get_mode,
 )
+from decomon.keras_utils import reset_layer_all_weights
 from decomon.layers.utils import is_a_merge_layer
 
 try:
@@ -235,16 +236,7 @@ def split_activation(
         )
         outputs = layer_wo_activation(inputs)
         # use same weights
-        actual_activation = layer.activation  # store activation
-        layer.activation = None  # remove activation in case of a layer having weights (would be in layer.get_weights())
-        layer_wo_activation.set_weights(layer.get_weights())
-        layer.activation = actual_activation  # put back the actual activation
-        # even share the object themselves if possible
-        # (dense and conv2d have kernel and bias weight attributes)
-        if hasattr(layer_wo_activation, "kernel"):
-            layer_wo_activation.kernel = layer.kernel
-        if hasattr(layer_wo_activation, "bias"):
-            layer_wo_activation.bias = layer.bias
+        reset_layer_all_weights(new_layer=layer_wo_activation, original_layer=layer)
         # activation layer
         if isinstance(activation, dict):
             if isinstance(layer.activation, Layer):  # can be an Activation, a PReLU, or a deel.lip.activations layer

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -5,6 +5,7 @@ import keras_core as keras
 import keras_core.ops as K
 import numpy as np
 import tensorflow as tf
+from keras_core import Model, Sequential
 from keras_core.layers import (
     Activation,
     Concatenate,
@@ -15,7 +16,7 @@ from keras_core.layers import (
     Maximum,
     Minimum,
 )
-from keras_core.models import Model
+from keras_core.src import Functional
 from keras_core.src.ops.node import Node
 
 from decomon.core import (
@@ -411,3 +412,14 @@ class Convert2Mode(Layer):
             {"mode_from": self.mode_from, "mode_to": self.mode_to, "perturbation_domain": self.perturbation_domain}
         )
         return config
+
+
+def ensure_functional_model(model: Model) -> Functional:
+    if isinstance(model, Functional):
+        return model
+    elif isinstance(model, Sequential):
+        model = Model(model.inputs, model.outputs)
+        assert isinstance(model, Functional)  # should be the case after passage in Model.__init__()
+        return model
+    else:
+        raise NotImplementedError("Decomon model available only for functional or sequential models.")

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -179,10 +179,12 @@ def get_input_tensors(
 
 
 def get_input_dim(layer: Layer) -> int:
-    if isinstance(layer.input_shape, list):
-        return int(np.prod(layer.input_shape[0][1:]))
+    if isinstance(layer.input, list):
+        if len(layer.input) == 0:
+            return 0
+        return int(np.prod(layer.input[0].shape[1:]))
     else:
-        return int(np.prod(layer.input_shape[1:]))
+        return int(np.prod(layer.input.shape[1:]))
 
 
 def prepare_inputs_for_layer(

--- a/src/decomon/types/__init__.py
+++ b/src/decomon/types/__init__.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import keras_core as keras
+import keras
 
 # create extra types for readability
 DecomonInputs = List[keras.KerasTensor]

--- a/src/decomon/types/__init__.py
+++ b/src/decomon/types/__init__.py
@@ -6,4 +6,18 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import keras
 
 # create extra types for readability
-DecomonInputs = List[keras.KerasTensor]
+
+
+BackendTensor = Any
+"""Type for backend tensors.
+
+If the backend is tensorflow, this should be `tf.Tensor`.
+For now, there is now exposed way to check wether a tensor is a backend tensor or not (this is a private function in keras)
+
+"""
+
+Tensor = Union[keras.KerasTensor, BackendTensor]
+"""Type for any tensor, from keras or backend."""
+
+
+DecomonInputs = List[Tensor]

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -119,9 +119,9 @@ def subset_sum_lower(W: keras.KerasTensor, b: keras.KerasTensor, repeat: int = 1
     B = K.sort(W, axis=1)
     C = K.repeat(B, repeats=repeat, axis=1)
     C_reduced = K.cumsum(C, axis=1)
-    D = K.minimum(K.sign(K.expand_dims(-b, 1) - C_reduced) + 1, 1)
+    D = K.minimum(K.sign(K.expand_dims(-b, 1) - C_reduced) + 1, K.cast(1.0, dtype=b.dtype))
 
-    score = K.minimum(K.sum(D * C, 1) + b, 0.0)
+    score = K.minimum(K.sum(D * C, 1) + b, K.cast(0.0, dtype=b.dtype))
     return score
 
 

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable, List, Optional, Tuple, Union
 
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
-from keras_core.config import epsilon
+from keras.config import epsilon
 
 from decomon.core import (
     BoxDomain,

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -58,7 +58,7 @@ def tanh_prime(x: keras.KerasTensor) -> keras.KerasTensor:
     """
 
     s_x = K.tanh(x)
-    return K.cast(1, dtype=x.dtype) - K.pow(s_x, K.cast(2, dtype=x.dtype))
+    return K.cast(1, dtype=x.dtype) - K.power(s_x, K.cast(2, dtype=x.dtype))
 
 
 def softsign_prime(x: keras.KerasTensor) -> keras.KerasTensor:
@@ -71,7 +71,7 @@ def softsign_prime(x: keras.KerasTensor) -> keras.KerasTensor:
 
     """
 
-    return K.cast(1.0, dtype=x.dtype) / K.pow(K.cast(1.0, dtype=x.dtype) + K.abs(x), K.cast(2, dtype=x.dtype))
+    return K.cast(1.0, dtype=x.dtype) / K.power(K.cast(1.0, dtype=x.dtype) + K.abs(x), K.cast(2, dtype=x.dtype))
 
 
 ##### corners ######
@@ -117,7 +117,7 @@ def convert_lower_search_2_subset_sum(
 
 def subset_sum_lower(W: keras.KerasTensor, b: keras.KerasTensor, repeat: int = 1) -> keras.KerasTensor:
     B = K.sort(W, axis=1)
-    C = K.repeat_elements(B, rep=repeat, axis=1)
+    C = K.repeat(B, repeats=repeat, axis=1)
     C_reduced = K.cumsum(C, axis=1)
     D = K.minimum(K.sign(K.expand_dims(-b, 1) - C_reduced) + 1, 1)
 
@@ -577,7 +577,7 @@ def get_linear_hull_s_shape(
 
     # case 0:
     coeff = (s_u - s_l) / K.maximum(K.cast(epsilon(), dtype=dtype), u_c_flat - l_c_flat)
-    alpha_u_0 = K.switch(
+    alpha_u_0 = K.where(
         K.greater_equal(s_u_prime, coeff), o_value + z_value * u_c_flat, z_value * u_c_flat
     )  # (None, n)
     alpha_u_1 = (o_value - alpha_u_0) * ((K.sign(l_c_flat) + o_value) / t_value)
@@ -595,7 +595,7 @@ def get_linear_hull_s_shape(
 
     # linear hull
     # case 0:
-    alpha_l_0 = K.switch(
+    alpha_l_0 = K.where(
         K.greater_equal(s_l_prime, coeff), o_value + z_value * l_c_flat, z_value * l_c_flat
     )  # (None, n)
     alpha_l_1 = (o_value - alpha_l_0) * ((K.sign(-u_c_flat) + o_value) / t_value)
@@ -651,10 +651,10 @@ def get_t_upper(
     threshold = K.min(score, -1)  # (None, n)
 
     index_t = K.cast(
-        K.switch(K.greater(threshold, z_value * threshold), index, K.clip(index - 1, 0, 100)), dtype=u_c_flat.dtype
+        K.where(K.greater(threshold, z_value * threshold), index, K.clip(index - 1, 0, 100)), dtype=u_c_flat.dtype
     )  # (None, n)
     t_value = K.sum(
-        K.switch(
+        K.where(
             K.equal(
                 o_value * K.cast(np.arange(0, 100)[None, None, :], dtype=u_c_flat.dtype) + z_value * u_c_reshaped,
                 K.expand_dims(index_t, -1) + z_value * u_c_reshaped,
@@ -708,10 +708,10 @@ def get_t_lower(
 
     threshold = K.min(score, -1)
     index_t = K.cast(
-        K.switch(K.greater(threshold, z_value * threshold), index, K.clip(index + 1, 0, 100)), dtype=u_c_flat.dtype
+        K.where(K.greater(threshold, z_value * threshold), index, K.clip(index + 1, 0, 100)), dtype=u_c_flat.dtype
     )  # (None, n)
     t_value = K.sum(
-        K.switch(
+        K.where(
             K.equal(
                 o_value * K.cast(np.arange(0, 100)[None, None, :], dtype=u_c_flat.dtype) + z_value * u_c_reshaped,
                 K.expand_dims(index_t, -1) + z_value * u_c_reshaped,

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -106,8 +106,8 @@ def convert_lower_search_2_subset_sum(
     x_max = x[:, 1]
 
     if len(W.shape) > 3:
-        W = K.reshape(W, (-1, W.shape[1], np.prod(W.shape[2:])))
-        b = K.reshape(b, (-1, np.prod(b.shape[1:])))
+        W = K.reshape(W, (-1, W.shape[1], int(np.prod(W.shape[2:]))))
+        b = K.reshape(b, (-1, int(np.prod(b.shape[1:]))))
 
     const = BoxDomain().get_lower(x, W, b)
 
@@ -565,8 +565,8 @@ def get_linear_hull_s_shape(
 
     # flatten
     shape = list(u_c.shape[1:])
-    u_c_flat = K.reshape(u_c, (-1, np.prod(shape)))  # (None, n)
-    l_c_flat = K.reshape(l_c, (-1, np.prod(shape)))  # (None, n)
+    u_c_flat = K.reshape(u_c, (-1, int(np.prod(shape))))  # (None, n)
+    l_c_flat = K.reshape(l_c, (-1, int(np.prod(shape))))  # (None, n)
 
     # upper bound
     # derivative

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -1,6 +1,6 @@
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
-import keras_core as keras
+import keras
 import numpy as np
 import numpy.typing as npt
 

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -149,9 +149,9 @@ def get_adv_box(
         output: npt.NDArray[np.float_]
         if decomon_model.backward_bounds:
             C = np.diag([1] * n_label)[None] - source_labels[:, :, None]
-            output = decomon_model.predict([z, C], verbose=0)
+            output = decomon_model.predict_on_single_batch_np([z, C])
         else:
-            output = decomon_model.predict(z, verbose=0)
+            output = decomon_model.predict_on_single_batch_np(z)
 
         def get_ibp_score(
             u_c: npt.NDArray[np.float_],
@@ -361,7 +361,7 @@ def check_adv_box(
         )
 
     else:
-        output = decomon_model.predict(z, verbose=0)
+        output = decomon_model.predict_on_single_batch_np(z)
 
         if not affine:
             # translate  into affine information
@@ -532,7 +532,7 @@ def get_range_box(
         ibp = decomon_model.ibp
         affine = decomon_model.affine
 
-        output = decomon_model.predict(z, verbose=0)
+        output = decomon_model.predict_on_single_batch_np(z)
         shape = list(output[-1].shape[1:])
         output_dim = np.prod(shape)
 
@@ -701,7 +701,7 @@ def get_range_noise(
     ibp = decomon_model.ibp
     affine = decomon_model.affine
 
-    output = decomon_model.predict(x_reshaped, verbose=0)
+    output = decomon_model.predict_on_single_batch_np(x_reshaped)
     shape = list(output[-1].shape[1:])
     output_dim = np.prod(shape)
 
@@ -1006,7 +1006,7 @@ def get_adv_noise(
     else:
         ibp = decomon_model.ibp
         affine = decomon_model.affine
-        output = decomon_model.predict(x_reshaped, verbose=0)
+        output = decomon_model.predict_on_single_batch_np(x_reshaped)
 
         def get_ibp_score(
             u_c: npt.NDArray[np.float_],

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -146,12 +146,12 @@ def get_adv_box(
         n_label = source_labels.shape[-1]
 
         # two possitible cases: the model improves the bound based on the knowledge of the labels
-        output: npt.NDArray[np.float_]
+        output: List[npt.NDArray[np.float_]]
         if decomon_model.backward_bounds:
             C = np.diag([1] * n_label)[None] - source_labels[:, :, None]
-            output = decomon_model.predict_on_single_batch_np([z, C])
+            output = decomon_model.predict_on_single_batch_np([z, C])  # type: ignore
         else:
-            output = decomon_model.predict_on_single_batch_np(z)
+            output = decomon_model.predict_on_single_batch_np(z)  # type: ignore
 
         def get_ibp_score(
             u_c: npt.NDArray[np.float_],

--- a/src/decomon/wrapper_with_tuning.py
+++ b/src/decomon/wrapper_with_tuning.py
@@ -1,9 +1,9 @@
 from typing import Union
 
-import keras_core as keras
+import keras
 import numpy as np
 import numpy.typing as npt
-from keras_core.optimizers import Adam
+from keras.optimizers import Adam
 
 from decomon.metrics.loss import get_upper_loss
 from decomon.models.models import DecomonModel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,12 @@ class ModelNumpyFromKerasTensors:
 
 class Helpers:
     @staticmethod
+    def tensorflow_in_GPU_mode() -> bool:
+        import tensorflow
+
+        return len(tensorflow.config.list_physical_devices("GPU")) > 0
+
+    @staticmethod
     def is_method_mode_compatible(method, mode):
         return not (
             ConvertMethod(method) in {ConvertMethod.CROWN_FORWARD_IBP, ConvertMethod.FORWARD_IBP}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,31 @@ class Helpers:
     function = ModelNumpyFromKerasTensors
 
     @staticmethod
+    def predict_on_small_numpy(
+        model: Model, x: Union[np.ndarray, List[np.ndarray]]
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        """Make predictions for model directly on small numpy arrays
+
+        Avoid using `model.predict()` known to be not designed for small arrays,
+        and leading to memory leaks when used in loops.
+
+        See https://keras.io/api/models/model_training_apis/#predict-method and
+        https://github.com/tensorflow/tensorflow/issues/44711
+
+        Args:
+            model:
+            x:
+
+        Returns:
+
+        """
+        output_tensors = model(x)
+        if isinstance(output_tensors, list):
+            return [output.numpy() for output in output_tensors]
+        else:
+            return output_tensors.numpy()
+
+    @staticmethod
     def get_standard_values_1d_box(n, dc_decomp=True, grad_bounds=False, nb=100):
         """A set of functions with their monotonic decomposition for testing the activations"""
         w_u_ = np.ones(nb, dtype=keras_config.floatx())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1472,7 +1472,7 @@ class Helpers:
 
     @staticmethod
     def toy_struct_cnn(dtype="float32", image_data_shape=(6, 6, 2)):
-        input_dim = np.prod(image_data_shape)
+        input_dim = int(np.prod(image_data_shape))
         layers = [
             Input((input_dim,)),
             Reshape(target_shape=image_data_shape),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_almost_equal
 
 from decomon.core import ForwardMode, Slope
 from decomon.models.utils import ConvertMethod
+from decomon.types import Tensor
 
 
 @pytest.fixture(params=[m.value for m in ForwardMode])
@@ -327,10 +328,10 @@ class Helpers:
 
     @staticmethod
     def get_inputs_for_mode_from_full_inputs(
-        inputs: Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]],
+        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-    ) -> Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]:
+    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
         """Extract from full inputs the ones corresponding to the selected mode.
 
         Args:
@@ -380,8 +381,8 @@ class Helpers:
 
     @staticmethod
     def get_input_ref_bounds_from_full_inputs(
-        inputs: Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]],
-    ) -> Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]:
+        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]],
+    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
         """Extract lower and upper bound for input ref from full inputs
 
         Args:
@@ -425,10 +426,10 @@ class Helpers:
 
     @staticmethod
     def get_input_tensors_for_decomon_convert_from_full_inputs(
-        inputs: List[keras.KerasTensor],
+        inputs: List[Tensor],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-    ) -> List[keras.KerasTensor]:
+    ) -> List[Tensor]:
         """Extract from full tensor inputs the ones for a conversion to decomon model.
 
         Args:
@@ -465,8 +466,8 @@ class Helpers:
 
     @staticmethod
     def get_input_ref_from_full_inputs(
-        inputs: Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]
-    ) -> Union[keras.KerasTensor, npt.NDArray[np.float_]]:
+        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]]
+    ) -> Union[Tensor, npt.NDArray[np.float_]]:
         """Extract from full inputs the input of reference for the original Keras layer.
 
         Args:
@@ -507,11 +508,11 @@ class Helpers:
 
     @staticmethod
     def get_full_outputs_from_outputs_for_mode(
-        outputs_for_mode: Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]],
+        outputs_for_mode: Union[List[Tensor], List[npt.NDArray[np.float_]]],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-        full_inputs: Optional[Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]] = None,
-    ) -> Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]:
+        full_inputs: Optional[Union[List[Tensor], List[npt.NDArray[np.float_]]]] = None,
+    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
         mode = ForwardMode(mode)
         if dc_decomp:
             if mode == ForwardMode.HYBRID:
@@ -557,7 +558,7 @@ class Helpers:
             return 6
 
     @staticmethod
-    def get_input_dim_from_full_inputs(inputs: Union[List[keras.KerasTensor], List[npt.NDArray[np.float_]]]) -> int:
+    def get_input_dim_from_full_inputs(inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]]) -> int:
         """Get input_dim for to_decomon or to_backward from full inputs
 
         Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1360,7 +1360,8 @@ class Helpers:
     @staticmethod
     def toy_network_tutorial(dtype="float32"):
         layers = []
-        layers.append(Dense(100, input_dim=1, dtype=dtype))  # specify the dimension of the input space
+        layers.append(Input((1,), dtype=dtype))
+        layers.append(Dense(100, dtype=dtype))
         layers.append(Activation("relu", dtype=dtype))
         layers.append(Dense(100, dtype=dtype))
         layers.append(Dense(1, activation="linear", dtype=dtype))
@@ -1370,9 +1371,8 @@ class Helpers:
     @staticmethod
     def toy_network_tutorial_with_embedded_activation(dtype="float32"):
         layers = []
-        layers.append(
-            Dense(100, input_dim=1, activation="relu", dtype=dtype)
-        )  # specify the dimension of the input space
+        layers.append(Input((1,), dtype=dtype))
+        layers.append(Dense(100, activation="relu", dtype=dtype))
         layers.append(Dense(100, dtype=dtype))
         layers.append(Dense(1, activation="linear", dtype=dtype))
         model = Sequential(layers)
@@ -1382,9 +1382,8 @@ class Helpers:
     def toy_embedded_sequential(dtype="float32"):
         layers = []
         units = 10
-        layers.append(
-            Dense(units, input_dim=1, activation="relu", dtype=dtype)
-        )  # specify the dimension of the input space
+        layers.append(Input((1,), dtype=dtype))
+        layers.append(Dense(units, activation="relu", dtype=dtype))
         layers.append(
             Helpers.dense_NN_1D(
                 dtype=dtype, archi=[2, 3, 2], sequential=True, input_dim=units, activation="relu", use_bias=False
@@ -1396,24 +1395,24 @@ class Helpers:
 
     @staticmethod
     def dense_NN_1D(input_dim, archi, sequential, activation, use_bias, dtype="float32"):
-        layers = [Dense(archi[0], use_bias=use_bias, activation=activation, input_dim=input_dim, dtype=dtype)]
-        layers += [Dense(n_i, use_bias=use_bias, activation=activation, dtype=dtype) for n_i in archi[1:]]
+        layers = [Input((input_dim,), dtype=dtype)]
+        layers += [Dense(n_i, use_bias=use_bias, activation=activation, dtype=dtype) for n_i in archi]
 
         if sequential:
             return Sequential(layers)
         else:
-            x = Input(input_dim, dtype=dtype)
-            output = layers[0](x)
+            input = layers[0]
+            output = input
             for layer_ in layers[1:]:
                 output = layer_(output)
-            return Model(x, output)
+            return Model(input, output)
 
     @staticmethod
     def toy_struct_v0_1D(input_dim, archi, activation, use_bias, merge_op=Add, dtype="float32"):
         nnet_0 = Helpers.dense_NN_1D(
             input_dim=input_dim, archi=archi, sequential=False, activation=activation, use_bias=use_bias, dtype=dtype
         )
-        nnet_1 = Dense(archi[-1], use_bias=use_bias, activation="linear", input_dim=input_dim, name="toto", dtype=dtype)
+        nnet_1 = Dense(archi[-1], use_bias=use_bias, activation="linear", name="toto", dtype=dtype)
 
         x = Input(input_dim, dtype=dtype)
         h_0 = nnet_0(x)
@@ -1459,7 +1458,7 @@ class Helpers:
             use_bias=use_bias,
             dtype=dtype,
         )
-        nnet_2 = Dense(archi[-1], use_bias=use_bias, activation="linear", input_dim=input_dim, dtype=dtype)
+        nnet_2 = Dense(archi[-1], use_bias=use_bias, activation="linear", dtype=dtype)
 
         x = Input(input_dim, dtype=dtype)
         nnet_0(x)
@@ -1475,7 +1474,8 @@ class Helpers:
     def toy_struct_cnn(dtype="float32", image_data_shape=(6, 6, 2)):
         input_dim = np.prod(image_data_shape)
         layers = [
-            Reshape(target_shape=image_data_shape, input_dim=input_dim),
+            Input((input_dim,)),
+            Reshape(target_shape=image_data_shape),
             Conv2D(
                 10,
                 kernel_size=(3, 3),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 from typing import List, Optional, Union
 
-import keras_core as keras
-import keras_core.config as keras_config
-import keras_core.ops as K
+import keras
+import keras.config as keras_config
+import keras.ops as K
 import numpy as np
 import numpy.typing as npt
 import pytest
-from keras_core import KerasTensor
-from keras_core.layers import (
+from keras import KerasTensor
+from keras.layers import (
     Activation,
     Add,
     Average,
@@ -17,7 +17,7 @@ from keras_core.layers import (
     Input,
     Reshape,
 )
-from keras_core.models import Model, Sequential
+from keras.models import Model, Sequential
 from numpy.testing import assert_almost_equal
 
 from decomon.core import ForwardMode, Slope

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1414,7 +1414,7 @@ class Helpers:
         )
         nnet_1 = Dense(archi[-1], use_bias=use_bias, activation="linear", name="toto", dtype=dtype)
 
-        x = Input(input_dim, dtype=dtype)
+        x = Input((input_dim,), dtype=dtype)
         h_0 = nnet_0(x)
         h_1 = nnet_1(x)
 
@@ -1433,7 +1433,7 @@ class Helpers:
             dtype=dtype,
         )
 
-        x = Input(input_dim, dtype=dtype)
+        x = Input((input_dim,), dtype=dtype)
         h_0 = nnet_0(x)
         h_1 = nnet_0(x)
         y = merge_op(dtype=dtype)([h_0, h_1])
@@ -1460,7 +1460,7 @@ class Helpers:
         )
         nnet_2 = Dense(archi[-1], use_bias=use_bias, activation="linear", dtype=dtype)
 
-        x = Input(input_dim, dtype=dtype)
+        x = Input((input_dim,), dtype=dtype)
         nnet_0(x)
         nnet_1(x)
         nnet_1.set_weights([-p for p in nnet_0.get_weights()])  # be sure that the produced output will differ

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,7 +1,7 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.ops as K
+import keras.ops as K
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -11,7 +11,7 @@ from decomon.layers.decomon_layers import DecomonConv2D
 
 
 def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal, helpers):
-    if data_format == "channels_first" and not len(_get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -1,7 +1,7 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
 import pytest
 from tensorflow.python.keras.backend import _get_available_gpus

--- a/tests/test_backward_dense.py
+++ b/tests/test_backward_dense.py
@@ -1,5 +1,5 @@
-import keras_core.config as keras_config
-from keras_core.layers import Dense, Input
+import keras.config as keras_config
+from keras.layers import Dense, Input
 
 from decomon.backward_layers.convert import to_backward
 from decomon.core import ForwardMode

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -105,7 +105,7 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, decimal, mode, 
 
 
 def test_Backward_Flatten_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
-    if data_format == "channels_first" and not len(_get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     dc_decomp = False

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -1,6 +1,6 @@
-import keras_core.config as keras_config
+import keras.config as keras_config
 import pytest
-from keras_core.layers import Layer, Reshape
+from keras.layers import Layer, Reshape
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.backward_layers.convert import to_backward

--- a/tests/test_backward_layers_get_config.py
+++ b/tests/test_backward_layers_get_config.py
@@ -1,5 +1,5 @@
 import pytest
-from keras_core.layers import Layer
+from keras.layers import Layer
 
 from decomon.backward_layers.backward_layers import (
     BackwardActivation,

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -65,7 +65,7 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, decimal, 
 
 
 def test_Backward_NativeFlatten_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
-    if data_format == "channels_first" and not len(_get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     dc_decomp = False

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -1,6 +1,6 @@
-import keras_core.config as keras_config
+import keras.config as keras_config
 import pytest
-from keras_core.layers import Activation, Flatten, Reshape
+from keras.layers import Activation, Flatten, Reshape
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.backward_layers.convert import to_backward

--- a/tests/test_backward_utils.py
+++ b/tests/test_backward_utils.py
@@ -1,9 +1,9 @@
 # Test unit for decomon with Dense layers
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
 import pytest
-from keras_core.layers import Input
+from keras.layers import Input
 
 from decomon.backward_layers.utils import (
     backward_add,

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -115,7 +115,8 @@ def test_convert_1D_backward_slope(slope, helpers):
 
 def test_name_forward():
     layers = []
-    layers.append(Dense(1, input_dim=1))
+    layers.append(Input((1,)))
+    layers.append(Dense(1))
     layers.append(Dense(1, name="superman"))  # specify the dimension of the input space
     layers.append(Activation("relu"))
     layers.append(Dense(1, activation="relu", name="batman"))
@@ -131,7 +132,8 @@ def test_name_forward():
 @pytest.mark.skipif(not (deel_lip_available), reason=deel_lip_skip_reason)
 def test_name_forward_deellip():
     layers = []
-    layers.append(Dense(1, input_dim=1))
+    layers.append(Input((1,)))
+    layers.append(Dense(1))
     layers.append(SpectralDense(1, name="superman"))  # specify the dimension of the input space
     layers.append(Activation("relu"))
     layers.append(SpectralDense(1, activation=GroupSort(n=1), name="batman"))
@@ -146,7 +148,8 @@ def test_name_forward_deellip():
 
 def test_name_backward():
     layers = []
-    layers.append(Dense(1, input_dim=1))
+    layers.append(Input((1,)))
+    layers.append(Dense(1))
     layers.append(Dense(1, name="superman"))  # specify the dimension of the input space
     layers.append(Activation("relu"))
     layers.append(Dense(1, activation="relu", name="batman"))
@@ -162,7 +165,8 @@ def test_name_backward():
 @pytest.mark.skipif(not (deel_lip_available), reason=deel_lip_skip_reason)
 def test_name_backward_deellip():
     layers = []
-    layers.append(Dense(1, input_dim=1))
+    layers.append(Input((1,)))
+    layers.append(Dense(1))
     layers.append(SpectralDense(1, name="superman"))  # specify the dimension of the input space
     layers.append(Activation("relu"))
     layers.append(SpectralDense(1, activation="relu", name="batman"))

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -6,7 +6,7 @@ import keras_core.ops as K
 import numpy as np
 import pytest
 from keras_core.layers import Activation, Dense, Flatten, Input, Reshape
-from keras_core.models import Sequential
+from keras_core.models import Model, Sequential
 
 from decomon.core import ForwardMode, Slope, get_affine, get_ibp, get_mode
 from decomon.layers.decomon_reshape import DecomonReshape
@@ -35,6 +35,23 @@ else:
 
 
 deel_lip_skip_reason = "deel-lip is not available"
+
+
+def test_convert_nok_several_inputs():
+    a = Input((1,))
+    b = Input((2,))
+    model = Model([a, b], a)
+
+    with pytest.raises(ValueError, match="only 1 input"):
+        clone(model)
+
+
+def test_convert_nok_unflattened_input():
+    a = Input((1, 2))
+    model = Model(a, a)
+
+    with pytest.raises(ValueError, match="flattened input"):
+        clone(model)
 
 
 def test_convert_1D(n, method, mode, floatx, decimal, helpers):

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,12 +1,12 @@
 # creating toy network and assess that the decomposition is correct
 
 
-import keras_core.config as keras_config
-import keras_core.ops as K
+import keras.config as keras_config
+import keras.ops as K
 import numpy as np
 import pytest
-from keras_core.layers import Activation, Dense, Flatten, Input, Reshape
-from keras_core.models import Model, Sequential
+from keras.layers import Activation, Dense, Flatten, Input, Reshape
+from keras.models import Model, Sequential
 
 from decomon.core import ForwardMode, Slope, get_affine, get_ibp, get_mode
 from decomon.layers.decomon_reshape import DecomonReshape

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -70,13 +70,13 @@ def test_convert_1D(n, method, mode, floatx, decimal, helpers):
 
     #  keras model and output of reference
     ref_nn = helpers.toy_network_tutorial(dtype=keras_config.floatx())
-    output_ref_ = ref_nn.predict(input_ref_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_)
 
     # decomon conversion
     decomon_model = clone(ref_nn, method=method, final_ibp=ibp, final_affine=affine)
 
     #  decomon outputs
-    outputs_ = decomon_model.predict(input_decomon_)
+    outputs_ = helpers.predict_on_small_numpy(decomon_model, input_decomon_)
 
     #  check bounds consistency
     helpers.assert_decomon_model_output_properties_box(
@@ -258,13 +258,13 @@ def test_clone_full_deellip_model_forward(method, mode, helpers):
         k_coef_lip=1.0,
         name="hkr_model",
     )
-    output_ref_ = ref_nn.predict(input_ref_reshaped_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_reshaped_)
 
     # decomon conversion
     decomon_model = clone(ref_nn, method=method, final_ibp=ibp, final_affine=affine)
 
     #  decomon outputs
-    outputs_ = decomon_model.predict(input_decomon_)
+    outputs_ = helpers.predict_on_small_numpy(decomon_model, input_decomon_)
 
     #  check bounds consistency
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = helpers.get_full_outputs_from_outputs_for_mode(
@@ -305,7 +305,7 @@ def test_convert_toy_models_1d(toy_model_1d, method, mode, helpers):
 
     #  keras model and output of reference
     ref_nn = toy_model_1d
-    output_ref_ = ref_nn.predict(input_ref_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_)
 
     # decomon conversion
     if (get_direction(method) == FeedDirection.BACKWARD) and has_merge_layers(ref_nn):
@@ -317,7 +317,7 @@ def test_convert_toy_models_1d(toy_model_1d, method, mode, helpers):
     decomon_model = clone(ref_nn, method=method, final_ibp=ibp, final_affine=affine)
 
     #  decomon outputs
-    outputs_ = decomon_model.predict(input_decomon_)
+    outputs_ = helpers.predict_on_small_numpy(decomon_model, input_decomon_)
 
     #  check bounds consistency
     helpers.assert_decomon_model_output_properties_box(
@@ -363,13 +363,13 @@ def test_convert_cnn(method, mode, helpers):
     #  keras model and output of reference
     image_data_shape = input_ref_.shape[1:]  # image shape: before flattening
     ref_nn = helpers.toy_struct_cnn(dtype=keras_config.floatx(), image_data_shape=image_data_shape)
-    output_ref_ = ref_nn.predict(input_ref_reshaped_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_reshaped_)
 
     # decomon conversion
     decomon_model = clone(ref_nn, method=method, final_ibp=ibp, final_affine=affine)
 
     #  decomon outputs
-    outputs_ = decomon_model.predict(input_decomon_)
+    outputs_ = helpers.predict_on_small_numpy(decomon_model, input_decomon_)
 
     #  check bounds consistency
     z_, u_c_, w_u_, b_u_, l_c_, w_l_, b_l_, h_, g_ = helpers.get_full_outputs_from_outputs_for_mode(

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -229,7 +229,7 @@ def test_clone_full_deellip_model_forward(method, mode, helpers):
 
     # deel-lip model and output of reference
     image_data_shape = input_ref_.shape[1:]  # image shape: before flattening
-    flatten_input_shape = (np.prod(image_data_shape),)
+    flatten_input_shape = (int(np.prod(image_data_shape)),)
     ref_nn = DeellipSequential(
         [
             Reshape(target_shape=image_data_shape, input_shape=flatten_input_shape),

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -27,7 +27,7 @@ def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
 
     # keras model and output of reference
     ref_nn = helpers.toy_network_tutorial(dtype=keras_config.floatx())
-    output_ref_ = ref_nn.predict(input_ref_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_)
 
     # convert to functional
     ref_nn = ensure_functional_model(ref_nn)

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -6,6 +6,7 @@ import keras_core.config as keras_config
 from decomon.core import get_affine, get_ibp
 from decomon.models.backward_cloning import convert_backward
 from decomon.models.forward_cloning import convert_forward
+from decomon.models.utils import ensure_functional_model
 
 
 def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
@@ -27,6 +28,9 @@ def test_convert_backward_1D(n, mode, floatx, decimal, helpers):
     # keras model and output of reference
     ref_nn = helpers.toy_network_tutorial(dtype=keras_config.floatx())
     output_ref_ = ref_nn.predict(input_ref_)
+
+    # convert to functional
+    ref_nn = ensure_functional_model(ref_nn)
 
     # decomon conversion
     back_bounds = []

--- a/tests/test_clone_backward.py
+++ b/tests/test_clone_backward.py
@@ -1,7 +1,7 @@
 # creating toy network and assess that the decomposition is correct
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 
 from decomon.core import get_affine, get_ibp
 from decomon.models.backward_cloning import convert_backward

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -25,7 +25,7 @@ def test_convert_forward_1D(n, mode, floatx, decimal, helpers):
 
     # keras model and output of reference
     ref_nn = helpers.toy_network_tutorial(dtype=keras_config.floatx())
-    output_ref_ = ref_nn.predict(input_ref_)
+    output_ref_ = helpers.predict_on_small_numpy(ref_nn, input_ref_)
 
     # decomon conversion
     _, outputs, _, _ = convert_forward(ref_nn, ibp=ibp, affine=affine, shared=True, input_tensors=input_tensors)

--- a/tests/test_clone_forward.py
+++ b/tests/test_clone_forward.py
@@ -1,7 +1,7 @@
 # creating toy network and assess that the decomposition is correct
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 
 from decomon.core import get_affine, get_ibp
 from decomon.models.forward_cloning import convert_forward

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -1,10 +1,10 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
 import pytest
-from keras_core.layers import Conv2D
+from keras.layers import Conv2D
 from tensorflow.python.keras.backend import _get_available_gpus
 
 from decomon.core import ForwardMode, get_affine, get_ibp

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -13,7 +13,7 @@ from decomon.layers.decomon_layers import DecomonConv2D
 
 
 def test_Decomon_conv_box(data_format, mode, dc_decomp, floatx, decimal, helpers):
-    if data_format == "channels_first" and not len(_get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1

--- a/tests/test_decomon_compute_output_shape.py
+++ b/tests/test_decomon_compute_output_shape.py
@@ -1,0 +1,165 @@
+import pytest
+
+from decomon.layers.decomon_layers import (
+    DecomonBatchNormalization,
+    DecomonConv2D,
+    DecomonDense,
+    DecomonFlatten,
+)
+from decomon.layers.decomon_merge_layers import DecomonAdd, DecomonConcatenate
+from decomon.layers.decomon_reshape import DecomonReshape
+from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+try:
+    import deel.lip
+except ImportError:
+    deel_lip_available = False
+    DecomonGroupSort2 = "DecomonGroupSort2"
+else:
+    deel_lip_available = True
+    from decomon.layers.deel_lip import DecomonGroupSort2
+
+
+@pytest.mark.parametrize(
+    "layer_class, layer_kwargs",
+    [
+        (DecomonDense, dict(units=3, use_bias=True)),
+        (DecomonFlatten, dict()),
+        (DecomonBatchNormalization, dict(center=True, scale=True)),
+        (DecomonBatchNormalization, dict(center=False, scale=False)),
+        (DecomonConv2D, dict(filters=10, kernel_size=(3, 3), data_format="channels_last")),
+        (DecomonMaxPooling2D, dict(pool_size=(2, 2), strides=(2, 2), padding="valid")),
+        (DecomonReshape, dict(target_shape=(1, -1, 1))),
+        (DecomonGroupSort2, dict()),
+    ],
+)
+@pytest.mark.parametrize(
+    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
+    [
+        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
+        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
+        (
+            "get_tensor_decomposition_images_box",
+            dict(odd=0, data_format="channels_last"),
+            "get_standard_values_images_box",
+            dict(odd=0, data_format="channels_last"),
+        ),
+    ],
+)
+def test_compute_output_shape(
+    helpers,
+    mode,
+    dc_decomp,
+    layer_class,
+    layer_kwargs,
+    kerastensor_inputs_fn_name,
+    kerastensor_inputs_kwargs,
+    np_inputs_fn_name,
+    np_inputs_kwargs,
+):
+    if (layer_class == DecomonBatchNormalization or layer_class == DecomonMaxPooling2D) and dc_decomp:
+        pytest.skip(f"{layer_class} with dc_decomp=True not yet implemented.")
+    if (
+        layer_class == DecomonConv2D or layer_class == DecomonMaxPooling2D
+    ) and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box":
+        pytest.skip(f"{layer_class} applies only on image-like inputs.")
+    if layer_class == DecomonGroupSort2:
+        if not deel_lip_available:
+            pytest.skip("deel-lip is not available")
+
+    # contruct inputs functions
+    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
+    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
+    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
+    np_inputs_kwargs["dc_decomp"] = dc_decomp
+
+    # tensors inputs
+    inputs = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+
+    # numpy inputs
+    inputs_ = np_inputs_fn(**np_inputs_kwargs)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+
+    # construct layer
+    layer = layer_class(mode=mode, dc_decomp=dc_decomp, **layer_kwargs)
+
+    # check symbolic tensor output shapes
+    inputshapes = [i.shape for i in inputs_for_mode]
+    outputshapes = layer.compute_output_shape(inputshapes)
+    outputs = layer(inputs_for_mode)
+    assert [o.shape for o in outputs] == outputshapes
+
+    # check output shapes for concrete call
+    outputs_ = layer(inputs_for_mode_)
+    # compare without batch sizes
+    assert [tuple(o.shape)[1:] for o in outputs_] == [s[1:] for s in outputshapes]
+
+
+@pytest.mark.parametrize(
+    "layer_class, layer_kwargs",
+    [
+        (DecomonAdd, dict()),
+        (DecomonConcatenate, dict()),
+    ],
+)
+@pytest.mark.parametrize(
+    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
+    [
+        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
+        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
+        (
+            "get_tensor_decomposition_images_box",
+            dict(odd=0, data_format="channels_last"),
+            "get_standard_values_images_box",
+            dict(odd=0, data_format="channels_last"),
+        ),
+    ],
+)
+def test_merge_layers_compute_output_shape(
+    helpers,
+    mode,
+    dc_decomp,
+    layer_class,
+    layer_kwargs,
+    kerastensor_inputs_fn_name,
+    kerastensor_inputs_kwargs,
+    np_inputs_fn_name,
+    np_inputs_kwargs,
+):
+    if dc_decomp:
+        pytest.skip(f"{layer_class} with dc_decomp=True not yet implemented.")
+
+    # contruct inputs functions
+    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
+    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
+    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
+    np_inputs_kwargs["dc_decomp"] = dc_decomp
+
+    # tensors inputs
+    inputs_1 = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
+    inputs_for_mode_1 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1, mode=mode, dc_decomp=dc_decomp)
+    inputs_2 = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
+    inputs_for_mode_2 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_2, mode=mode, dc_decomp=dc_decomp)
+    inputs_for_mode = inputs_for_mode_1 + inputs_for_mode_2
+
+    # numpy inputs
+    inputs_1_ = np_inputs_fn(**np_inputs_kwargs)
+    inputs_for_mode_1_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1_, mode=mode, dc_decomp=dc_decomp)
+    inputs_2_ = np_inputs_fn(**np_inputs_kwargs)
+    inputs_for_mode_2_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_2_, mode=mode, dc_decomp=dc_decomp)
+    inputs_for_mode_ = inputs_for_mode_1_ + inputs_for_mode_2_
+
+    # construct layer
+    layer = layer_class(mode=mode, dc_decomp=dc_decomp, **layer_kwargs)
+
+    # check symbolic tensor output shapes
+    inputshapes = [i.shape for i in inputs_for_mode]
+    outputshapes = layer.compute_output_shape(inputshapes)
+    outputs = layer(inputs_for_mode)
+    assert [o.shape for o in outputs] == outputshapes
+
+    # check output shapes for concrete call
+    outputs_ = layer(inputs_for_mode_)
+    # compare without batch sizes
+    assert [tuple(o.shape)[1:] for o in outputs_] == [s[1:] for s in outputshapes]

--- a/tests/test_decomon_reset_layer.py
+++ b/tests/test_decomon_reset_layer.py
@@ -1,4 +1,4 @@
-import keras
+import keras.ops as K
 import numpy as np
 import pytest
 from keras.layers import BatchNormalization, Conv2D, Dense, Flatten

--- a/tests/test_decomon_reset_layer.py
+++ b/tests/test_decomon_reset_layer.py
@@ -53,11 +53,12 @@ def test_decomondense_reset_layer_decomon_with_new_weights(helpers):
     layer(K.zeros((2, input_dim)))
     decomon_layer = DecomonDense(units=units, mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
-    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
-    decomon_layer(inputs_for_mode)
     # Add new variables
     decomon_layer.add_weight(shape=(input_dim, units), initializer="ones", name="alpha", trainable=True)
     decomon_layer.add_weight(shape=(input_dim, units), initializer="ones", name="beta", trainable=False)
+    # Build layer
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    decomon_layer(inputs_for_mode)
     assert len(decomon_layer.weights) == 4
     assert len(decomon_layer.trainable_weights) == 3
 
@@ -79,13 +80,13 @@ def test_decomondense_reset_layer_keras_with_new_weights(helpers):
     units = 3
     mode = ForwardMode.HYBRID
     layer = Dense(units=units)
+    # Add new variables
+    layer.add_weight(shape=(input_dim, units), initializer="ones", name="alpha", trainable=False)
     layer(K.zeros((2, input_dim)))
     decomon_layer = DecomonDense(units=units, mode=mode, dc_decomp=dc_decomp)
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
     decomon_layer(inputs_for_mode)
-    # Add new variables
-    layer.add_weight(shape=(input_dim, units), initializer="ones", name="alpha", trainable=False)
     assert len(layer.weights) == 3
 
     kernel = layer.kernel

--- a/tests/test_decomon_reset_layer.py
+++ b/tests/test_decomon_reset_layer.py
@@ -1,7 +1,7 @@
-import keras_core as keras
+import keras
 import numpy as np
 import pytest
-from keras_core.layers import BatchNormalization, Conv2D, Dense, Flatten
+from keras.layers import BatchNormalization, Conv2D, Dense, Flatten
 from numpy.testing import assert_almost_equal
 
 from decomon.core import ForwardMode

--- a/tests/test_dense_layer.py
+++ b/tests/test_dense_layer.py
@@ -1,9 +1,9 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
-from keras_core.layers import Dense
+from keras.layers import Dense
 from numpy.testing import assert_almost_equal
 
 from decomon.core import ForwardMode, get_affine, get_ibp

--- a/tests/test_keras_utils.py
+++ b/tests/test_keras_utils.py
@@ -1,7 +1,7 @@
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import pytest
-from keras_core.layers import Dense
+from keras.layers import Dense
 
 from decomon.keras_utils import get_weight_index_from_name
 

--- a/tests/test_keras_utils.py
+++ b/tests/test_keras_utils.py
@@ -7,20 +7,20 @@ from decomon.keras_utils import get_weight_index_from_name
 
 
 def test_get_weight_index_from_name_nok_attribute():
-    layer = Dense(3, input_dim=1)
+    layer = Dense(3)
     layer(K.zeros((2, 1)))
     with pytest.raises(AttributeError):
         get_weight_index_from_name(layer=layer, weight_name="toto")
 
 
 def test_get_weight_index_from_name_nok_index():
-    layer = Dense(3, input_dim=1, use_bias=False)
+    layer = Dense(3, use_bias=False)
     layer(K.zeros((2, 1)))
     with pytest.raises(IndexError):
         get_weight_index_from_name(layer=layer, weight_name="bias")
 
 
 def test_get_weight_index_from_name_ok():
-    layer = Dense(3, input_dim=1)
+    layer = Dense(3)
     layer(K.zeros((2, 1)))
     assert get_weight_index_from_name(layer=layer, weight_name="bias") in [0, 1]

--- a/tests/test_layers_convert_utils.py
+++ b/tests/test_layers_convert_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from keras_core.layers import Dense, Input
+from keras.layers import Dense, Input
 
 from decomon.layers.convert import get_layer_input_shape
 

--- a/tests/test_layers_convert_utils.py
+++ b/tests/test_layers_convert_utils.py
@@ -1,0 +1,25 @@
+import pytest
+from keras_core.layers import Dense, Input
+
+from decomon.layers.convert import get_layer_input_shape
+
+
+def test_get_layer_input_shape_nok_uncalled():
+    layer = Dense(3)
+    with pytest.raises(AttributeError):
+        get_layer_input_shape(layer)
+
+
+def test_get_layer_input_shape_nok_multiple_shapes():
+    layer = Dense(3)
+    layer(Input((1,)))
+    layer(Input((1, 1)))
+    with pytest.raises(AttributeError):
+        get_layer_input_shape(layer)
+
+
+def test_get_layer_input_shape_ok():
+    layer = Dense(3)
+    layer(Input((1,)))
+    input_shape = get_layer_input_shape(layer)
+    assert input_shape == [(None, 1)]

--- a/tests/test_layers_get_config.py
+++ b/tests/test_layers_get_config.py
@@ -114,13 +114,16 @@ def test_decomon_layers():
     config = layer.get_config()
     assert config["rate"] == rate
 
-    for cls in [DecomonBatchNormalization, DecomonInputLayer, DecomonFlatten]:
+    shape = (2, 5)
+    layer = DecomonInputLayer(shape=shape)
+    config = layer.get_config()
+    assert config["batch_shape"] == (None,) + shape
+
+    for cls in [DecomonBatchNormalization, DecomonFlatten]:
         layer = cls()
         config = layer.get_config()
         assert "mode" in config
         if layer == DecomonBatchNormalization:
             assert "axis" in config
-        elif layer == DecomonInputLayer:
-            assert "input_shape" in config
         elif layer == DecomonFlatten:
             assert "data_format" in config

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,18 +1,10 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
 import pytest
-from keras_core.layers import (
-    Add,
-    Average,
-    Concatenate,
-    Maximum,
-    Minimum,
-    Multiply,
-    Subtract,
-)
+from keras.layers import Add, Average, Concatenate, Maximum, Minimum, Multiply, Subtract
 
 from decomon.core import ForwardMode, get_affine, get_ibp
 from decomon.layers.convert import to_decomon

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,4 +1,4 @@
-import keras_core.ops as K
+import keras.ops as K
 
 from decomon.metrics.utils import categorical_cross_entropy
 

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -207,11 +207,7 @@ def test_convert_deellip_to_keras_groupsort():
 def test_convert_deellip_to_keras_spectraldense():
     units = 3
     layer = SpectralDense(units=units)
-    layer(
-        Input(
-            1,
-        )
-    )
+    layer(Input((1,)))
     keras_layer = convert_deellip_to_keras(layer)
     # new attributes added
     assert hasattr(keras_layer, "is_lipschitz")

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -91,7 +91,7 @@ def test_split_activation_do_nothing(layer_class, layer_kwargs):
 
 def test_split_activation_uninitialized_layer_ko():
     layer = Dense(3, activation="relu")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         layers = split_activation(layer)
 
 
@@ -237,7 +237,7 @@ def test_convert_deellip_to_keras_spectraldense():
 def test_convert_deellip_to_keras_spectraldense_not_initialized_ko():
     units = 3
     layer = SpectralDense(units=units)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         keras_layer = convert_deellip_to_keras(layer)
 
 

--- a/tests/test_models_utils.py
+++ b/tests/test_models_utils.py
@@ -1,9 +1,9 @@
-import keras_core as keras
-import keras_core.ops as K
+import keras
+import keras.ops as K
 import numpy as np
 import pytest
-from keras_core import Input
-from keras_core.layers import Activation, Conv2D, Dense, Layer, Permute, PReLU
+from keras import Input
+from keras.layers import Activation, Conv2D, Dense, Layer, Permute, PReLU
 from numpy.testing import assert_almost_equal
 
 from decomon.models.utils import (

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -1,5 +1,5 @@
-import keras_core.config as keras_config
-from keras_core.layers import MaxPooling2D
+import keras.config as keras_config
+from keras.layers import MaxPooling2D
 
 from decomon.layers.maxpooling import DecomonMaxPooling2D
 

--- a/tests/test_preprocess_keras_model.py
+++ b/tests/test_preprocess_keras_model.py
@@ -18,6 +18,7 @@ from decomon.models.convert import (
     preprocess_keras_model,
     split_activations_in_keras_model,
 )
+from decomon.models.utils import ensure_functional_model
 
 try:
     import deel.lip

--- a/tests/test_preprocess_keras_model.py
+++ b/tests/test_preprocess_keras_model.py
@@ -1,16 +1,8 @@
-import keras_core.ops as K
+import keras.ops as K
 import numpy as np
 import pytest
-from keras_core.layers import (
-    Activation,
-    Conv2D,
-    Dense,
-    Flatten,
-    Input,
-    InputLayer,
-    PReLU,
-)
-from keras_core.models import Model, Sequential
+from keras.layers import Activation, Conv2D, Dense, Flatten, Input, InputLayer, PReLU
+from keras.models import Model, Sequential
 from numpy.testing import assert_almost_equal
 
 from decomon.models.convert import (

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -9,7 +9,7 @@ from decomon.layers.decomon_reshape import DecomonPermute, DecomonReshape
 
 
 def keras_target_shape_reshape(input_ref):
-    return (np.prod(input_ref.shape[1:]),)
+    return (int(np.prod(input_ref.shape[1:])),)
 
 
 def target_shape_keras2np_reshape(target_shape):

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -1,7 +1,7 @@
-import keras_core.config as keras_config
+import keras.config as keras_config
 import numpy as np
 import pytest
-from keras_core.layers import Permute, Reshape
+from keras.layers import Permute, Reshape
 
 from decomon.core import ForwardMode, get_affine, get_ibp
 from decomon.layers.convert import to_decomon

--- a/tests/test_to_decomon.py
+++ b/tests/test_to_decomon.py
@@ -75,5 +75,5 @@ def test_to_decomon_ok(layer_class, layer_kwargs, input_shape_wo_batchsize, nb_i
         layer(input_tensors)
     decomon_layer = to_decomon(layer, input_dim=1)
     # check trainable weights
-    for i in range(len(layer._trainable_weights)):
-        assert layer._trainable_weights[i] is decomon_layer._trainable_weights[i]
+    for i in range(len(layer.weights)):
+        assert layer.weights[i] is decomon_layer.weights[i]

--- a/tests/test_to_decomon.py
+++ b/tests/test_to_decomon.py
@@ -1,5 +1,5 @@
 import pytest
-from keras_core.layers import Add, Conv2D, Dense, Input, Layer, Reshape
+from keras.layers import Add, Conv2D, Dense, Input, Layer, Reshape
 
 from decomon.layers.convert import to_decomon
 from decomon.layers.utils import is_a_merge_layer

--- a/tests/test_to_decomon.py
+++ b/tests/test_to_decomon.py
@@ -65,13 +65,12 @@ def test_to_decomon_not_implemented_ko():
 def test_to_decomon_ok(layer_class, layer_kwargs, input_shape_wo_batchsize, nb_inputs):
     layer = layer_class(**layer_kwargs)
     # init input_shape and weights
-    input_shape = (None,) + input_shape_wo_batchsize
     # input_tensors + build layer
     if nb_inputs == 1:
-        input_tensor = Input(input_shape)
+        input_tensor = Input(input_shape_wo_batchsize)
         layer(input_tensor)
     else:
-        input_tensors = [Input(input_shape) for _ in range(nb_inputs)]
+        input_tensors = [Input(input_shape_wo_batchsize) for _ in range(nb_inputs)]
         layer(input_tensors)
     decomon_layer = to_decomon(layer, input_dim=1)
     # check trainable weights

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.ops as K
+import keras.ops as K
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal

--- a/tests/test_utils_conv.py
+++ b/tests/test_utils_conv.py
@@ -1,10 +1,10 @@
 # Test unit for decomon with Dense layers
 
 
-import keras_core.ops as K
+import keras.ops as K
 import numpy as np
 import pytest
-from keras_core.layers import Conv2D
+from keras.layers import Conv2D
 from numpy.testing import assert_almost_equal
 
 from decomon.backward_layers.utils_conv import get_toeplitz

--- a/tests/test_utils_conv.py
+++ b/tests/test_utils_conv.py
@@ -17,7 +17,7 @@ def test_toeplitz_from_Keras(channels, filter_size, strides, flatten, data_forma
     if floatx == 16:
         decimal = 0
 
-    if data_format == "channels_first" and not len(K._get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     dc_decomp = False
@@ -67,7 +67,7 @@ def test_toeplitz_from_Keras(channels, filter_size, strides, flatten, data_forma
 def test_toeplitz_from_Decomon(
     floatx, decimal, mode, channels, filter_size, strides, flatten, data_format, padding, helpers
 ):
-    if data_format == "channels_first" and not len(K._get_available_gpus()):
+    if data_format == "channels_first" and not helpers.tensorflow_in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode")
 
     odd, m_0, m_1 = 0, 0, 1

--- a/tests/test_utils_pooling.py
+++ b/tests/test_utils_pooling.py
@@ -1,4 +1,4 @@
-import keras_core.ops as K
+import keras.ops as K
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal

--- a/tests/test_utils_pooling.py
+++ b/tests/test_utils_pooling.py
@@ -31,15 +31,16 @@ def test_get_lower_upper_linear_hull_max(
     inputs = helpers.get_tensor_decomposition_images_box(data_format, odd, dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
     inputs_ = helpers.get_standard_values_images_box(data_format, odd, m0=m_0, m1=m_1, dc_decomp=dc_decomp)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
     input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
+    inputs_for_mode_tf_ = [K.convert_to_tensor(inp, dtype="float{}".format(floatx)) for inp in inputs_for_mode_]
 
     if finetune_odd is not None:
         finetune_odd = K.convert_to_tensor(finetune_odd, dtype="float{}".format(floatx))
 
     # decomon output
-    output = func(inputs_for_mode, mode=mode, axis=axis, finetune_lower=finetune_odd)
-    f_pooling = helpers.function(inputs, output)
-    w_, b_ = f_pooling(inputs_)
+    w_tf_, b_tf_ = func(inputs_for_mode_tf_, mode=mode, axis=axis, finetune_lower=finetune_odd)
+    w_, b_ = w_tf_.numpy(), b_tf_.numpy()
 
     # reference output
     output_ref_ = np.max(input_ref_, axis=axis)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -42,7 +42,7 @@ def test_get_upper_1d_box(toy_model_1d, n, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_1d, method=method, ibp=ibp, affine=affine, mode=mode)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_1d.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_1d, y)
 
     try:
         assert (upper - y_ref).min() + 1e-6 >= 0.0
@@ -63,7 +63,7 @@ def test_get_lower_1d_box(toy_model_1d, n, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_1d, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_1d.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_1d, y)
 
     try:
         assert (y_ref - lower).min() + 1e-6 >= 0.0
@@ -84,7 +84,7 @@ def test_get_range_1d_box(toy_model_1d, n, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_1d, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_1d.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_1d, y)
 
     try:
         assert (upper - y_ref).min() + 1e-6 >= 0.0
@@ -105,7 +105,7 @@ def test_get_upper_multid_box(toy_model_multid, odd, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     upper = get_upper_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_multid.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_multid, y)
 
     assert (upper - y_ref).min() + 1e-6 >= 0.0
 
@@ -122,7 +122,7 @@ def test_get_lower_multid_box(toy_model_multid, odd, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     lower = get_lower_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_multid.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_multid, y)
 
     assert (y_ref - lower).min() + 1e-6 >= 0.0
 
@@ -139,7 +139,7 @@ def test_get_range_multid_box(toy_model_multid, odd, method, mode, helpers):
     affine = get_affine(mode)
     backward_model = clone(toy_model_multid, method=method, final_ibp=ibp, final_affine=affine)
     upper, lower = get_range_box(backward_model, z[:, 0], z[:, 1])
-    y_ref = toy_model_multid.predict(y)
+    y_ref = helpers.predict_on_small_numpy(toy_model_multid, y)
 
     assert (upper - y_ref).min() + 1e-6 >= 0.0
     assert (y_ref - lower).min() + 1e-6 >= 0.0

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from keras_core.layers import Activation, Dense, Input
-from keras_core.models import Sequential
+from keras.layers import Activation, Dense, Input
+from keras.models import Sequential
 from numpy.testing import assert_almost_equal
 
 from decomon import get_lower_box, get_range_box, get_upper_box

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from keras_core.layers import Activation, Dense
+from keras_core.layers import Activation, Dense, Input
 from keras_core.models import Sequential
 from numpy.testing import assert_almost_equal
 
@@ -12,7 +12,8 @@ from decomon.models import clone
 @pytest.fixture()
 def toy_model_1d():
     sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=1))
+    sequential.add(Input((1,)))
+    sequential.add(Dense(1, activation="linear"))
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
     return sequential
@@ -22,7 +23,8 @@ def toy_model_1d():
 def toy_model_multid(odd, helpers):
     input_dim = helpers.get_input_dim_multid_box(odd)
     sequential = Sequential()
-    sequential.add(Dense(1, activation="linear", input_dim=input_dim))
+    sequential.add(Input((input_dim,)))
+    sequential.add(Dense(1, activation="linear"))
     sequential.add(Activation("relu"))
     sequential.add(Dense(1, activation="linear"))
     return sequential

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ deps =
     pytest
     deel-lip
 commands =
+    pip uninstall keras keras-nightly -y
+    pip install keras-nightly
+    pip list
     pytest -v {posargs}
 description =
     pytest environment
@@ -33,6 +36,9 @@ deps =
     deel-lip
     pytest-cov
 commands =
+    pip uninstall keras keras-nightly -y
+    pip install keras-nightly
+    pip list
     pytest -v \
       --cov decomon \
       --cov-report xml:coverage.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ description =
     pytest environment
     without deel-lip
 
-[testenv:py39-linux]
+[testenv:py39-linux-nodeellip]
 # coverage in only one env
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pre-commit
     convert-doc-to-test
     type
-    py{38,39}-{linux,macos,win}{-nodeellip,}{-tf212,}
+    py{39,311}-{linux,macos,win}{-nodeellip,}
 
 [testenv]
 platform = linux: linux
@@ -13,28 +13,23 @@ platform = linux: linux
            win: win32
 deps =
     pytest
-    tf212: tensorflow<2.13
     deel-lip
 commands =
     pytest -v {posargs}
 description =
     pytest environment
-    tf212: with tensorflow<2.13
 
-[testenv:py{38,39}-{linux,macos,win}-nodeellip{-tf212,}]
+[testenv:py{39,311}-{linux,macos,win}-nodeellip]
 deps =
     pytest
-    tf212: tensorflow<2.13
 description =
     pytest environment
     without deel-lip
-    tf212: with tensorflow<2.13
 
-[testenv:py39-linux-tf212]
+[testenv:py39-linux]
 # coverage in only one env
 deps =
     pytest
-    tensorflow<2.13
     deel-lip
     pytest-cov
 commands =
@@ -47,7 +42,6 @@ commands =
 description =
     pytest environment
     without deel-lip
-    tf212: with tensorflow<2.13
     with coverage
 
 [testenv:pre-commit]


### PR DESCRIPTION
The future keras 3 will have several backend (not only tensorflow) and will be available during Fall 2023 (cf this [post](https://keras.io/keras_core/announcement/))

We can see the future behaviour by using keras_core (but not anymore updated since the work has been moved to keras main repo) or directly keras-nightly which is already in keras 3 mode.

Thus this PR is trying to convert decomon to keras 3:

- update the dependencies and tox envs
- avoid using tensorflow and instead use only keras ops
- update code because of some api changes in keras