### PR TITLE
Robustify isort linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black"]
+        args: ["--profile", "black", "--src", "src"]
 
   - repo: https://github.com/psf/black
     rev: 23.7.0 # Replace by any tag/version: https://github.com/psf/black/tags
@@ -40,7 +40,7 @@ repos:
     rev: 1.7.0
     hooks:
       - id: nbqa-isort
-        args: ["--profile=black"]
+        args: ["--profile=black", "--src=src"]
       - id: nbqa-black
       - id: nbqa
         entry: nbqa pycln


### PR DESCRIPTION
Sometimes isort can set 3rd-party libaries as 1st-party ones if a random directory with the library name in the project arborescence (on the repository or even locally). And thus make `pre-commit` change wrongly a file.

To avoid this we specify to isort where the source directory for our library is.