### PR TITLE
Test data_format="channels_first" with pytorch

### DIFF
--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -179,7 +179,10 @@ class BackwardConv2D(BackwardLayer):
 
         if self.layer.use_bias:
             bias_ = K.cast(self.layer.bias, self.layer.dtype)
-            b_out_u_ = b_out_u_ + bias_[None]
+            if self.layer.data_format == "channels_last":
+                b_out_u_ = b_out_u_ + bias_[None]
+            else:
+                b_out_u_ = b_out_u_ + bias_[:, None]
         b_out_u_ = K.ravel(b_out_u_)
 
         z_value = K.cast(0.0, self.dtype)

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -11,8 +11,8 @@ from decomon.layers.decomon_layers import DecomonConv2D
 
 def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal, helpers):
     # skip unavailable combinations
-    if floatx == 16 and keras_config.backend() == "torch":
-        pytest.skip("Pytorch does not implement conv2d for float16")
+    if floatx == 16 and keras_config.backend() == "torch" and not helpers.in_GPU_mode():
+        pytest.skip("Pytorch does not implement conv2d for float16 in CPU mode.")
 
     if data_format == "channels_first" and not helpers.in_GPU_mode() and keras_config.backend() == "tensorflow":
         pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow.")

--- a/tests/test_backward_conv.py
+++ b/tests/test_backward_conv.py
@@ -14,8 +14,8 @@ def test_Decomon_conv_box(data_format, padding, use_bias, mode, floatx, decimal,
     if floatx == 16 and keras_config.backend() == "torch":
         pytest.skip("Pytorch does not implement conv2d for float16")
 
-    if data_format == "channels_first" and not helpers.in_GPU_mode() and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode in CPU mode.")
+    if data_format == "channels_first" and not helpers.in_GPU_mode() and keras_config.backend() == "tensorflow":
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow.")
 
     odd, m_0, m_1 = 0, 0, 1
     dc_decomp = False

--- a/tests/test_backward_layers.py
+++ b/tests/test_backward_layers.py
@@ -104,8 +104,8 @@ def test_Backward_Activation_multiD_box(odd, activation, floatx, decimal, mode, 
 
 
 def test_Backward_Flatten_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
-    if data_format == "channels_first" and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+    if data_format == "channels_first" and not helpers.in_GPU_mode() and keras_config.backend() == "tensorflow":
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow.")
 
     dc_decomp = False
 

--- a/tests/test_backward_native_layers.py
+++ b/tests/test_backward_native_layers.py
@@ -64,8 +64,8 @@ def test_Backward_NativeActivation_multiD_box(odd, activation, floatx, decimal, 
 
 
 def test_Backward_NativeFlatten_multiD_box(odd, floatx, decimal, mode, data_format, helpers):
-    if data_format == "channels_first" and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+    if data_format == "channels_first" and not helpers.in_GPU_mode() and keras_config.backend() == "tensorflow":
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow.")
 
     dc_decomp = False
 

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -16,8 +16,8 @@ def test_Decomon_conv_box(data_format, mode, dc_decomp, floatx, decimal, helpers
     if floatx == 16 and keras_config.backend() == "torch" and not helpers.in_GPU_mode():
         pytest.skip("Pytorch does not implement conv2d for float16 in CPU mode.")
 
-    if data_format == "channels_first" and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+    if data_format == "channels_first" and not helpers.in_GPU_mode() and keras_config.backend() == "tensorflow":
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow.")
 
     odd, m_0, m_1 = 0, 0, 1
     kwargs_layer = dict(filters=10, kernel_size=(3, 3), dtype=keras_config.floatx(), data_format=data_format)

--- a/tests/test_utils_conv.py
+++ b/tests/test_utils_conv.py
@@ -20,8 +20,8 @@ def test_toeplitz_from_Keras(channels, filter_size, strides, flatten, data_forma
     if floatx == 16:
         decimal = 0
 
-    if data_format == "channels_first" and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+    if data_format == "channels_first" and keras.config.backend() == "tensorflow" and not helpers.in_GPU_mode():
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow")
 
     dc_decomp = False
     odd, m_0, m_1 = 0, 0, 1
@@ -75,8 +75,8 @@ def test_toeplitz_from_Decomon(
     if floatx == 16 and keras.config.backend() == "torch" and not helpers.in_GPU_mode():
         pytest.skip("Pytorch does not implement conv2d for float16 in CPU mode.")
 
-    if data_format == "channels_first" and not helpers.in_GPU_mode():
-        pytest.skip("data format 'channels first' is possible only in GPU mode")
+    if data_format == "channels_first" and keras.config.backend() == "tensorflow" and not helpers.in_GPU_mode():
+        pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow")
 
     odd, m_0, m_1 = 0, 0, 1
     if floatx == 16:

--- a/tests/test_utils_conv.py
+++ b/tests/test_utils_conv.py
@@ -23,6 +23,9 @@ def test_toeplitz_from_Keras(channels, filter_size, strides, flatten, data_forma
     if data_format == "channels_first" and keras.config.backend() == "tensorflow" and not helpers.in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow")
 
+    if data_format == "channels_first":
+        pytest.xfail("get_toeplitz with channels_first is bugged for now.")
+
     dc_decomp = False
     odd, m_0, m_1 = 0, 0, 1
 
@@ -77,6 +80,9 @@ def test_toeplitz_from_Decomon(
 
     if data_format == "channels_first" and keras.config.backend() == "tensorflow" and not helpers.in_GPU_mode():
         pytest.skip("data format 'channels first' is possible only in GPU mode for tensorflow")
+
+    if data_format == "channels_first":
+        pytest.xfail("get_toeplitz with channels_first is bugged for now.")
 
     odd, m_0, m_1 = 0, 0, 1
     if floatx == 16:


### PR DESCRIPTION
- unskip tests with `data_format == "channels_first"` with pytorch (implemented even on CPU as it is the default behaviour)
- xfail `get_toeplitz` tests for data_format == "channels_first" as it is bugged in this case
- fix bias shape in `BackwardConv2d.get_affine_components()`