### PR TITLE
Update and simplify tox config file to ensure test coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,42 +13,22 @@ platform = linux: linux
            win: win32
 deps =
     pytest
-    deel-lip
-commands =
-    pip uninstall keras keras-nightly -y
-    pip install keras-nightly
-    pip list
-    pytest -v {posargs}
-description =
-    pytest environment
-
-[testenv:py{39,311}-{linux,macos,win}-nodeellip]
-deps =
-    pytest
-description =
-    pytest environment
-    without deel-lip
-
-[testenv:py39-linux-nodeellip]
-# coverage in only one env
-deps =
-    pytest
-    deel-lip
-    pytest-cov
+    !nodeellip: deel-lip
+    py39-linux-nodeellip: pytest-cov
 commands =
     pip uninstall keras keras-nightly -y
     pip install keras-nightly
     pip list
     pytest -v \
-      --cov decomon \
-      --cov-report xml:coverage.xml \
-      --cov-report html:coverage_html \
-      --cov-report term \
-      {posargs}
+    py39-linux-nodeellip:    --cov decomon \
+    py39-linux-nodeellip:    --cov-report xml:coverage.xml \
+    py39-linux-nodeellip:    --cov-report html:coverage_html \
+    py39-linux-nodeellip:    --cov-report term \
+    {posargs}
 description =
     pytest environment
-    without deel-lip
-    with coverage
+    nodeellip: without deel-lip
+    py39-linux-nodeellip: with coverage
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
Surprisingly, having the section [testenv:py39-linux-nodeellip] after the more generic section
[testenv:py{39,311}-{linux,macos,win}-nodeellip] skip the more specific section definition.

So the coverage was missed. This can be corrected by putting [testenv:py39-linux-nodeellip] before [testenv:py{39,311}-{linux,macos,win}-nodeellip] but this not intuitive.

We choose here to do everything in the main section [testenv] by making full use of generative names and factor conditions.

In particular, to have a command be used if a given factor is absent, by using an exclamation mark:

	!nodeellip: ...