### PR TITLE
Install official release keras 3.0 instead of keras-nightly

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -92,6 +92,9 @@ jobs:
           python -m pip install -U pip setuptools
           pip install .
           pip install -r docs/requirements.txt
+          # ensure having keras 3 instead of keras 2.15 installed by tensorflow
+          pip uninstall -y keras
+          pip install "keras>=3"
       - name: generate documentation
         id: sphinx-build
         run: |

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,5 +9,6 @@ dependencies:
       - pandas
       - scipy
       - tensorboard>=2.13
+      - tensorflow>=2.15
       - jupyter-server-proxy
       - ..  # decomon

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,6 @@
-# use keras-nighlty (keras 3) instead of last release of keras (keras 2)
-pip uninstall -y keras keras-nightly
-pip install keras-nightly
+# use keras 3 instead of keras 2 installed by tensorflow
+pip uninstall -y keras
+pip install "keras>=3"
 
 # tensorboard launches at startup
 mv binder/tensorboardserverextension.py ${NB_PYTHON_PREFIX}/lib/python*/site-packages/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 myst_parser
 sphinx_rtd_theme
+tensorflow>=2.15  # install a backend for keras 3 (and tensorflow is the one needed by default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,9 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies =[
-    "tensorflow >=2.13.0",
     "matplotlib",
     "numpy >=1.21",
-    "keras-nightly",
+    "keras>=3",
 ]
 dynamic = ["version"]
 

--- a/src/decomon/__init__.py
+++ b/src/decomon/__init__.py
@@ -4,8 +4,9 @@ The goal of Decomon is to provide a simple interface to the latest explanation
 techniques for certified perturbation analysis
 """
 
-
 from importlib.metadata import PackageNotFoundError, version
+
+import keras
 
 from . import layers, models
 from .metrics.loss import get_adv_loss, get_lower_loss, get_model, get_upper_loss
@@ -30,3 +31,13 @@ try:
 except PackageNotFoundError:
     # package is not installed
     pass
+
+
+# Check keras version
+if not hasattr(keras, "__version__") or not keras.__version__.startswith("3"):
+    raise RuntimeError(
+        "Decomon is now compatible only with keras >= 3.0. "
+        "Please check your keras version. "
+        "You might have a keras 2 installed forcefully by tensorflow. "
+        "In that case, you just need to reinstall keras 3 after installing tensorflow."
+    )

--- a/tests/test_keras3.py
+++ b/tests/test_keras3.py
@@ -1,0 +1,16 @@
+import importlib
+
+import keras
+import pytest
+
+import decomon
+
+
+def test_ok_with_keras3():
+    importlib.reload(decomon)
+
+
+def test_nok_with_keras2():
+    keras.__version__ = "2.15"
+    with pytest.raises(RuntimeError):
+        importlib.reload(decomon)

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,11 @@ deps =
     pytest
     !nodeellip: deel-lip
     py39-linux-nodeellip: pytest-cov
+    tensorflow>=2.15  # backend for keras 3
 commands =
-    pip uninstall keras keras-nightly -y
-    pip install keras-nightly
+    # be sure to get keras 3 instead of keras 2 brought back by tensorflow 2.15
+    pip uninstall keras  -y
+    pip install "keras>=3"
     pip list
     pytest -v \
     py39-linux-nodeellip:    --cov decomon \

--- a/tutorials/tutorial1_sinus-interactive.ipynb
+++ b/tutorials/tutorial1_sinus-interactive.ipynb
@@ -55,8 +55,11 @@
     "    # install dev version for dev doc, or release version for release doc\n",
     "    !{sys.executable} -m pip install -U pip\n",
     "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@keras3#egg=decomon\n",
-    "    !{sys.executable} -m pip uninstall -y keras keras-nightly\n",
-    "    !{sys.executable} -m pip install keras-nightly"
+    "    # install desired backend (by default tensorflow)\n",
+    "    !{sys.executable} -m pip install \"tensorflow>=2.15\"\n",
+    "    # ensure having keras 3 and not keras 2.15\n",
+    "    !{sys.executable} -m pip uninstall -y keras\n",
+    "    !{sys.executable} -m pip install \"keras>=3\""
    ]
   },
   {

--- a/tutorials/tutorial2_noise_sensor.ipynb
+++ b/tutorials/tutorial2_noise_sensor.ipynb
@@ -59,8 +59,11 @@
     "    # install dev version for dev doc, or release version for release doc\n",
     "    !{sys.executable} -m pip install -U pip\n",
     "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@keras3#egg=decomon\n",
-    "    !{sys.executable} -m pip uninstall -y keras keras-nightly\n",
-    "    !{sys.executable} -m pip install keras-nightly"
+    "    # install desired backend (by default tensorflow)\n",
+    "    !{sys.executable} -m pip install \"tensorflow>=2.15\"\n",
+    "    # ensure having keras 3 and not keras 2.15\n",
+    "    !{sys.executable} -m pip uninstall -y keras\n",
+    "    !{sys.executable} -m pip install \"keras>=3\""
    ]
   },
   {

--- a/tutorials/tutorial3_adversarial_attack.ipynb
+++ b/tutorials/tutorial3_adversarial_attack.ipynb
@@ -57,8 +57,11 @@
     "    # install dev version for dev doc, or release version for release doc\n",
     "    !{sys.executable} -m pip install -U pip\n",
     "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@keras3#egg=decomon\n",
-    "    !{sys.executable} -m pip uninstall -y keras keras-nightly\n",
-    "    !{sys.executable} -m pip install keras-nightly"
+    "    # install desired backend (by default tensorflow)\n",
+    "    !{sys.executable} -m pip install \"tensorflow>=2.15\"\n",
+    "    # ensure having keras 3 and not keras 2.15\n",
+    "    !{sys.executable} -m pip uninstall -y keras\n",
+    "    !{sys.executable} -m pip install \"keras>=3\""
    ]
   },
   {

--- a/tutorials/tutorial4_certified_over_estimation.ipynb
+++ b/tutorials/tutorial4_certified_over_estimation.ipynb
@@ -65,9 +65,12 @@
     "\n",
     "    # install dev version for dev doc, or release version for release doc\n",
     "    !{sys.executable} -m pip install -U pip\n",
-    "    !{sys.executable} -m pip install git+https://github.com/nhuet/decomon@nb_keras3#egg=decomon\n",
-    "    !{sys.executable} -m pip uninstall -y keras keras-nightly\n",
-    "    !{sys.executable} -m pip install keras-nightly"
+    "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@keras3#egg=decomon\n",
+    "    # install desired backend (by default tensorflow)\n",
+    "    !{sys.executable} -m pip install \"tensorflow>=2.15\"\n",
+    "    # ensure having keras 3 and not keras 2.15\n",
+    "    !{sys.executable} -m pip uninstall -y keras\n",
+    "    !{sys.executable} -m pip install \"keras>=3\""
    ]
   },
   {

--- a/tutorials/z_Advanced/tensorboard-and-decomon.ipynb
+++ b/tutorials/z_Advanced/tensorboard-and-decomon.ipynb
@@ -57,8 +57,11 @@
     "    !{sys.executable} -m pip install \"tensorflow>=2.13\" \"tensorboard>=2.13\" \"keras>=2.13\"\n",
     "    !{sys.executable} -m pip install -U pip\n",
     "    !{sys.executable} -m pip install git+https://github.com/airbus/decomon@keras3#egg=decomon\n",
-    "    !{sys.executable} -m pip uninstall -y keras keras-nightly\n",
-    "    !{sys.executable} -m pip install keras-nightly"
+    "    # install desired backend (by default tensorflow)\n",
+    "    !{sys.executable} -m pip install \"tensorflow>=2.15\"\n",
+    "    # ensure having keras 3 and not keras 2.15\n",
+    "    !{sys.executable} -m pip uninstall -y keras\n",
+    "    !{sys.executable} -m pip install \"keras>=3\""
    ]
   },
   {


### PR DESCRIPTION
Keras 3.0 has officially been released: https://keras.io/keras_3/

- We need to update to tensorflow 2.15 compatible with keras 3 (see https://keras.io/getting_started/)
- We still need to reinstall keras 3 after tensorflow 2.15 which install keras 2.15. This will not be necessary starting from tensorflow 2.16.
- We add a check at decomon import and raise an error if keras version is not 3.
- In decomon dependencies, we remove tensorflow as it will now depends on the backend chosen by the user (tensorflow, jax, or pytorch)