### PR TITLE
Remove check for symbolic tensors in BatchDiag and BatchIdentityLike operations

### DIFF
--- a/src/decomon/backward_layers/backward_merge.py
+++ b/src/decomon/backward_layers/backward_merge.py
@@ -100,6 +100,19 @@ class BackwardMerge(ABC, Wrapper):
         """
         pass
 
+    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+        """Compute expected output shape according to input shape
+
+        Will be called by symbolic calls on Keras Tensors.
+
+        Args:
+            input_shape
+
+        Returns:
+
+        """
+        raise NotImplementedError()
+
     def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
         """
         Args:

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -49,12 +49,6 @@ class BatchedIdentityLike(keras.Operation):
     """
 
     def call(self, x: BackendTensor) -> Tensor:
-        if is_symbolic_tensor(x):
-            return self.compute_output_spec(x)
-        else:
-            return self._call(x)
-
-    def _call(self, x: BackendTensor) -> BackendTensor:
         input_shape = x.shape
         identity_tensor = K.identity(input_shape[-1], dtype=x.dtype)
         n_repeat = int(np.prod(input_shape[:-1]))
@@ -83,12 +77,6 @@ class BatchedDiagLike(keras.Operation):
     """
 
     def call(self, x: BackendTensor) -> Tensor:
-        if is_symbolic_tensor(x):
-            return self.compute_output_spec(x)
-        else:
-            return self._call(x)
-
-    def _call(self, x: BackendTensor) -> BackendTensor:
         return K.concatenate([K.diag(K.ravel(w_part))[None] for w_part in K.split(x, len(x), axis=0)], axis=0)
 
     def compute_output_spec(self, x: Tensor) -> keras.KerasTensor:

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -123,7 +123,7 @@ def _prepare_input_tensors(
     original_input_shapes = get_layer_input_shape(layer)
     decomon_input_shapes: List[List[Optional[int]]] = [list(input_shape[1:]) for input_shape in original_input_shapes]
     n_input = len(decomon_input_shapes)
-    x_input_shape = perturbation_domain.get_x_input_shape(input_dim)
+    x_input_shape = perturbation_domain.get_x_input_shape_wo_batchsize(input_dim)
     x_input = Input(x_input_shape, dtype=layer.dtype)
     w_input = [Input(tuple([input_dim] + decomon_input_shapes[i])) for i in range(n_input)]
     y_input = [Input(tuple(decomon_input_shapes[i])) for i in range(n_input)]

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -25,7 +25,12 @@ from decomon.keras_utils import BatchedIdentityLike
 from decomon.layers.utils import softmax_to_linear as softmax_2_linear
 from decomon.models.crown import Convert2BackwardMode, Fuse, MergeWithPrevious
 from decomon.models.forward_cloning import OutputMapDict
-from decomon.models.utils import Convert2Mode, ensure_functional_model, get_depth_dict
+from decomon.models.utils import (
+    Convert2Mode,
+    ensure_functional_model,
+    get_depth_dict,
+    get_input_dim,
+)
 from decomon.types import BackendTensor, Tensor
 
 
@@ -408,9 +413,12 @@ def convert_backward(
     layer_fn: Callable[..., BackwardLayer] = to_backward,
     final_ibp: bool = True,
     final_affine: bool = False,
+    input_dim: int = -1,
     **kwargs: Any,
 ) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], Dict[int, BackwardLayer], None]:
     model = ensure_functional_model(model)
+    if input_dim == -1:
+        input_dim = get_input_dim(model)
     if back_bounds is None:
         back_bounds = []
     if forward_map is None:
@@ -446,6 +454,7 @@ def convert_backward(
         mode_from=mode_from,
         mode_to=mode_to,
         perturbation_domain=perturbation_domain,
+        input_dim=input_dim,
     )(output)
     if mode_to != mode_from and mode_from == ForwardMode.IBP:
         f_input = Lambda(lambda z: Concatenate(1)([z[0][:, None], z[1][:, None]]))

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -23,6 +23,7 @@ from decomon.models.utils import (
     ensure_functional_model,
     get_direction,
     get_ibp_affine_from_method,
+    get_input_dim,
     get_input_tensors,
     is_input_node,
     preprocess_layer,
@@ -109,6 +110,8 @@ def convert(
     if finetune:
         finetune_forward = True
         finetune_backward = True
+    if input_dim == -1:
+        input_dim = get_input_dim(model)
 
     if isinstance(method, str):
         method = ConvertMethod(method.lower())
@@ -148,13 +151,16 @@ def convert(
             forward_map=forward_map,
             final_ibp=final_ibp,
             final_affine=final_affine,
+            input_dim=input_dim,
             **kwargs,
         )
     else:
         # check final_ibp and final_affine
         mode_from = get_mode(ibp, affine)
         mode_to = get_mode(final_ibp, final_affine)
-        output = Convert2Mode(mode_from=mode_from, mode_to=mode_to, perturbation_domain=perturbation_domain)(output)
+        output = Convert2Mode(
+            mode_from=mode_from, mode_to=mode_to, perturbation_domain=perturbation_domain, input_dim=input_dim
+        )(output)
 
     # build decomon model
     return input_tensors, output, layer_map, forward_map


### PR DESCRIPTION
Since we implement `compute_output_shape()`, we do not need anymore to manage symbolic tensors in `call()`.

Actually some `compute_output_shape()` from layers using `BatchDiag` and `BatchIdentityLike` was missing, namely `MergeWithPrevious`, `ConvertMode`, and `BackwardMerge` layers. So we add them.

About computing the output shape of `ConvertMode`:
 - We compute the theoretic shapes of missing shapes in `InputsOutputsSpec.get_fullinputshapes_from_inputshapesformode()
` 
- For that (to compute `x_shape` in ibp mode) we need to know the model input shape, in order to use `perturbation_domain.get_x_input_shape_wo_batchsize()` (renamed from `get_x_input_shape()`) -> we add it as an attribute of `InputsOutputsSpec`
- We make use of `InputsOutputsSpec.get_fullinputshapes_from_inputshapesformode() `and `.extract_inputshapesformode_from_fullinputshapes()` to compute the output shapes of `ConvertMode`
- Thus we need to pass model input shape in `ConvertMode.__init__()`
- We add this model input dim in the convert functions calling `ConvertMode` (this was computed from the model in inner functions anyway)

About backward merge layers: the backward conversion is not ready yet for merge layers so we simply raise a NotImplementedError in their `compute_output_shape()`.
