### PR TITLE
Fix test_utils_conv.py and test_backward_conv.py

### DIFF
--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -35,6 +35,7 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal,
         use_bias=use_bias,
         mode=mode,
         dtype=keras_config.floatx(),
+        data_format=data_format,
     )
     decomon_layer(inputs_for_mode)  # init weights
 

--- a/tests/test_utils_conv.py
+++ b/tests/test_utils_conv.py
@@ -31,6 +31,7 @@ def test_toeplitz_from_Keras(channels, filter_size, strides, flatten, data_forma
 
     # should be working either with convolution of conv2D
     kwargs_layer = dict(
+        data_format=data_format,
         filters=channels,
         kernel_size=(filter_size, filter_size),
         strides=strides,
@@ -91,6 +92,7 @@ def test_toeplitz_from_Decomon(
         padding=padding,
         use_bias=False,
         dtype=input_ref.dtype,
+        data_format=data_format,
     )
 
     # should be working either with convolution of conv2D


### PR DESCRIPTION
The tested data_format was not injected into the tested layer. Thus we were always having layers assuming data_format=channels_last.

NB: this cannot be seen without a gpu for now, because the tests with channels_firt are skipped. 
But we could run the tests on torch which allows channels first even in CPU mode. (This is actually the pytorch preferred data format.)