### PR TITLE
Fix backward layers

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -18,7 +18,7 @@ from decomon.core import (
     get_affine,
     get_ibp,
 )
-from decomon.keras_utils import BatchedDiagLike
+from decomon.keras_utils import BatchedDiagLike, BatchedIdentityLike
 from decomon.layers.convert import to_decomon
 from decomon.layers.core import DecomonLayer
 from decomon.layers.decomon_layers import DecomonBatchNormalization
@@ -551,51 +551,40 @@ class BackwardBatchNormalization(BackwardLayer):
             **kwargs,
         )
 
-        if not isinstance(layer, DecomonBatchNormalization):
-            raise NotImplementedError()
         self.axis = self.layer.axis
         self.op_flat = Flatten()
 
     def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
         y = inputs[-1]
-        w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
-
-        n_dim = y.shape[1:]
-        n_out = w_u_out.shape[-1]
-        # reshape
-        w_u_out = K.reshape(w_u_out, [-1, 1] + list(n_dim) + [n_out])
-        w_l_out = K.reshape(w_l_out, [-1, 1] + list(n_dim) + [n_out])
+        n_out = int(np.prod(y.shape[1:]))
 
         n_dim = len(y.shape)
         shape = [1] * n_dim
         shape[self.axis] = self.layer.moving_mean.shape[0]
 
         if not hasattr(self.layer, "gamma") or self.layer.gamma is None:  # scale = False
-            gamma = K.ones(shape)
+            gamma = K.ones_like(self.layer.moving_variance)
         else:  # scale = True
-            gamma = K.reshape(self.layer.gamma + 0.0, shape)
+            gamma = self.layer.gamma
         if not hasattr(self.layer, "beta") or self.layer.beta is None:  # center = False
-            beta = K.zeros(shape)
+            beta = K.zeros_like(self.layer.moving_mean)
         else:  # center = True
-            beta = K.reshape(self.layer.beta + 0.0, shape)
-        moving_mean = K.reshape(self.layer.moving_mean + 0.0, shape)
-        moving_variance = K.reshape(self.layer.moving_variance + 0.0, shape)
+            beta = self.layer.beta
 
-        w = gamma / K.sqrt(moving_variance + self.layer.epsilon)
-        b = beta - w * moving_mean
+        w = gamma / K.sqrt(self.layer.moving_variance + self.layer.epsilon)
+        b = beta - w * self.layer.moving_mean
 
-        # flatten w_, b_
-        w = K.expand_dims(K.expand_dims(w, -1), 1)
-        b = K.expand_dims(K.expand_dims(b, -1), 1)
+        # reshape w
+        w_b = K.reshape(
+            K.reshape(BatchedIdentityLike()(K.reshape(y, (-1, n_out))), tuple(y.shape) + (-1,))
+            * K.reshape(w, shape + [1]),
+            (-1, n_out, n_out),
+        )
 
-        n_dim = int(np.prod(y.shape[1:]))
-        w_u_b = K.reshape(w_u_out * w, (-1, n_dim, n_out))
-        w_l_b = K.reshape(w_l_out * w, (-1, n_dim, n_out))
-        axis = [i for i in range(2, len(b.shape) - 1)]
-        b_u_b = K.sum(w_u_out * b, axis) + b_u_out
-        b_l_b = K.sum(w_l_out * b, axis) + b_l_out
+        # reshape b
+        b_b = K.reshape(K.ones_like(y) * K.reshape(b, shape), (-1, n_out))
 
-        return [w_u_b, b_u_b, w_l_b, b_l_b]
+        return [w_b, b_b, w_b, b_b]
 
 
 class BackwardInputLayer(BackwardLayer):

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -2,8 +2,10 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import keras
-from keras.layers import Layer, Wrapper
+import numpy as np
+from keras.layers import InputLayer, Layer, Wrapper
 
+from decomon.backward_layers.utils import get_identity_lirpa_shapes
 from decomon.core import (
     BoxDomain,
     ForwardMode,
@@ -89,6 +91,42 @@ class BackwardLayer(ABC, Wrapper):
         """
         # generic case: nothing to do before call
         pass
+
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+        """Compute expected output shape according to input shape
+
+        Will be called by symbolic calls on Keras Tensors.
+
+        Args:
+            input_shape
+
+        Returns:
+
+        """
+        if isinstance(self.layer, DecomonLayer):
+            decomon_input_shape = [inp.shape for inp in self.layer.input]
+            decomon_output_shape = [out.shape for out in self.layer.output]
+            keras_output_shape = self.inputs_outputs_spec.get_kerasinputshape_from_inputshapesformode(
+                decomon_output_shape
+            )
+            keras_input_shape = self.inputs_outputs_spec.get_kerasinputshape_from_inputshapesformode(
+                decomon_input_shape
+            )
+        else:  # Keras layer
+            keras_output_shape = self.layer.output.shape
+            if isinstance(self.layer, InputLayer):
+                keras_input_shape = keras_output_shape
+            else:
+                keras_input_shape = self.layer.input.shape
+
+        batch_size = keras_input_shape[0]
+        flattened_keras_output_shape = int(np.prod(keras_output_shape[1:]))  # type: ignore
+        flattened_keras_input_shape = int(np.prod(keras_input_shape[1:]))  # type: ignore
+
+        b_shape = batch_size, flattened_keras_output_shape
+        w_shape = batch_size, flattened_keras_input_shape, flattened_keras_output_shape
+
+        return [w_shape, b_shape, w_shape, b_shape]
 
     def freeze_weights(self) -> None:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from keras.layers import (
 )
 from keras.models import Model, Sequential
 from numpy.testing import assert_almost_equal
+from pytest_cases import fixture, fixture_union, param_fixture
 
 from decomon.core import ForwardMode, Slope
 from decomon.keras_utils import (
@@ -95,9 +96,7 @@ def activation(request):
     return request.param
 
 
-@pytest.fixture(params=["channels_last", "channels_first"])
-def data_format(request):
-    return request.param
+data_format = param_fixture(argname="data_format", argvalues=["channels_last", "channels_first"])
 
 
 @pytest.fixture(params=[0, 1])
@@ -1607,3 +1606,66 @@ def toy_model(request, helpers):
 def toy_model_1d(request, helpers):
     model_name = request.param
     return helpers.toy_model(model_name, dtype=keras_config.floatx())
+
+
+@fixture()
+def decomon_inputs_1d(n, mode, dc_decomp, helpers):
+    # tensors inputs
+    inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_1d_box(n=n, dc_decomp=dc_decomp)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
+
+    # inputs metadata worth to pass to the layer
+    inputs_metadata = dict()
+
+    return inputs, inputs_for_mode, input_ref, inputs_, inputs_for_mode_, input_ref_, inputs_metadata
+
+
+@fixture()
+def decomon_inputs_multid(odd, mode, dc_decomp, helpers):
+    # tensors inputs
+    inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_multid_box(odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
+
+    # inputs metadata worth to pass to the layer
+    inputs_metadata = dict()
+
+    return inputs, inputs_for_mode, input_ref, inputs_, inputs_for_mode_, input_ref_, inputs_metadata
+
+
+@fixture()
+def decomon_inputs_images(data_format, mode, dc_decomp, helpers):
+    odd, m_0, m_1 = 0, 0, 1
+
+    # tensors inputs
+    inputs = helpers.get_tensor_decomposition_images_box(data_format=data_format, odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = helpers.get_standard_values_images_box(data_format=data_format, odd=odd, dc_decomp=dc_decomp)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
+
+    # inputs metadata worth to pass to the layer
+    inputs_metadata = dict(data_format=data_format)
+
+    return inputs, inputs_for_mode, input_ref, inputs_, inputs_for_mode_, input_ref_, inputs_metadata
+
+
+decomon_inputs = fixture_union(
+    "decomon_inputs",
+    [decomon_inputs_1d, decomon_inputs_multid, decomon_inputs_images],
+    unpack_into="inputs, inputs_for_mode, input_ref, inputs_, inputs_for_mode_, input_ref_, inputs_metadata",
+)

--- a/tests/test_backward_compute_output_shape.py
+++ b/tests/test_backward_compute_output_shape.py
@@ -1,0 +1,113 @@
+import pytest
+from keras.layers import Activation, InputLayer, Reshape
+
+from decomon.backward_layers.convert import to_backward
+from decomon.layers.core import DecomonLayer
+from decomon.layers.decomon_layers import (
+    DecomonActivation,
+    DecomonBatchNormalization,
+    DecomonConv2D,
+    DecomonDense,
+    DecomonFlatten,
+)
+from decomon.layers.decomon_merge_layers import DecomonAdd, DecomonConcatenate
+from decomon.layers.decomon_reshape import DecomonReshape
+from decomon.layers.maxpooling import DecomonMaxPooling2D
+
+try:
+    import deel.lip
+except ImportError:
+    deel_lip_available = False
+    DecomonGroupSort2 = "DecomonGroupSort2"
+else:
+    deel_lip_available = True
+    from decomon.layers.deel_lip import DecomonGroupSort2
+
+
+@pytest.mark.parametrize(
+    "layer_class, layer_kwargs",
+    [
+        (DecomonDense, dict(units=3, use_bias=True)),
+        (DecomonFlatten, dict()),
+        (DecomonBatchNormalization, dict(center=True, scale=True)),
+        (DecomonBatchNormalization, dict(center=False, scale=False)),
+        (DecomonActivation, dict(activation="linear")),
+        (DecomonActivation, dict(activation="relu")),
+        (Activation, dict(activation="linear")),
+        (Activation, dict(activation="relu")),
+        (DecomonConv2D, dict(filters=10, kernel_size=(3, 3), data_format="channels_last")),
+        (DecomonReshape, dict(target_shape=(1, -1, 1))),
+        (Reshape, dict(target_shape=(1, -1, 1))),
+        (DecomonGroupSort2, dict()),
+    ],
+)
+@pytest.mark.parametrize(
+    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
+    [
+        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
+        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
+        (
+            "get_tensor_decomposition_images_box",
+            dict(odd=0, data_format="channels_last"),
+            "get_standard_values_images_box",
+            dict(odd=0, data_format="channels_last"),
+        ),
+    ],
+)
+def test_compute_output_shape(
+    helpers,
+    mode,
+    layer_class,
+    layer_kwargs,
+    kerastensor_inputs_fn_name,
+    kerastensor_inputs_kwargs,
+    np_inputs_fn_name,
+    np_inputs_kwargs,
+):
+    dc_decomp = False
+    if (layer_class == DecomonBatchNormalization or layer_class == DecomonMaxPooling2D) and dc_decomp:
+        pytest.skip(f"{layer_class} with dc_decomp=True not yet implemented.")
+    if (
+        layer_class == DecomonConv2D or layer_class == DecomonMaxPooling2D
+    ) and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box":
+        pytest.skip(f"{layer_class} applies only on image-like inputs.")
+    if layer_class == DecomonGroupSort2:
+        if not deel_lip_available:
+            pytest.skip("deel-lip is not available")
+
+    # contruct inputs functions
+    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
+    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
+    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
+    np_inputs_kwargs["dc_decomp"] = dc_decomp
+
+    # tensors inputs
+    inputs = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    inputs_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = np_inputs_fn(**np_inputs_kwargs)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+
+    # construct and build original layer (decomon or keras)
+    if issubclass(layer_class, DecomonLayer):
+        layer = layer_class(mode=mode, dc_decomp=dc_decomp, **layer_kwargs)
+        layer(inputs_for_mode)
+    else:  # keras layer
+        layer = layer_class(**layer_kwargs)
+        layer(inputs_ref)
+
+    # get backward layer
+    backward_layer = to_backward(layer, mode=mode)
+
+    # check symbolic tensor output shapes
+    inputshapes = [i.shape for i in inputs_for_mode]
+    outputshapes = backward_layer.compute_output_shape(inputshapes)
+    outputs = backward_layer(inputs_for_mode)
+    assert [o.shape for o in outputs] == outputshapes
+
+    # check output shapes for concrete call
+    outputs_ = backward_layer(inputs_for_mode_)
+    # compare without batch sizes
+    assert [tuple(o.shape)[1:] for o in outputs_] == [s[1:] for s in outputshapes]

--- a/tests/test_backward_layer_wo_merge.py
+++ b/tests/test_backward_layer_wo_merge.py
@@ -1,0 +1,144 @@
+import keras.config as keras_config
+import numpy as np
+import pytest
+from keras.layers import (
+    Activation,
+    BatchNormalization,
+    Conv2D,
+    Dense,
+    Dropout,
+    Flatten,
+    Input,
+    MaxPooling2D,
+    Permute,
+    Reshape,
+)
+from keras.ops import convert_to_numpy
+from keras.src.layers.merging.dot import batch_dot
+
+from decomon.backward_layers.convert import to_backward
+from decomon.core import ForwardMode
+from decomon.layers.core import DecomonLayer
+from decomon.layers.decomon_layers import DecomonDense
+
+
+@pytest.mark.parametrize(
+    "layer_class, layer_kwargs",
+    [
+        (Dense, dict(units=3, use_bias=True)),
+        (Dense, dict(units=3, use_bias=False)),
+        (Activation, dict(activation="linear")),
+        (Activation, dict(activation="relu")),
+        (Reshape, dict(target_shape=(1, -1, 1))),
+        (BatchNormalization, dict()),
+        (BatchNormalization, dict(axis=1)),
+        (BatchNormalization, dict(center=False, scale=False)),
+        (BatchNormalization, dict(axis=2, center=False)),
+        (BatchNormalization, dict(axis=3)),
+        (Conv2D, dict(filters=10, kernel_size=(3, 3), data_format="channels_last")),
+        (Flatten, dict()),
+        (Dropout, dict(rate=0.9)),
+        (Permute, dict(dims=(1,))),
+        (Permute, dict(dims=(2, 1, 3))),
+    ],
+)
+@pytest.mark.parametrize(
+    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
+    [
+        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
+        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
+        (
+            "get_tensor_decomposition_images_box",
+            dict(odd=0, data_format="channels_last"),
+            "get_standard_values_images_box",
+            dict(odd=0, data_format="channels_last"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("randomize_weights", [False, True])
+def test_backward_layer(
+    helpers,
+    mode,
+    layer_class,
+    layer_kwargs,
+    kerastensor_inputs_fn_name,
+    kerastensor_inputs_kwargs,
+    np_inputs_fn_name,
+    np_inputs_kwargs,
+    randomize_weights,
+):
+    # skip nonsensical combinations
+    if (
+        layer_class is BatchNormalization
+        and "axis" in layer_kwargs
+        and layer_kwargs["axis"] > 1
+        and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box"
+    ):
+        pytest.skip("batchnormalization on axis>1 possible only for image-like data")
+    if layer_class in (Conv2D, MaxPooling2D) and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box":
+        pytest.skip("convolution and maxpooling2d possible only for image-like data")
+    if (
+        layer_class is Permute
+        and len(layer_kwargs["dims"]) < 3
+        and kerastensor_inputs_fn_name == "get_tensor_decomposition_images_box"
+    ):
+        pytest.skip("1d permutation not possible for image-like data")
+    if (
+        layer_class is Permute
+        and len(layer_kwargs["dims"]) == 3
+        and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box"
+    ):
+        pytest.skip("3d permutation possible only for image-like data")
+
+    dc_decomp = False
+    decimal = 4
+
+    # contruct inputs functions
+    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
+    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
+    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
+    np_inputs_kwargs["dc_decomp"] = dc_decomp
+
+    # tensors inputs
+    inputs = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
+    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
+
+    # numpy inputs
+    inputs_ = np_inputs_fn(**np_inputs_kwargs)
+    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+    input_ref_ = helpers.get_input_ref_from_full_inputs(inputs_)
+
+    # construct and build original layer (keras)
+    layer = layer_class(**layer_kwargs)
+    output_ref = layer(input_ref)
+    f_ref = helpers.function(inputs, output_ref)
+
+    # randomize weights
+    if randomize_weights:
+        for weight in layer.weights:
+            weight.assign(np.random.random(tuple(weight.shape)))
+
+    # get backward layer & function
+    backward_layer = to_backward(layer, mode=mode)
+    outputs = backward_layer(inputs_for_mode)
+    f_backward = helpers.function(inputs, outputs)
+
+    # keras & decomon outputs
+    output_ref_ = f_ref(inputs_)
+    outputs_ = f_backward(inputs_)
+
+    # flattened keras inputs/outputs
+    input_ref_flat_ = np.reshape(input_ref_, (input_ref_.shape[0], -1))
+    output_ref_flat_ = np.reshape(output_ref_, (output_ref_.shape[0], -1))
+
+    # check bounds consistency
+    w_u_out_, b_u_out_, w_l_out_, b_l_out_ = outputs_
+    upper_ = convert_to_numpy(batch_dot(w_u_out_, input_ref_flat_, axes=(-2, -1))) + b_u_out_  # batch mult
+    lower_ = convert_to_numpy(batch_dot(w_l_out_, input_ref_flat_, axes=(-2, -1))) + b_l_out_  # batch mult
+    np.testing.assert_almost_equal(
+        np.clip(lower_ - output_ref_flat_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_min >x_"
+    )
+    np.testing.assert_almost_equal(
+        np.clip(output_ref_flat_ - upper_, 0, np.inf), 0.0, decimal=decimal, err_msg="x_max < x_"
+    )

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -20,6 +20,7 @@ def test_Backward_Activation_1D_box_model(n, activation, mode, floatx, decimal, 
 
     # decomon layer
     decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=keras_config.floatx())
+    decomon_layer(inputs_for_mode)  # build it
 
     # get backward layer
     backward_layer = to_backward(decomon_layer)
@@ -52,6 +53,7 @@ def test_Backward_Activation_1D_box_model_slope(helpers):
 
     #  decomon layer
     decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=keras_config.floatx())
+    decomon_layer(inputs_for_mode)  # build it
 
     # to_backward with a given slope => outputs
     outputs_by_slope = {}
@@ -86,6 +88,7 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, decimal, mode, 
 
     #  decomon layer
     decomon_layer = DecomonActivation(activation, dc_decomp=dc_decomp, mode=mode, dtype=keras_config.floatx())
+    decomon_layer(inputs_for_mode)  # build it
 
     # get backward layer
     backward_layer = to_backward(decomon_layer)
@@ -118,6 +121,7 @@ def test_Backward_Flatten_multiD_box(odd, floatx, decimal, mode, data_format, he
 
     #  decomon layer
     decomon_layer = DecomonFlatten(data_format, dc_decomp=dc_decomp, mode=mode, dtype=keras_config.floatx())
+    decomon_layer(inputs_for_mode)  # build it
 
     # get backward layer
     backward_layer = to_backward(decomon_layer)
@@ -147,6 +151,7 @@ def test_Backward_Reshape_multiD_box(odd, floatx, decimal, mode, helpers):
 
     #  decomon layer
     decomon_layer = DecomonReshape((-1,), dc_decomp=dc_decomp, mode=mode, dtype=keras_config.floatx())
+    decomon_layer(inputs_for_mode)  # build it
 
     # get backward layer
     backward_layer = to_backward(decomon_layer)

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -11,12 +11,14 @@ def test_Backward_NativeActivation_1D_box_model(n, activation, mode, floatx, dec
     #  tensor inputs
     inputs = helpers.get_tensor_decomposition_1d_box(dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
     # numpy inputs
     inputs_ = helpers.get_standard_values_1d_box(n, dc_decomp=dc_decomp)
 
     # keras layer
     keras_layer = Activation(activation, dtype=keras_config.floatx())
+    keras_layer(input_ref)  # build it
 
     # get backward layer
     backward_layer = to_backward(keras_layer, mode=mode)
@@ -40,12 +42,14 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, decimal, 
     #  tensor inputs
     inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
     # numpy inputs
     inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
     # keras layer
     keras_layer = Activation(activation, dtype=keras_config.floatx())
+    keras_layer(input_ref)  # build it
 
     # get backward layer
     backward_layer = to_backward(keras_layer, mode=mode)
@@ -72,12 +76,14 @@ def test_Backward_NativeFlatten_multiD_box(odd, floatx, decimal, mode, data_form
     #  tensor inputs
     inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
     # numpy inputs
     inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
     # keras layer
     keras_layer = Flatten(data_format, dtype=keras_config.floatx())
+    keras_layer(input_ref)  # build it
 
     # get backward layer
     backward_layer = to_backward(keras_layer, mode=mode)
@@ -101,12 +107,14 @@ def test_Backward_NativeReshape_multiD_box(odd, floatx, decimal, mode, helpers):
     #  tensor inputs
     inputs = helpers.get_tensor_decomposition_multid_box(odd=odd, dc_decomp=dc_decomp)
     inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
+    input_ref = helpers.get_input_ref_from_full_inputs(inputs)
 
     # numpy inputs
     inputs_ = helpers.get_standard_values_multid_box(odd, dc_decomp=dc_decomp)
 
     # keras layer
     keras_layer = Reshape((-1,), dtype=keras_config.floatx())
+    keras_layer(input_ref)  # build it
 
     # get backward layer
     backward_layer = to_backward(keras_layer, mode=mode)

--- a/tests/test_decomon_compute_output_shape.py
+++ b/tests/test_decomon_compute_output_shape.py
@@ -27,59 +27,38 @@ else:
         (DecomonFlatten, dict()),
         (DecomonBatchNormalization, dict(center=True, scale=True)),
         (DecomonBatchNormalization, dict(center=False, scale=False)),
-        (DecomonConv2D, dict(filters=10, kernel_size=(3, 3), data_format="channels_last")),
+        (DecomonConv2D, dict(filters=10, kernel_size=(3, 3))),
         (DecomonMaxPooling2D, dict(pool_size=(2, 2), strides=(2, 2), padding="valid")),
         (DecomonReshape, dict(target_shape=(1, -1, 1))),
         (DecomonGroupSort2, dict()),
     ],
 )
-@pytest.mark.parametrize(
-    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
-    [
-        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
-        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
-        (
-            "get_tensor_decomposition_images_box",
-            dict(odd=0, data_format="channels_last"),
-            "get_standard_values_images_box",
-            dict(odd=0, data_format="channels_last"),
-        ),
-    ],
-)
+@pytest.mark.parametrize("n", [0])  # limit 1d cases
+@pytest.mark.parametrize("odd", [0])  # limit multid cases
+@pytest.mark.parametrize("data_format", ["channels_last"])  # limit images cases
 def test_compute_output_shape(
     helpers,
     mode,
     dc_decomp,
     layer_class,
     layer_kwargs,
-    kerastensor_inputs_fn_name,
-    kerastensor_inputs_kwargs,
-    np_inputs_fn_name,
-    np_inputs_kwargs,
+    inputs_for_mode,  # decomon inputs: symbolic tensors
+    input_ref,  # keras input: symbolic tensor
+    inputs_for_mode_,  # decomon inputs: numpy arrays
+    inputs_metadata,  # inputs metadata: data_format, ...
 ):
+    # skip nonsensical combinations
     if (layer_class == DecomonBatchNormalization or layer_class == DecomonMaxPooling2D) and dc_decomp:
         pytest.skip(f"{layer_class} with dc_decomp=True not yet implemented.")
-    if (
-        layer_class == DecomonConv2D or layer_class == DecomonMaxPooling2D
-    ) and kerastensor_inputs_fn_name != "get_tensor_decomposition_images_box":
+    if (layer_class == DecomonConv2D or layer_class == DecomonMaxPooling2D) and len(input_ref.shape) < 4:
         pytest.skip(f"{layer_class} applies only on image-like inputs.")
     if layer_class == DecomonGroupSort2:
         if not deel_lip_available:
             pytest.skip("deel-lip is not available")
 
-    # contruct inputs functions
-    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
-    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
-    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
-    np_inputs_kwargs["dc_decomp"] = dc_decomp
-
-    # tensors inputs
-    inputs = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
-    inputs_for_mode = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs, mode=mode, dc_decomp=dc_decomp)
-
-    # numpy inputs
-    inputs_ = np_inputs_fn(**np_inputs_kwargs)
-    inputs_for_mode_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_, mode=mode, dc_decomp=dc_decomp)
+    # add data_format for convolution and maxpooling
+    if layer_class in (DecomonConv2D, DecomonMaxPooling2D):
+        layer_kwargs["data_format"] = inputs_metadata["data_format"]
 
     # construct layer
     layer = layer_class(mode=mode, dc_decomp=dc_decomp, **layer_kwargs)
@@ -103,63 +82,37 @@ def test_compute_output_shape(
         (DecomonConcatenate, dict()),
     ],
 )
-@pytest.mark.parametrize(
-    "kerastensor_inputs_fn_name, kerastensor_inputs_kwargs, np_inputs_fn_name, np_inputs_kwargs",
-    [
-        ("get_tensor_decomposition_1d_box", dict(), "get_standard_values_1d_box", dict(n=0)),
-        ("get_tensor_decomposition_multid_box", dict(odd=0), "get_standard_values_multid_box", dict(odd=0)),
-        (
-            "get_tensor_decomposition_images_box",
-            dict(odd=0, data_format="channels_last"),
-            "get_standard_values_images_box",
-            dict(odd=0, data_format="channels_last"),
-        ),
-    ],
-)
+@pytest.mark.parametrize("n", [0])  # limit 1d cases
+@pytest.mark.parametrize("odd", [0])  # limit multid cases
+@pytest.mark.parametrize("data_format", ["channels_last"])  # limit images cases
 def test_merge_layers_compute_output_shape(
     helpers,
     mode,
     dc_decomp,
     layer_class,
     layer_kwargs,
-    kerastensor_inputs_fn_name,
-    kerastensor_inputs_kwargs,
-    np_inputs_fn_name,
-    np_inputs_kwargs,
+    inputs_for_mode,  # decomon inputs: symbolic tensors
+    inputs_for_mode_,  # decomon inputs: numpy arrays
 ):
     if dc_decomp:
         pytest.skip(f"{layer_class} with dc_decomp=True not yet implemented.")
 
-    # contruct inputs functions
-    kerastensor_inputs_fn = getattr(helpers, kerastensor_inputs_fn_name)
-    kerastensor_inputs_kwargs["dc_decomp"] = dc_decomp
-    np_inputs_fn = getattr(helpers, np_inputs_fn_name)
-    np_inputs_kwargs["dc_decomp"] = dc_decomp
-
     # tensors inputs
-    inputs_1 = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
-    inputs_for_mode_1 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1, mode=mode, dc_decomp=dc_decomp)
-    inputs_2 = kerastensor_inputs_fn(**kerastensor_inputs_kwargs)
-    inputs_for_mode_2 = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_2, mode=mode, dc_decomp=dc_decomp)
-    inputs_for_mode = inputs_for_mode_1 + inputs_for_mode_2
+    concatenated_inputs_for_mode = inputs_for_mode + inputs_for_mode
 
     # numpy inputs
-    inputs_1_ = np_inputs_fn(**np_inputs_kwargs)
-    inputs_for_mode_1_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_1_, mode=mode, dc_decomp=dc_decomp)
-    inputs_2_ = np_inputs_fn(**np_inputs_kwargs)
-    inputs_for_mode_2_ = helpers.get_inputs_for_mode_from_full_inputs(inputs=inputs_2_, mode=mode, dc_decomp=dc_decomp)
-    inputs_for_mode_ = inputs_for_mode_1_ + inputs_for_mode_2_
+    concatenated_inputs_for_mode_ = inputs_for_mode_ + inputs_for_mode_
 
     # construct layer
     layer = layer_class(mode=mode, dc_decomp=dc_decomp, **layer_kwargs)
 
     # check symbolic tensor output shapes
-    inputshapes = [i.shape for i in inputs_for_mode]
+    inputshapes = [i.shape for i in concatenated_inputs_for_mode]
     outputshapes = layer.compute_output_shape(inputshapes)
-    outputs = layer(inputs_for_mode)
+    outputs = layer(concatenated_inputs_for_mode)
     assert [o.shape for o in outputs] == outputshapes
 
     # check output shapes for concrete call
-    outputs_ = layer(inputs_for_mode_)
+    outputs_ = layer(concatenated_inputs_for_mode_)
     # compare without batch sizes
     assert [tuple(o.shape)[1:] for o in outputs_] == [s[1:] for s in outputshapes]

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ platform = linux: linux
            win: win32
 deps =
     pytest
+    pytest-cases
     !nodeellip: deel-lip
     py39-linux-tf-nodeellip: pytest-cov
     tf: tensorflow>=2.15  # backend for keras 3


### PR DESCRIPTION
- Add a generic compute_output_shape() to allow simple call when dealing with symbolic tensors
- Add a test for compute_output_shape() with backward layers
- Add a test on backward layers outputs without having to merge them with previous backward bounds
- Fix BackwardBatchNormalization
- Fix BackwardDense in case of image-like inputs
- Use pytest-cases to simplify the parametrization of backward layers test

More about testing directly backward layers:

The backward layers are supposed to output lower and upper affine bounds of the action of the original keras layer on the **flatten** keras inputs (knowing some prebounds on the inputs).
    
So we can check that
    
    w_l_out * flatten_keras_input + b_l_out <= flatten_keras_output
    w_u_out * flatten_keras_input + b_u_out >= flatten_keras_output
    
(equality if linear opreation).