### PR TITLE
Fix dependencies conflict between tensorflow and decomon in binder env

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,6 +9,6 @@ dependencies:
       - pandas
       - scipy
       - tensorboard>=2.13
-      - tensorflow>=2.15
+#      - tensorflow>=2.15  # conflicting dependencies with decomon (keras 2)
       - jupyter-server-proxy
       - ..  # decomon

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,5 @@
+# install tensorflow backend separately from decomon (dependencies conflict as tf 2.15 requires keras 2)
+pip install tensorflow>=2.15
 # use keras 3 instead of keras 2 installed by tensorflow
 pip uninstall -y keras
 pip install "keras>=3"


### PR DESCRIPTION
We cannot install decomon with tensorflow 2.15 at the same time as pip does not how to solve the conflict:
- tensorflow 2.15 => keras 2.15
- decomon => keras >= 3