### PR TITLE
Pin pytest to <8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ platform = linux: linux
            macos: darwin
            win: win32
 deps =
-    pytest
+    pytest<8
     pytest-cases
     py39-linux-tf: pytest-cov
     tf: tensorflow>=2.15  # backend for keras 3


### PR DESCRIPTION
There are breaking changes in pytest 8.0.0 that are not yet compatible with pytest-cases fixtures: https://github.com/smarie/python-pytest-cases/issues/330