### PR TITLE
Simplify annotations as python>=3.9

### DIFF
--- a/docs/generate_nb_index.py
+++ b/docs/generate_nb_index.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import urllib.parse
-from typing import List, Tuple
 
 NOTEBOOKS_LIST_PLACEHOLDER = "[[notebooks-list]]"
 NOTEBOOKS_PAGE_TEMPLATE_RELATIVE_PATH = "tutorials.template.md"
@@ -25,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def extract_notebook_title_n_description(
     notebook_filepath: str,
-) -> Tuple[str, List[str]]:
+) -> tuple[str, list[str]]:
     # load notebook
     with open(notebook_filepath, "rt", encoding="utf-8") as f:
         notebook = json.load(f)
@@ -33,7 +32,7 @@ def extract_notebook_title_n_description(
     # find title + description: from first cell,  h1 title + remaining text.
     # or title from filename else
     title = ""
-    description_lines: List[str] = []
+    description_lines: list[str] = []
     cell = notebook["cells"][0]
     if cell["cell_type"] == "markdown":
         firstline = cell["source"][0].strip()
@@ -51,7 +50,7 @@ def extract_notebook_title_n_description(
     return title, description_lines
 
 
-def filter_tags_from_description(description_lines: List[str], html_tag_to_remove: str) -> List[str]:
+def filter_tags_from_description(description_lines: list[str], html_tag_to_remove: str) -> list[str]:
     description = "".join(description_lines)
     # opening/closing tags
     opening_tag = html_tag_to_remove
@@ -147,7 +146,7 @@ def get_binder_link(
     return link
 
 
-def get_repo_n_branches_for_binder_n_github_links() -> Tuple[bool, str, str, str, str, str, bool]:
+def get_repo_n_branches_for_binder_n_github_links() -> tuple[bool, str, str, str, str, str, bool]:
     # repos + branches to use for binder environment and notebooks content.
     creating_links = True
     use_nbgitpuller = False

--- a/src/decomon/backward_layers/activations.py
+++ b/src/decomon/backward_layers/activations.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -39,7 +40,7 @@ LINEAR = "linear"
 
 
 def backward_relu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     alpha: float = 0.0,
@@ -48,7 +49,7 @@ def backward_relu(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of relu
 
     Args:
@@ -87,13 +88,13 @@ def backward_relu(
 
 
 def backward_sigmoid(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of sigmoid
 
     Args:
@@ -118,13 +119,13 @@ def backward_sigmoid(
 
 
 def backward_tanh(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of tanh
 
     Args:
@@ -149,13 +150,13 @@ def backward_tanh(
 
 
 def backward_hard_sigmoid(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of hard sigmoid
 
     Args:
@@ -178,13 +179,13 @@ def backward_hard_sigmoid(
 
 
 def backward_elu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of Exponential Linear Unit
 
     Args:
@@ -208,13 +209,13 @@ def backward_elu(
 
 
 def backward_selu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPA of Scaled Exponential Linear Unit (SELU)
 
     Args:
@@ -238,13 +239,13 @@ def backward_selu(
 
 
 def backward_linear(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPA of linear
 
     Args:
@@ -265,13 +266,13 @@ def backward_linear(
 
 
 def backward_exponential(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPAof exponential
 
     Args:
@@ -294,13 +295,13 @@ def backward_exponential(
 
 
 def backward_softplus(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPA of softplus
 
     Args:
@@ -325,13 +326,13 @@ def backward_softplus(
 
 
 def backward_softsign(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPA of softsign
 
     Args:
@@ -359,7 +360,7 @@ def backward_softsign(
 
 
 def backward_softsign_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -368,7 +369,7 @@ def backward_softsign_(
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     w_u_0, b_u_0, w_l_0, b_l_0 = get_linear_hull_s_shape(
@@ -391,14 +392,14 @@ def backward_softsign_(
 
 
 def backward_softmax(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward LiRPA of softmax
 
     Args:
@@ -422,7 +423,7 @@ def backward_softmax(
     raise NotImplementedError()
 
 
-def deserialize(name: str) -> Callable[..., List[Tensor]]:
+def deserialize(name: str) -> Callable[..., list[Tensor]]:
     """Get the activation from name.
 
     Args:
@@ -457,7 +458,7 @@ def deserialize(name: str) -> Callable[..., List[Tensor]]:
     raise ValueError("Could not interpret " "activation function identifier:", name)
 
 
-def get(identifier: Any) -> Callable[..., List[Tensor]]:
+def get(identifier: Any) -> Callable[..., list[Tensor]]:
     """Get the `identifier` activation function.
 
     Args:

--- a/src/decomon/backward_layers/backward_layers.py
+++ b/src/decomon/backward_layers/backward_layers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -65,7 +65,7 @@ class BackwardDense(BackwardLayer):
             )
         self.frozen_weights = False
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if len(inputs) == 0:
             inputs = self.layer.input
 
@@ -96,7 +96,7 @@ class BackwardDense(BackwardLayer):
 
         return [w, b, w, b]
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape
@@ -166,7 +166,7 @@ class BackwardConv2D(BackwardLayer):
             )
         self.frozen_weights = False
 
-    def get_affine_components(self, inputs: List[BackendTensor]) -> Tuple[BackendTensor, BackendTensor]:
+    def get_affine_components(self, inputs: list[BackendTensor]) -> tuple[BackendTensor, BackendTensor]:
         """Express the implicit affine matrix of the convolution layer.
 
         Conv is a linear operator but its affine component is implicit
@@ -210,7 +210,7 @@ class BackwardConv2D(BackwardLayer):
 
         return w_out_, b_out_
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         weight_, bias_ = self.get_affine_components(inputs)
         return [weight_, bias_] * 2
 
@@ -252,13 +252,13 @@ class BackwardActivation(BackwardLayer):
         self.activation_name = layer.get_config()["activation"]
         self.slope = Slope(slope)
         self.finetune = finetune
-        self.finetune_param: List[keras.Variable] = []
+        self.finetune_param: list[keras.Variable] = []
         if self.finetune:
             self.frozen_alpha = False
-        self.grid_finetune: List[keras.Variable] = []
+        self.grid_finetune: list[keras.Variable] = []
         self.frozen_grid = False
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -268,7 +268,7 @@ class BackwardActivation(BackwardLayer):
         )
         return config
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape
@@ -371,7 +371,7 @@ class BackwardActivation(BackwardLayer):
 
         self.built = True
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         # infer the output dimension
         if self.activation_name != "linear":
             if self.finetune:
@@ -452,7 +452,7 @@ class BackwardFlatten(BackwardLayer):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return get_identity_lirpa(inputs)
 
 
@@ -477,7 +477,7 @@ class BackwardReshape(BackwardLayer):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return get_identity_lirpa(inputs)
 
 
@@ -504,7 +504,7 @@ class BackwardPermute(BackwardLayer):
         self.dims = layer.dims
         self.op = layer.call
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
 
         # w_u_out (None, n_in, n_out)
@@ -545,7 +545,7 @@ class BackwardDropout(BackwardLayer):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return get_identity_lirpa(inputs)
 
 
@@ -573,7 +573,7 @@ class BackwardBatchNormalization(BackwardLayer):
         self.axis = self.layer.axis
         self.op_flat = Flatten()
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         y = inputs[-1]
         n_out = int(np.prod(y.shape[1:]))
 
@@ -625,5 +625,5 @@ class BackwardInputLayer(BackwardLayer):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return get_identity_lirpa(inputs)

--- a/src/decomon/backward_layers/backward_maxpooling.py
+++ b/src/decomon/backward_layers/backward_maxpooling.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -14,8 +14,8 @@ from decomon.types import BackendTensor
 class BackwardMaxPooling2D(BackwardLayer):
     """Backward  LiRPA of MaxPooling2D"""
 
-    pool_size: Tuple[int, int]
-    strides: Tuple[int, int]
+    pool_size: tuple[int, int]
+    strides: tuple[int, int]
     padding: str
     data_format: str
     fast: bool
@@ -41,12 +41,12 @@ class BackwardMaxPooling2D(BackwardLayer):
 
     def _pooling_function_fast(
         self,
-        inputs: List[BackendTensor],
+        inputs: list[BackendTensor],
         w_u_out: BackendTensor,
         b_u_out: BackendTensor,
         w_l_out: BackendTensor,
         b_l_out: BackendTensor,
-    ) -> List[BackendTensor]:
+    ) -> list[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
 
         op_flat = Flatten()
@@ -79,12 +79,12 @@ class BackwardMaxPooling2D(BackwardLayer):
 
     def _pooling_function_not_fast(
         self,
-        inputs: List[BackendTensor],
+        inputs: list[BackendTensor],
         w_u_out: BackendTensor,
         b_u_out: BackendTensor,
         w_l_out: BackendTensor,
         b_l_out: BackendTensor,
-    ) -> List[BackendTensor]:
+    ) -> list[BackendTensor]:
         """
         Args:
             inputs
@@ -184,7 +184,7 @@ class BackwardMaxPooling2D(BackwardLayer):
 
         return [w_u_out, b_u_out, w_l_out, b_l_out]
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         w_u_out, b_u_out, w_l_out, b_l_out = get_identity_lirpa(inputs)
         if self.fast:
             return self._pooling_function_fast(

--- a/src/decomon/backward_layers/convert.py
+++ b/src/decomon/backward_layers/convert.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from keras.layers import Layer
 
@@ -8,7 +8,7 @@ import decomon.backward_layers.backward_merge
 from decomon.backward_layers.core import BackwardLayer
 from decomon.core import BoxDomain, ForwardMode, PerturbationDomain, Slope
 
-_mapping_name2class: Dict[str, Any] = vars(decomon.backward_layers.backward_layers)
+_mapping_name2class: dict[str, Any] = vars(decomon.backward_layers.backward_layers)
 _mapping_name2class.update(vars(decomon.backward_layers.backward_merge))
 _mapping_name2class.update(vars(decomon.backward_layers.backward_maxpooling))
 

--- a/src/decomon/backward_layers/core.py
+++ b/src/decomon/backward_layers/core.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import numpy as np
@@ -20,7 +20,7 @@ from decomon.types import BackendTensor
 
 class BackwardLayer(ABC, Wrapper):
     layer: Layer
-    _trainable_weights: List[keras.Variable]
+    _trainable_weights: list[keras.Variable]
 
     def __init__(
         self,
@@ -58,7 +58,7 @@ class BackwardLayer(ABC, Wrapper):
     def affine(self) -> bool:
         return get_affine(self.mode)
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -71,7 +71,7 @@ class BackwardLayer(ABC, Wrapper):
         return config
 
     @abstractmethod
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         """
         Args:
             inputs
@@ -81,7 +81,7 @@ class BackwardLayer(ABC, Wrapper):
         """
         pass
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape
@@ -92,7 +92,7 @@ class BackwardLayer(ABC, Wrapper):
         # generic case: nothing to do before call
         pass
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    def compute_output_shape(self, input_shape: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:
         """Compute expected output shape according to input shape
 
         Will be called by symbolic calls on Keras Tensors.

--- a/src/decomon/backward_layers/utils.py
+++ b/src/decomon/backward_layers/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -22,8 +22,8 @@ from decomon.utils import maximum, minus, relu_, subtract
 
 
 def backward_add(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -31,7 +31,7 @@ def backward_add(
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """Backward  LiRPA of inputs_0+inputs_1
 
     Args:
@@ -84,10 +84,10 @@ def backward_add(
 
 def backward_linear_prod(
     x_0: Tensor,
-    bounds_x: List[Tensor],
-    back_bounds: List[Tensor],
+    bounds_x: list[Tensor],
+    back_bounds: list[Tensor],
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of a subroutine prod
 
     Args:
@@ -158,8 +158,8 @@ def backward_linear_prod(
 
 
 def backward_maximum(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -168,7 +168,7 @@ def backward_maximum(
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """Backward  LiRPA of maximum(inputs_0, inputs_1)
 
     Args:
@@ -228,7 +228,7 @@ def backward_maximum(
 
 # convex hull of the maximum between two functions
 def backward_max_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -238,7 +238,7 @@ def backward_max_(
     axis: int = -1,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of max
 
     Args:
@@ -350,8 +350,8 @@ def backward_max_(
 
 
 def backward_minimum(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -360,7 +360,7 @@ def backward_minimum(
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """Backward  LiRPA of minimum(inputs_0, inputs_1)
 
     Args:
@@ -407,7 +407,7 @@ def backward_minus(
     b_u_out: Tensor,
     w_l_out: Tensor,
     b_l_out: Tensor,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of -x
 
     Args:
@@ -430,7 +430,7 @@ def backward_scale(
     b_u_out: Tensor,
     w_l_out: Tensor,
     b_l_out: Tensor,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of scale_factor*x
 
     Args:
@@ -453,8 +453,8 @@ def backward_scale(
 
 
 def backward_subtract(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -462,7 +462,7 @@ def backward_subtract(
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """Backward  LiRPA of inputs_0 - inputs_1
 
     Args:
@@ -499,8 +499,8 @@ def backward_subtract(
 
 
 def backward_multiply(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -508,7 +508,7 @@ def backward_multiply(
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """Backward  LiRPA of element-wise multiply inputs_0*inputs_1
 
     Args:
@@ -582,7 +582,7 @@ def backward_multiply(
 
 
 def backward_sort(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     w_u_out: Tensor,
     b_u_out: Tensor,
     w_l_out: Tensor,
@@ -591,7 +591,7 @@ def backward_sort(
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Backward  LiRPA of sort
 
     Args:
@@ -646,7 +646,7 @@ def backward_sort(
     return [w_u_out, b_u_out, w_l_out, b_l_out]
 
 
-def get_identity_lirpa(inputs: List[Tensor]) -> List[Tensor]:
+def get_identity_lirpa(inputs: list[Tensor]) -> list[Tensor]:
     y = inputs[-1]
     shape = int(np.prod(y.shape[1:]))
 
@@ -658,7 +658,7 @@ def get_identity_lirpa(inputs: List[Tensor]) -> List[Tensor]:
     return [w_u_out, b_u_out, w_l_out, b_l_out]
 
 
-def get_identity_lirpa_shapes(input_shapes: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+def get_identity_lirpa_shapes(input_shapes: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:
     y_shape = input_shapes[-1]
     batch_size = y_shape[0]
     flatten_dim = int(np.prod(y_shape[1:]))  # type: ignore

--- a/src/decomon/core.py
+++ b/src/decomon/core.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -40,12 +40,12 @@ class PerturbationDomain(ABC):
     def get_nb_x_components(self) -> int:
         ...
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         return {
             "opt_option": self.opt_option,
         }
 
-    def get_x_input_shape_wo_batchsize(self, original_input_dim: int) -> Tuple[int, ...]:
+    def get_x_input_shape_wo_batchsize(self, original_input_dim: int) -> tuple[int, ...]:
         n_comp_x = self.get_nb_x_components()
         if n_comp_x == 1:
             return (original_input_dim,)
@@ -92,7 +92,7 @@ class BallDomain(PerturbationDomain):
             raise ValueError(p_error_msg)
         self.p = p
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -201,20 +201,20 @@ class InputsOutputsSpec:
     def affine(self) -> bool:
         return get_affine(self.mode)
 
-    def get_kerasinputshape(self, inputsformode: List[Tensor]) -> Tuple[Optional[int], ...]:
+    def get_kerasinputshape(self, inputsformode: list[Tensor]) -> tuple[Optional[int], ...]:
         return inputsformode[-1].shape
 
     def get_kerasinputshape_from_inputshapesformode(
-        self, inputshapesformode: List[Tuple[Optional[int], ...]]
-    ) -> Tuple[Optional[int], ...]:
+        self, inputshapesformode: list[tuple[Optional[int], ...]]
+    ) -> tuple[Optional[int], ...]:
         return inputshapesformode[-1]
 
     def get_fullinputshapes_from_inputshapesformode(
         self,
-        inputshapesformode: List[Tuple[Optional[int], ...]],
-    ) -> List[Tuple[Optional[int], ...]]:
+        inputshapesformode: list[tuple[Optional[int], ...]],
+    ) -> list[tuple[Optional[int], ...]]:
         nb_tensors = self.nb_tensors
-        empty_shape: Tuple[Optional[int], ...] = tuple()
+        empty_shape: tuple[Optional[int], ...] = tuple()
         if self.dc_decomp:
             if self.mode == ForwardMode.HYBRID:
                 (
@@ -276,8 +276,8 @@ class InputsOutputsSpec:
         return [x_shape, u_c_shape, w_u_shape, b_u_shape, l_c_shape, w_l_shape, b_l_shape, h_shape, g_shape]
 
     def get_fullinputs_from_inputsformode(
-        self, inputsformode: List[Tensor], compute_ibp_from_affine: bool = True, tight: bool = True
-    ) -> List[Tensor]:
+        self, inputsformode: list[Tensor], compute_ibp_from_affine: bool = True, tight: bool = True
+    ) -> list[Tensor]:
         """
 
         Args:
@@ -347,8 +347,8 @@ class InputsOutputsSpec:
         return [x, u_c, w_u, b_u, l_c, w_l, b_l, h, g]
 
     def get_fullinputs_by_type_from_inputsformode_to_merge(
-        self, inputsformode: List[Tensor], compute_ibp_from_affine: bool = False, tight: bool = True
-    ) -> List[List[Tensor]]:
+        self, inputsformode: list[Tensor], compute_ibp_from_affine: bool = False, tight: bool = True
+    ) -> list[list[Tensor]]:
         """
 
         Args:
@@ -419,11 +419,11 @@ class InputsOutputsSpec:
 
         return [inputs_x, inputs_u_c, inputs_w_u, inputs_b_u, inputs_l_c, inputs_w_l, inputs_b_l, inputs_h, inputs_g]
 
-    def split_inputsformode_to_merge(self, inputsformode: List[Any]) -> List[List[Any]]:
+    def split_inputsformode_to_merge(self, inputsformode: list[Any]) -> list[list[Any]]:
         n_comp = self.nb_tensors
         return [inputsformode[n_comp * i : n_comp * (i + 1)] for i in range(len(inputsformode) // n_comp)]
 
-    def extract_inputsformode_from_fullinputs(self, inputs: List[Tensor]) -> List[Tensor]:
+    def extract_inputsformode_from_fullinputs(self, inputs: list[Tensor]) -> list[Tensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputs
         if self.mode == ForwardMode.HYBRID:
             inputsformode = [x, u_c, w_u, b_u, l_c, w_l, b_l]
@@ -438,8 +438,8 @@ class InputsOutputsSpec:
         return inputsformode
 
     def extract_inputshapesformode_from_fullinputshapes(
-        self, inputshapes: List[Tuple[Optional[int], ...]]
-    ) -> List[Tuple[Optional[int], ...]]:
+        self, inputshapes: list[tuple[Optional[int], ...]]
+    ) -> list[tuple[Optional[int], ...]]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = inputshapes
         if self.mode == ForwardMode.HYBRID:
             inputshapesformode = [x, u_c, w_u, b_u, l_c, w_l, b_l]
@@ -453,7 +453,7 @@ class InputsOutputsSpec:
             inputshapesformode += [h, g]
         return inputshapesformode
 
-    def extract_outputsformode_from_fulloutputs(self, outputs: List[Tensor]) -> List[Tensor]:
+    def extract_outputsformode_from_fulloutputs(self, outputs: list[Tensor]) -> list[Tensor]:
         return self.extract_inputsformode_from_fullinputs(outputs)
 
     @staticmethod

--- a/src/decomon/keras_utils.py
+++ b/src/decomon/keras_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 import keras
 import keras.ops as K
@@ -143,7 +143,7 @@ def get_weight_index_from_name(layer: Layer, weight_name: str) -> int:
         raise IndexError(f"The weight {weight_name} is not tracked by the layer {layer}.")
 
 
-def reset_layer(new_layer: Layer, original_layer: Layer, weight_names: List[str]) -> None:
+def reset_layer(new_layer: Layer, original_layer: Layer, weight_names: list[str]) -> None:
     """Reset some weights of a layer by using the weights of another layer.
 
     Args:
@@ -199,7 +199,7 @@ def share_layer_all_weights(
     )
 
 
-def share_weights_and_build(original_layer: Layer, new_layer: Layer, weight_names: List[str]) -> None:
+def share_weights_and_build(original_layer: Layer, new_layer: Layer, weight_names: list[str]) -> None:
     """Share the weights specidifed by names of an already built layer to another unbuilt layer.
 
     We assume that each weight is also an original_laer's attribute whose name is the weight name.

--- a/src/decomon/layers/activations.py
+++ b/src/decomon/layers/activations.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -40,7 +41,7 @@ GROUP_SORT_2 = "GroupSort2"
 
 
 def relu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     alpha: float = 0.0,
@@ -49,7 +50,7 @@ def relu(
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """
     Args:
         inputs: list of input tensors
@@ -82,14 +83,14 @@ def relu(
 
 
 def linear_hull_s_shape(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     func: Callable[[Tensor], Tensor] = K.sigmoid,
     f_prime: Callable[[Tensor], Tensor] = sigmoid_prime,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Computing the linear hull of s-shape functions
 
     Args:
@@ -158,13 +159,13 @@ def linear_hull_s_shape(
 
 
 def sigmoid(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Sigmoid activation function .
     `1 / (1 + exp(-x))`.
 
@@ -190,13 +191,13 @@ def sigmoid(
 
 
 def tanh(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Hyperbolic activation function.
     `tanh(x)=2*sigmoid(2*x)+1`
 
@@ -223,13 +224,13 @@ def tanh(
 
 
 def hard_sigmoid(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Hard sigmoid activation function.
        Faster to compute than sigmoid activation.
 
@@ -255,13 +256,13 @@ def hard_sigmoid(
 
 
 def elu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Exponential linear unit.
 
     Args:
@@ -286,13 +287,13 @@ def elu(
 
 
 def selu(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Scaled Exponential Linear Unit (SELU).
 
     SELU is equal to: `scale * elu(x, alpha)`, where alpha and scale
@@ -323,13 +324,13 @@ def selu(
 
 
 def linear(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA foe Linear (i.e. identity) activation function.
 
     Args:
@@ -348,13 +349,13 @@ def linear(
 
 
 def exponential(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Exponential activation function.
 
     Args:
@@ -376,13 +377,13 @@ def exponential(
 
 
 def softplus(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Softplus activation function `log(exp(x) + 1)`.
 
     Args:
@@ -406,13 +407,13 @@ def softplus(
 
 
 def softsign(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Softsign activation function `x / (abs(x) + 1)`.
 
     Args:
@@ -438,7 +439,7 @@ def softsign(
 
 
 def softmax(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -446,7 +447,7 @@ def softmax(
     clip: bool = True,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA for Softmax activation function.
 
     Args:
@@ -501,21 +502,21 @@ def softmax(
 
 
 def group_sort_2(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     data_format: str = "channels_last",
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
     raise NotImplementedError()
 
 
-def deserialize(name: str) -> Callable[..., List[Tensor]]:
+def deserialize(name: str) -> Callable[..., list[Tensor]]:
     """Get the activation from name.
 
     Args:
@@ -553,7 +554,7 @@ def deserialize(name: str) -> Callable[..., List[Tensor]]:
         raise ValueError(f"Could not interpret activation function identifier: {name}")
 
 
-def get(identifier: Any) -> Callable[..., List[Tensor]]:
+def get(identifier: Any) -> Callable[..., list[Tensor]]:
     """Get the `identifier` activation function.
 
     Args:

--- a/src/decomon/layers/convert.py
+++ b/src/decomon/layers/convert.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 from keras.layers import Activation, Input, Layer
@@ -79,7 +79,7 @@ def to_decomon(
 
 def _to_decomon_wo_input_init(
     layer: Layer,
-    namespace: Dict[str, Any],
+    namespace: dict[str, Any],
     slope: Union[str, Slope] = Slope.V_SLOPE,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
@@ -119,9 +119,9 @@ def _to_decomon_wo_input_init(
 
 def _prepare_input_tensors(
     layer: Layer, input_dim: int, dc_decomp: bool, perturbation_domain: PerturbationDomain, mode: ForwardMode
-) -> List[keras.KerasTensor]:
+) -> list[keras.KerasTensor]:
     original_input_shapes = get_layer_input_shape(layer)
-    decomon_input_shapes: List[List[Optional[int]]] = [list(input_shape[1:]) for input_shape in original_input_shapes]
+    decomon_input_shapes: list[list[Optional[int]]] = [list(input_shape[1:]) for input_shape in original_input_shapes]
     n_input = len(decomon_input_shapes)
     x_input_shape = perturbation_domain.get_x_input_shape_wo_batchsize(input_dim)
     x_input = Input(x_input_shape, dtype=layer.dtype)
@@ -150,10 +150,10 @@ def _prepare_input_tensors(
     return flatten_input_list
 
 
-SingleInputShapeType = Tuple[Optional[int], ...]
+SingleInputShapeType = tuple[Optional[int], ...]
 
 
-def get_layer_input_shape(layer: Layer) -> List[SingleInputShapeType]:
+def get_layer_input_shape(layer: Layer) -> list[SingleInputShapeType]:
     """Retrieves the input shape(s) of a layer.
 
     Only applicable if the layer has exactly one input,

--- a/src/decomon/layers/core.py
+++ b/src/decomon/layers/core.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import keras
 from keras.layers import Layer
@@ -19,11 +19,11 @@ from decomon.types import BackendTensor
 class DecomonLayer(ABC, Layer):
     """Abstract class that contains the common information of every implemented layers for Forward LiRPA"""
 
-    _trainable_weights: List[keras.Variable]
+    _trainable_weights: list[keras.Variable]
 
     @property
     @abstractmethod
-    def original_keras_layer_class(self) -> Type[Layer]:
+    def original_keras_layer_class(self) -> type[Layer]:
         """The keras layer class from which this class is the decomon equivalent."""
         pass
 
@@ -72,7 +72,7 @@ class DecomonLayer(ABC, Layer):
     def affine(self) -> bool:
         return get_affine(self.mode)
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -86,7 +86,7 @@ class DecomonLayer(ABC, Layer):
         )
         return config
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape
@@ -99,7 +99,7 @@ class DecomonLayer(ABC, Layer):
         self.original_keras_layer_class.build(self, y_input_shape)
 
     @abstractmethod
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         """
         Args:
             inputs
@@ -109,8 +109,8 @@ class DecomonLayer(ABC, Layer):
         """
 
     def compute_output_shape(
-        self, input_shape: Union[Tuple[Optional[int], ...], List[Tuple[Optional[int], ...]]]
-    ) -> Union[Tuple[Optional[int], ...], List[Tuple[Optional[int], ...]]]:
+        self, input_shape: Union[tuple[Optional[int], ...], list[tuple[Optional[int], ...]]]
+    ) -> Union[tuple[Optional[int], ...], list[tuple[Optional[int], ...]]]:
         """Compute expected output shape according to input shape
 
         Will be called by symbolic calls on Keras Tensors.
@@ -139,7 +139,7 @@ class DecomonLayer(ABC, Layer):
                 return input_shape
 
         # we know from here that we got a list of input shapes. Mypy does not.
-        input_shapes: List[Tuple[Optional[int], ...]] = input_shape  # type: ignore
+        input_shapes: list[tuple[Optional[int], ...]] = input_shape  # type: ignore
         y_shape = self.inputs_outputs_spec.get_kerasinputshape_from_inputshapesformode(
             input_shapes
         )  # input shape for the original layer
@@ -203,7 +203,7 @@ class DecomonLayer(ABC, Layer):
             reset_layer(new_layer=self, original_layer=layer, weight_names=weight_names)
 
     @property
-    def keras_weights_names(self) -> List[str]:
+    def keras_weights_names(self) -> list[str]:
         """Weights names of the corresponding Keras layer.
 
         Will be used to decide which weight to take from the keras layer in `reset_layer()`
@@ -211,7 +211,7 @@ class DecomonLayer(ABC, Layer):
         """
         return []
 
-    def join(self, bounds: List[BackendTensor]) -> List[BackendTensor]:
+    def join(self, bounds: list[BackendTensor]) -> list[BackendTensor]:
         """
         Args:
             bounds

--- a/src/decomon/layers/decomon_layers.py
+++ b/src/decomon/layers/decomon_layers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -41,7 +41,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
     def __init__(
         self,
         filters: int,
-        kernel_size: Union[int, Tuple[int, int]],
+        kernel_size: Union[int, tuple[int, int]],
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -88,7 +88,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=4), InputSpec(min_ndim=4)]
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape
@@ -136,7 +136,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
         self.kernel = layer.kernel
         self.bias = layer.bias
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         """computing the perturbation analysis of the operator without the activation function
 
         Args:
@@ -218,10 +218,10 @@ class DecomonConv2D(DecomonLayer, Conv2D):
                 x_max = self.perturbation_domain.get_upper(x, w_u - w_l, b_u - b_l)
                 mask_b = o_value - K.sign(x_max)
 
-                def step_pos(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
+                def step_pos(x: BackendTensor, _: list[BackendTensor]) -> tuple[BackendTensor, list[BackendTensor]]:
                     return conv_pos(x), []
 
-                def step_neg(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
+                def step_neg(x: BackendTensor, _: list[BackendTensor]) -> tuple[BackendTensor, list[BackendTensor]]:
                     return conv_neg(x), []
 
                 b_u_out = conv_pos(b_u) + conv_neg(b_l)
@@ -261,7 +261,7 @@ class DecomonConv2D(DecomonLayer, Conv2D):
         )
 
     @property
-    def keras_weights_names(self) -> List[str]:
+    def keras_weights_names(self) -> list[str]:
         """Weights names of the corresponding Keras layer.
 
         Will be used to decide which weight to take from the keras layer in `reset_layer()`
@@ -317,10 +317,10 @@ class DecomonDense(DecomonLayer, Dense):
             **kwargs,
         )
         self.input_spec = [InputSpec(min_ndim=2) for _ in range(self.nb_tensors)]
-        self.input_shape_build: Optional[List[Tuple[Optional[int], ...]]] = None
+        self.input_shape_build: Optional[list[tuple[Optional[int], ...]]] = None
         self.op_dot = K.dot
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             input_shape: list of input shape
@@ -418,7 +418,7 @@ class DecomonDense(DecomonLayer, Dense):
             op = Dot(1)
             self.op_dot = lambda x, y: op([x, y])
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         """
         Args:
             inputs
@@ -511,7 +511,7 @@ class DecomonDense(DecomonLayer, Dense):
         )
 
     @property
-    def keras_weights_names(self) -> List[str]:
+    def keras_weights_names(self) -> list[str]:
         """Weights names of the corresponding Keras layer.
 
         Will be used to decide which weight to take from the keras layer in `reset_layer()`
@@ -570,7 +570,7 @@ class DecomonActivation(DecomonLayer, Activation):
         self.activation = activations.get(activation)
         self.activation_name = activation
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         if self.finetune and self.mode in [ForwardMode.HYBRID, ForwardMode.AFFINE]:
             shape = input_shape[-1][1:]
 
@@ -591,7 +591,7 @@ class DecomonActivation(DecomonLayer, Activation):
                     constraint=ClipAlpha(),
                 )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.finetune and self.mode in [ForwardMode.AFFINE, ForwardMode.HYBRID] and self.activation_name != "linear":
             if self.activation_name[:4] == "relu":
                 return self.activation(
@@ -707,7 +707,7 @@ class DecomonFlatten(DecomonLayer, Flatten):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         """
         Args:
             self
@@ -718,7 +718,7 @@ class DecomonFlatten(DecomonLayer, Flatten):
         """
         return None
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         def op(x: BackendTensor) -> BackendTensor:
             return Flatten.call(self, x)
 
@@ -808,11 +808,11 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
             **kwargs,
         )
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
-    def call(self, inputs: List[BackendTensor], training: bool = False, **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], training: bool = False, **kwargs: Any) -> list[BackendTensor]:
         z_value = K.cast(0.0, self.dtype)
 
         if training:
@@ -879,7 +879,7 @@ class DecomonBatchNormalization(DecomonLayer, BatchNormalization):
         )
 
     @property
-    def keras_weights_names(self) -> List[str]:
+    def keras_weights_names(self) -> list[str]:
         """Weights names of the corresponding Keras layer.
 
         Will be used to decide which weight to take from the keras layer in `reset_layer()`
@@ -903,7 +903,7 @@ class DecomonDropout(DecomonLayer, Dropout):
     def __init__(
         self,
         rate: float,
-        noise_shape: Optional[Tuple[int, ...]] = None,
+        noise_shape: Optional[tuple[int, ...]] = None,
         seed: Optional[int] = None,
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
@@ -926,11 +926,11 @@ class DecomonDropout(DecomonLayer, Dropout):
             **kwargs,
         )
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         super().build(input_shape)
         self.input_spec = [InputSpec(min_ndim=len(elem)) for elem in input_shape]
 
-    def call(self, inputs: List[BackendTensor], training: bool = False, **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], training: bool = False, **kwargs: Any) -> list[BackendTensor]:
         if training:
             raise NotImplementedError("not working during training")
 
@@ -944,16 +944,16 @@ class DecomonInputLayer(DecomonLayer, InputLayer):
 
     original_keras_layer_class = InputLayer
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return inputs
 
     def __init__(
         self,
-        shape: Optional[Tuple[int, ...]] = None,
+        shape: Optional[tuple[int, ...]] = None,
         batch_size: Optional[int] = None,
         dtype: Optional[str] = None,
         sparse: Optional[bool] = None,
-        batch_shape: Optional[Tuple[Optional[int], ...]] = None,
+        batch_shape: Optional[tuple[Optional[int], ...]] = None,
         input_tensor: Optional[keras.KerasTensor] = None,
         name: Optional[str] = None,
         perturbation_domain: Optional[PerturbationDomain] = None,

--- a/src/decomon/layers/decomon_merge_layers.py
+++ b/src/decomon/layers/decomon_merge_layers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 from keras.layers import (
@@ -26,7 +26,7 @@ from decomon.utils import maximum, minus, subtract
 class DecomonMerge(DecomonLayer):
     """Base class for Decomon layers based on Mergind Keras layers."""
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:  # type: ignore
+    def compute_output_shape(self, input_shape: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:  # type: ignore
         """Compute output shapes from input shapes.
 
         By default, we assume that all inputs will be merged into "one" (still a list of tensors though).
@@ -81,7 +81,7 @@ class DecomonMerge(DecomonLayer):
             ]
             return self.inputs_outputs_spec.extract_inputshapesformode_from_fullinputshapes(fulloutputshapes)
 
-    def build(self, input_shape: List[Tuple[Optional[int], ...]]) -> None:
+    def build(self, input_shape: list[tuple[Optional[int], ...]]) -> None:
         n_comp = self.nb_tensors
         input_shape_y = input_shape[n_comp - 1 :: n_comp]
         self.original_keras_layer_class.build(self, input_shape_y)
@@ -115,7 +115,7 @@ class DecomonAdd(DecomonMerge, Add):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -186,7 +186,7 @@ class DecomonAverage(DecomonMerge, Average):
         )
         self.op = Lambda(lambda x: sum(x) / len(x))
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -256,7 +256,7 @@ class DecomonSubtract(DecomonMerge, Subtract):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -305,7 +305,7 @@ class DecomonMinimum(DecomonMerge, Minimum):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -368,7 +368,7 @@ class DecomonMaximum(DecomonMerge, Maximum):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -428,7 +428,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
             **kwargs,
         )
 
-        def func(inputs: List[BackendTensor]) -> BackendTensor:
+        def func(inputs: list[BackendTensor]) -> BackendTensor:
             return Concatenate.call(self, inputs)
 
         self.op = func
@@ -437,7 +437,7 @@ class DecomonConcatenate(DecomonMerge, Concatenate):
         else:
             self.op_w = Concatenate(axis=self.axis + 1)
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         # splits the inputs
         (
             inputs_x,
@@ -507,7 +507,7 @@ class DecomonMultiply(DecomonMerge, Multiply):
             **kwargs,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 
@@ -547,7 +547,7 @@ class DecomonDot(DecomonMerge, Dot):
 
     def __init__(
         self,
-        axes: Union[int, Tuple[int, int]] = (-1, -1),
+        axes: Union[int, tuple[int, int]] = (-1, -1),
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -571,7 +571,7 @@ class DecomonDot(DecomonMerge, Dot):
         else:
             self.axes = axes
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.dc_decomp:
             raise NotImplementedError()
 

--- a/src/decomon/layers/decomon_reshape.py
+++ b/src/decomon/layers/decomon_reshape.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 from keras.layers import InputSpec, Layer, Permute, Reshape
 from keras.src.backend import rnn
@@ -17,7 +17,7 @@ class DecomonReshape(DecomonLayer, Reshape):
 
     def __init__(
         self,
-        target_shape: Tuple[int, ...],
+        target_shape: tuple[int, ...],
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -69,7 +69,7 @@ class DecomonReshape(DecomonLayer, Reshape):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         def op(x: BackendTensor) -> BackendTensor:
             return Reshape.call(self, x)
 
@@ -101,7 +101,7 @@ class DecomonReshape(DecomonLayer, Reshape):
 
             else:
 
-                def step_func(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
+                def step_func(x: BackendTensor, _: list[BackendTensor]) -> tuple[BackendTensor, list[BackendTensor]]:
                     return op(x), _
 
                 w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]
@@ -123,7 +123,7 @@ class DecomonPermute(DecomonLayer, Permute):
 
     def __init__(
         self,
-        dims: Tuple[int, ...],
+        dims: tuple[int, ...],
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
@@ -177,7 +177,7 @@ class DecomonPermute(DecomonLayer, Permute):
         if self.dc_decomp:
             self.input_spec += [InputSpec(min_ndim=1), InputSpec(min_ndim=1)]
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         def op(x: BackendTensor) -> BackendTensor:
             return Permute.call(self, x)
 
@@ -208,7 +208,7 @@ class DecomonPermute(DecomonLayer, Permute):
                 w_l_out = op(w_l)
             else:
 
-                def step_func(x: BackendTensor, _: List[BackendTensor]) -> Tuple[BackendTensor, List[BackendTensor]]:
+                def step_func(x: BackendTensor, _: list[BackendTensor]) -> tuple[BackendTensor, list[BackendTensor]]:
                     return op(x), _
 
                 w_u_out = rnn(step_function=step_func, inputs=w_u, initial_states=[], unroll=False)[1]

--- a/src/decomon/layers/maxpooling.py
+++ b/src/decomon/layers/maxpooling.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -19,15 +19,15 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
     original_keras_layer_class = MaxPooling2D
 
-    pool_size: Tuple[int, int]
-    strides: Tuple[int, int]
+    pool_size: tuple[int, int]
+    strides: tuple[int, int]
     padding: str
     data_format: str
 
     def __init__(
         self,
-        pool_size: Union[int, Tuple[int, int]] = (2, 2),
-        strides: Optional[Union[int, Tuple[int, int]]] = None,
+        pool_size: Union[int, tuple[int, int]] = (2, 2),
+        strides: Optional[Union[int, tuple[int, int]]] = None,
         padding: str = "valid",
         data_format: Optional[str] = None,
         perturbation_domain: Optional[PerturbationDomain] = None,
@@ -157,8 +157,8 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
     def _pooling_function_fast(
         self,
-        inputs: List[BackendTensor],
-    ) -> List[BackendTensor]:
+        inputs: list[BackendTensor],
+    ) -> list[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         dtype = x.dtype
         empty_tensor = self.inputs_outputs_spec.get_empty_tensor(dtype=dtype)
@@ -186,8 +186,8 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
 
     def _pooling_function_not_fast(
         self,
-        inputs: List[BackendTensor],
-    ) -> List[BackendTensor]:
+        inputs: list[BackendTensor],
+    ) -> list[BackendTensor]:
         x, u_c, w_u, b_u, l_c, w_l, b_l, h, g = self.inputs_outputs_spec.get_fullinputs_from_inputsformode(
             inputs, compute_ibp_from_affine=False
         )
@@ -230,7 +230,7 @@ class DecomonMaxPooling2D(DecomonLayer, MaxPooling2D):
             outputs, axis=-1, dc_decomp=self.dc_decomp, mode=self.mode, perturbation_domain=self.perturbation_domain
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         if self.fast:
             return self._pooling_function_fast(inputs)
         else:

--- a/src/decomon/layers/utils.py
+++ b/src/decomon/layers/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -90,7 +90,7 @@ class Project_initializer_pos(Initializer):
         super().__init__(**kwargs)
         self.initializer = initializer
 
-    def __call__(self, shape: Tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any) -> BackendTensor:
+    def __call__(self, shape: tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any) -> BackendTensor:
         w = self.initializer.__call__(shape, dtype)
         return K.maximum(K.cast(0.0, dtype=dtype), w)
 
@@ -102,19 +102,19 @@ class Project_initializer_neg(Initializer):
         super().__init__(**kwargs)
         self.initializer = initializer
 
-    def __call__(self, shape: Tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any) -> BackendTensor:
+    def __call__(self, shape: tuple[Optional[int], ...], dtype: Optional[str] = None, **kwargs: Any) -> BackendTensor:
         w = self.initializer.__call__(shape, dtype)
         return K.minimum(K.cast(0.0, dtype=dtype), w)
 
 
 def softplus_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
@@ -147,13 +147,13 @@ def softplus_(
 
 
 def sum(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     axis: int = -1,
     dc_decomp: bool = False,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
@@ -196,12 +196,12 @@ def sum(
 
 
 def frac_pos(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
 
@@ -244,14 +244,14 @@ def frac_pos(
 
 # convex hull of the maximum between two functions
 def max_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     finetune: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of max(x, axis)
 
     Args:
@@ -396,7 +396,7 @@ def max_(
     )
 
 
-def softmax_to_linear(model: keras.Model) -> Tuple[keras.Model, bool]:
+def softmax_to_linear(model: keras.Model) -> tuple[keras.Model, bool]:
     """linearize the softmax layer for verification
 
     Args:
@@ -422,18 +422,18 @@ def softmax_to_linear(model: keras.Model) -> Tuple[keras.Model, bool]:
     return model, False
 
 
-def linear_to_softmax(model: keras.Model) -> Tuple[keras.Model, bool]:
+def linear_to_softmax(model: keras.Model) -> tuple[keras.Model, bool]:
     model.layers[-1].activation = keras.activations.get("softmax")
     return model
 
 
 def multiply(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of (element-wise) multiply(x,y)=-x*y.
 
     Args:
@@ -522,13 +522,13 @@ def multiply(
 
 
 def permute_dimensions(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     axis: int,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis_perm: int = 1,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of (element-wise) permute(x,axis)
 
     Args:
@@ -588,13 +588,13 @@ def permute_dimensions(
 
 
 def broadcast(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     n: int,
     axis: int,
     mode: Union[str, ForwardMode],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of broadcasting
 
     Args:
@@ -643,12 +643,12 @@ def broadcast(
 
 
 def split(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     axis: int = -1,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[List[Tensor]]:
+) -> list[list[Tensor]]:
     """LiRPA implementation of split
 
     Args:
@@ -718,12 +718,12 @@ def split(
 
 
 def sort(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     axis: int = -1,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of sort by selection
 
     Args:
@@ -856,11 +856,11 @@ def sort(
 
 
 def pow(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of pow(x )=x**2
 
     Args:
@@ -879,11 +879,11 @@ def pow(
 
 
 def abs(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of |x|
 
     Args:
@@ -914,11 +914,11 @@ def abs(
 
 
 def frac_pos_hull(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of 1/x for x>0
 
     Args:
@@ -953,14 +953,14 @@ def frac_pos_hull(
 
 # convex hull for min
 def min_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     finetune: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of min(x, axis=axis)
 
     Args:
@@ -992,13 +992,13 @@ def min_(
 
 
 def expand_dims(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     axis: int = -1,
     perturbation_domain: Optional[PerturbationDomain] = None,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
     mode = ForwardMode(mode)
@@ -1044,12 +1044,12 @@ def expand_dims(
 
 
 def log(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Exponential activation function.
 
     Args:
@@ -1108,13 +1108,13 @@ def log(
 
 
 def exp(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Exponential activation function.
 
     Args:

--- a/src/decomon/layers/utils_pooling.py
+++ b/src/decomon/layers/utils_pooling.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -18,13 +18,13 @@ from decomon.types import BackendTensor, Tensor
 
 
 def get_upper_linear_hull_max(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Compute the linear hull that overapproximates max along the axis dimension
 
     Args:
@@ -135,14 +135,14 @@ def get_upper_linear_hull_max(
 
 
 def get_lower_linear_hull_max(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
     axis: int = -1,
     finetune_lower: Optional[BackendTensor] = None,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Compute the linear hull that overapproximates max along the axis dimension
 
     Args:

--- a/src/decomon/metrics/metric.py
+++ b/src/decomon/metrics/metric.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -49,7 +49,7 @@ class MetricLayer(ABC, Layer):
         else:
             self.perturbation_domain = perturbation_domain
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -62,7 +62,7 @@ class MetricLayer(ABC, Layer):
         return config
 
     @abstractmethod
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> BackendTensor:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> BackendTensor:
         """
         Args:
             inputs
@@ -114,7 +114,7 @@ class AdversarialCheck(MetricLayer):
 
         return K.max(adv_score, -1)
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> BackendTensor:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> BackendTensor:
         """
         Args:
             inputs
@@ -186,7 +186,7 @@ class AdversarialScore(AdversarialCheck):
         """
         super().__init__(ibp=ibp, affine=affine, mode=mode, perturbation_domain=perturbation_domain, **kwargs)
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> BackendTensor:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> BackendTensor:
         """
         Args:
             inputs
@@ -318,7 +318,7 @@ class UpperScore(MetricLayer):
 
         return K.sum(upper_score, -1)
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> BackendTensor:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> BackendTensor:
         """
         Args:
             inputs

--- a/src/decomon/metrics/utils.py
+++ b/src/decomon/metrics/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional, Union
 
 from decomon.core import BoxDomain, ForwardMode, PerturbationDomain
 from decomon.layers.utils import exp, expand_dims, log, sum
@@ -9,11 +9,11 @@ from decomon.utils import add, minus
 
 
 def categorical_cross_entropy(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     perturbation_domain: Optional[PerturbationDomain] = None,
-) -> List[Tensor]:
+) -> list[Tensor]:
     # step 1: exponential
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()

--- a/src/decomon/models/backward_cloning.py
+++ b/src/decomon/models/backward_cloning.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -46,7 +47,7 @@ def get_disconnected_input(
     if dtype is None:
         dtype = floatx()
 
-    def disco_priv(inputs: List[Tensor]) -> List[Tensor]:
+    def disco_priv(inputs: list[Tensor]) -> list[Tensor]:
         x, u_c, w_f_u, b_f_u, l_c, w_f_l, b_f_l, h, g = inputs_outputs_spec.get_fullinputs_from_inputsformode(inputs)
         dtype = x.dtype
         empty_tensor = inputs_outputs_spec.get_empty_tensor(dtype=dtype)
@@ -66,7 +67,7 @@ def get_disconnected_input(
 def retrieve_layer(
     node: Node,
     layer_fn: Callable[[Layer], BackwardLayer],
-    backward_map: Dict[int, BackwardLayer],
+    backward_map: dict[int, BackwardLayer],
     joint: bool = True,
 ) -> BackwardLayer:
     if id(node) in backward_map:
@@ -83,17 +84,17 @@ def crown_(
     ibp: bool,
     affine: bool,
     perturbation_domain: PerturbationDomain,
-    input_map: Dict[int, List[keras.KerasTensor]],
+    input_map: dict[int, list[keras.KerasTensor]],
     layer_fn: Callable[[Layer], BackwardLayer],
-    backward_bounds: List[keras.KerasTensor],
-    backward_map: Optional[Dict[int, BackwardLayer]] = None,
+    backward_bounds: list[keras.KerasTensor],
+    backward_map: Optional[dict[int, BackwardLayer]] = None,
     joint: bool = True,
     fuse: bool = True,
-    output_map: Optional[Dict[int, List[keras.KerasTensor]]] = None,
+    output_map: Optional[dict[int, list[keras.KerasTensor]]] = None,
     merge_layers: Optional[Layer] = None,
     fuse_layer: Optional[Layer] = None,
     **kwargs: Any,
-) -> Tuple[List[keras.KerasTensor], Optional[Layer]]:
+) -> tuple[list[keras.KerasTensor], Optional[Layer]]:
     """
 
 
@@ -216,25 +217,25 @@ def crown_(
 
 def get_input_nodes(
     model: Model,
-    dico_nodes: Dict[int, List[Node]],
+    dico_nodes: dict[int, list[Node]],
     ibp: bool,
     affine: bool,
-    input_tensors: List[keras.KerasTensor],
+    input_tensors: list[keras.KerasTensor],
     output_map: OutputMapDict,
     layer_fn: Callable[[Layer], BackwardLayer],
     joint: bool,
     set_mode_layer: Layer,
     perturbation_domain: Optional[PerturbationDomain] = None,
     **kwargs: Any,
-) -> Tuple[Dict[int, List[keras.KerasTensor]], Dict[int, BackwardLayer], Dict[int, List[keras.KerasTensor]]]:
+) -> tuple[dict[int, list[keras.KerasTensor]], dict[int, BackwardLayer], dict[int, list[keras.KerasTensor]]]:
     keys = [e for e in dico_nodes.keys()]
     keys.sort(reverse=True)
     fuse_layer = None
-    input_map: Dict[int, List[keras.KerasTensor]] = {}
-    backward_map: Dict[int, BackwardLayer] = {}
+    input_map: dict[int, list[keras.KerasTensor]] = {}
+    backward_map: dict[int, BackwardLayer] = {}
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
-    crown_map: Dict[int, List[keras.KerasTensor]] = {}
+    crown_map: dict[int, list[keras.KerasTensor]] = {}
     for depth in keys:
         nodes = dico_nodes[depth]
         for node in nodes:
@@ -246,7 +247,7 @@ def get_input_nodes(
                 #    import pdb; pdb.set_trace()
                 input_map[id(node)] = input_tensors
             else:
-                output: List[keras.KerasTensor] = []
+                output: list[keras.KerasTensor] = []
                 for parent in parents:
                     # do something
                     if id(parent) in output_map.keys():
@@ -283,8 +284,8 @@ def get_input_nodes(
 
 def crown_model(
     model: Model,
-    input_tensors: List[keras.KerasTensor],
-    back_bounds: Optional[List[keras.KerasTensor]] = None,
+    input_tensors: list[keras.KerasTensor],
+    back_bounds: Optional[list[keras.KerasTensor]] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     ibp: bool = True,
     affine: bool = True,
@@ -296,7 +297,7 @@ def crown_model(
     layer_fn: Callable[..., BackwardLayer] = to_backward,
     fuse: bool = True,
     **kwargs: Any,
-) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], Dict[int, BackwardLayer], None]:
+) -> tuple[list[keras.KerasTensor], list[keras.KerasTensor], dict[int, BackwardLayer], None]:
     if back_bounds is None:
         back_bounds = []
     if forward_map is None:
@@ -400,8 +401,8 @@ def crown_model(
 
 def convert_backward(
     model: Model,
-    input_tensors: List[keras.KerasTensor],
-    back_bounds: Optional[List[keras.KerasTensor]] = None,
+    input_tensors: list[keras.KerasTensor],
+    back_bounds: Optional[list[keras.KerasTensor]] = None,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     ibp: bool = True,
     affine: bool = True,
@@ -415,7 +416,7 @@ def convert_backward(
     final_affine: bool = False,
     input_dim: int = -1,
     **kwargs: Any,
-) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], Dict[int, BackwardLayer], None]:
+) -> tuple[list[keras.KerasTensor], list[keras.KerasTensor], dict[int, BackwardLayer], None]:
     model = ensure_functional_model(model)
     if input_dim == -1:
         input_dim = get_input_dim(model)

--- a/src/decomon/models/convert.py
+++ b/src/decomon/models/convert.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import keras
 from keras.layers import InputLayer, Layer
@@ -31,7 +32,7 @@ from decomon.models.utils import (
 )
 
 
-def _clone_keras_model(model: Model, layer_fn: Callable[[Layer], List[Layer]]) -> Model:
+def _clone_keras_model(model: Model, layer_fn: Callable[[Layer], list[Layer]]) -> Model:
     if model.inputs is None:
         raise ValueError("model.inputs must be not None. You should call the model on a batch of data.")
 
@@ -79,11 +80,11 @@ def preprocess_keras_model(
 # create status
 def convert(
     model: Model,
-    input_tensors: List[keras.KerasTensor],
+    input_tensors: list[keras.KerasTensor],
     method: Union[str, ConvertMethod] = ConvertMethod.CROWN,
     ibp: bool = False,
     affine: bool = False,
-    back_bounds: Optional[List[keras.KerasTensor]] = None,
+    back_bounds: Optional[list[keras.KerasTensor]] = None,
     layer_fn: Callable[..., Layer] = to_decomon,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     input_dim: int = -1,
@@ -97,10 +98,10 @@ def convert(
     final_ibp: bool = False,
     final_affine: bool = False,
     **kwargs: Any,
-) -> Tuple[
-    List[keras.KerasTensor],
-    List[keras.KerasTensor],
-    Union[LayerMapDict, Dict[int, BackwardLayer]],
+) -> tuple[
+    list[keras.KerasTensor],
+    list[keras.KerasTensor],
+    Union[LayerMapDict, dict[int, BackwardLayer]],
     Optional[OutputMapDict],
 ]:
     if back_bounds is None:
@@ -119,7 +120,7 @@ def convert(
     # prepare the Keras Model: split non-linear activation functions into separate Activation layers
     model = preprocess_keras_model(model)
 
-    layer_map: Union[LayerMapDict, Dict[int, BackwardLayer]]
+    layer_map: Union[LayerMapDict, dict[int, BackwardLayer]]
 
     if method != ConvertMethod.CROWN:
         input_tensors, output, layer_map, forward_map = convert_forward(
@@ -172,12 +173,12 @@ def clone(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     perturbation_domain: Optional[PerturbationDomain] = None,
     method: Union[str, ConvertMethod] = ConvertMethod.CROWN,
-    back_bounds: Optional[List[keras.KerasTensor]] = None,
+    back_bounds: Optional[list[keras.KerasTensor]] = None,
     finetune: bool = False,
     shared: bool = True,
     finetune_forward: bool = False,
     finetune_backward: bool = False,
-    extra_inputs: Optional[List[keras.KerasTensor]] = None,
+    extra_inputs: Optional[list[keras.KerasTensor]] = None,
     to_keras: bool = True,
     final_ibp: Optional[bool] = None,
     final_affine: Optional[bool] = None,

--- a/src/decomon/models/crown.py
+++ b/src/decomon/models/crown.py
@@ -1,5 +1,5 @@
 # extra layers necessary for backward LiRPA
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras.ops as K
 from keras.layers import InputSpec, Layer
@@ -15,7 +15,7 @@ class Fuse(Layer):
         super().__init__(**kwargs)
         self.mode = ForwardMode(mode)
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         inputs_wo_backward_bounds = inputs[:-4]
         backward_bounds = inputs[-4:]
 
@@ -28,7 +28,7 @@ class Fuse(Layer):
 
         return merge_with_previous([w_f_u, b_f_u, w_f_l, b_f_l] + backward_bounds)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    def compute_output_shape(self, input_shape: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:
         inputs_wo_backward_bounds_shapes = input_shape[:-4]
         backward_bounds_shapes = input_shape[-4:]
 
@@ -51,7 +51,7 @@ class Fuse(Layer):
             [w_f_u_shape, b_f_u_shape, w_f_l_shape, b_f_l_shape] + backward_bounds_shapes
         )
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update({"mode": self.mode})
         return config
@@ -63,7 +63,7 @@ class Convert2BackwardMode(Layer):
         self.mode = ForwardMode(mode)
         self.perturbation_domain = perturbation_domain
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         inputs_wo_backward_bounds = inputs[:-4]
         backward_bounds = inputs[-4:]
         w_u_out, b_u_out, w_l_out, b_l_out = backward_bounds
@@ -91,7 +91,7 @@ class Convert2BackwardMode(Layer):
         else:
             raise ValueError(f"Unknwon mode {self.mode}")
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update({"mode": self.mode, "perturbation_domain": self.perturbation_domain})
         return config
@@ -100,8 +100,8 @@ class Convert2BackwardMode(Layer):
 class MergeWithPrevious(Layer):
     def __init__(
         self,
-        input_shape_layer: Optional[Tuple[int, ...]] = None,
-        backward_shape_layer: Optional[Tuple[int, ...]] = None,
+        input_shape_layer: Optional[tuple[int, ...]] = None,
+        backward_shape_layer: Optional[tuple[int, ...]] = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -117,13 +117,13 @@ class MergeWithPrevious(Layer):
             b_b_spec = InputSpec(ndim=2, axes={-1: n_out})
             self.input_spec = [w_out_spec, b_out_spec] * 2 + [w_b_spec, b_b_spec] * 2  #
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         return merge_with_previous(inputs)
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    def compute_output_shape(self, input_shape: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:
         return merge_with_previous_compute_output_shape(input_shape)
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {
@@ -135,8 +135,8 @@ class MergeWithPrevious(Layer):
 
 
 def merge_with_previous_compute_output_shape(
-    input_shapes: List[Tuple[Optional[int], ...]]
-) -> List[Tuple[Optional[int], ...]]:
+    input_shapes: list[tuple[Optional[int], ...]]
+) -> list[tuple[Optional[int], ...]]:
     w_b_in_shape, b_b_in_shape = input_shapes[-2:]
     w_out_in_shape, b_out_in_shape = input_shapes[:2]
     batch_size, flattened_keras_input_shape, flattened_keras_output_shape = w_out_in_shape
@@ -146,7 +146,7 @@ def merge_with_previous_compute_output_shape(
     return [w_b_out_shape, b_b_out_shape] * 2
 
 
-def merge_with_previous(inputs: List[BackendTensor]) -> List[BackendTensor]:
+def merge_with_previous(inputs: list[BackendTensor]) -> list[BackendTensor]:
     w_u_out, b_u_out, w_l_out, b_l_out, w_b_u, b_b_u, w_b_l, b_b_l = inputs
 
     # w_u_out (None, n_h_in, n_h_out)

--- a/src/decomon/models/forward_cloning.py
+++ b/src/decomon/models/forward_cloning.py
@@ -4,8 +4,9 @@ It inherits from keras Sequential class.
 
 """
 import inspect
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 from keras.layers import InputLayer, Layer
@@ -26,11 +27,11 @@ from decomon.models.utils import (
 )
 
 OutputMapKey = Union[str, int]
-OutputMapVal = Union[List[keras.KerasTensor], "OutputMapDict"]
-OutputMapDict = Dict[OutputMapKey, OutputMapVal]
+OutputMapVal = Union[list[keras.KerasTensor], "OutputMapDict"]
+OutputMapDict = dict[OutputMapKey, OutputMapVal]
 
-LayerMapVal = Union[List[DecomonLayer], "LayerMapDict"]
-LayerMapDict = Dict[int, LayerMapVal]
+LayerMapVal = Union[list[DecomonLayer], "LayerMapDict"]
+LayerMapDict = dict[int, LayerMapVal]
 
 
 def include_dim_layer_fn(
@@ -43,7 +44,7 @@ def include_dim_layer_fn(
     affine: bool = True,
     finetune: bool = False,
     shared: bool = True,
-) -> Callable[[Layer], List[Layer]]:
+) -> Callable[[Layer], list[Layer]]:
     """include external parameters inside the translation of a layer to its decomon counterpart
 
     Args:
@@ -66,7 +67,7 @@ def include_dim_layer_fn(
 
     if "input_dim" in inspect.signature(layer_fn).parameters:
 
-        def func(layer: Layer) -> List[Layer]:
+        def func(layer: Layer) -> list[Layer]:
             return [
                 layer_fn_copy(
                     layer,
@@ -83,7 +84,7 @@ def include_dim_layer_fn(
 
     else:
 
-        def func(layer: Layer) -> List[Layer]:
+        def func(layer: Layer) -> list[Layer]:
             return [layer_fn_copy(layer)]
 
     return func
@@ -91,7 +92,7 @@ def include_dim_layer_fn(
 
 def convert_forward(
     model: Model,
-    input_tensors: List[keras.KerasTensor],
+    input_tensors: list[keras.KerasTensor],
     layer_fn: Callable[..., Layer] = to_decomon,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     input_dim: int = -1,
@@ -103,7 +104,7 @@ def convert_forward(
     shared: bool = True,
     softmax_to_linear: bool = True,
     **kwargs: Any,
-) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], LayerMapDict, OutputMapDict]:
+) -> tuple[list[keras.KerasTensor], list[keras.KerasTensor], LayerMapDict, OutputMapDict]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
 
@@ -138,14 +139,14 @@ def convert_forward(
 
 def convert_forward_functional_model(
     model: Model,
-    layer_fn: Callable[[Layer], List[Layer]],
-    input_tensors: List[keras.KerasTensor],
+    layer_fn: Callable[[Layer], list[Layer]],
+    input_tensors: list[keras.KerasTensor],
     softmax_to_linear: bool = True,
     count: int = 0,
     output_map: Optional[OutputMapDict] = None,
     layer_map: Optional[LayerMapDict] = None,
-    layer2layer_map: Optional[Dict[int, List[Layer]]] = None,
-) -> Tuple[List[keras.KerasTensor], List[keras.KerasTensor], LayerMapDict, OutputMapDict, Dict[int, List[Layer]]]:
+    layer2layer_map: Optional[dict[int, list[Layer]]] = None,
+) -> tuple[list[keras.KerasTensor], list[keras.KerasTensor], LayerMapDict, OutputMapDict, dict[int, list[Layer]]]:
     if softmax_to_linear:
         model, has_softmax = softmax_2_linear(model)
 
@@ -163,7 +164,7 @@ def convert_forward_functional_model(
         layer_map = {}
     if layer2layer_map is None:
         layer2layer_map = {}
-    output: List[keras.KerasTensor] = input_tensors
+    output: list[keras.KerasTensor] = input_tensors
     for depth in keys:
         nodes = dico_nodes[depth]
         for node in nodes:

--- a/src/decomon/models/models.py
+++ b/src/decomon/models/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -19,8 +19,8 @@ from decomon.models.utils import ConvertMethod
 class DecomonModel(keras.Model):
     def __init__(
         self,
-        inputs: Union[keras.KerasTensor, List[keras.KerasTensor]],
-        outputs: Union[keras.KerasTensor, List[keras.KerasTensor]],
+        inputs: Union[keras.KerasTensor, list[keras.KerasTensor]],
+        outputs: Union[keras.KerasTensor, list[keras.KerasTensor]],
         perturbation_domain: Optional[PerturbationDomain] = None,
         dc_decomp: bool = False,
         method: Union[str, ConvertMethod] = ConvertMethod.FORWARD_AFFINE,
@@ -43,7 +43,7 @@ class DecomonModel(keras.Model):
         self.backward_bounds = backward_bounds
         self.shared = shared
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         # force having functional config which is skipped by default
         # because DecomonModel.__init__() has not same signature as Functional.__init__()
         config = Model(self.inputs, self.outputs).get_config()
@@ -96,8 +96,8 @@ class DecomonModel(keras.Model):
                 layer.reset_finetuning()
 
     def predict_on_single_batch_np(
-        self, inputs: Union[np.ndarray, List[np.ndarray]]
-    ) -> Union[np.ndarray, List[np.ndarray]]:
+        self, inputs: Union[np.ndarray, list[np.ndarray]]
+    ) -> Union[np.ndarray, list[np.ndarray]]:
         """Make predictions on numpy arrays fitting in one batch
 
         Avoid using `self.predict()` known to be not designed for small arrays,
@@ -128,8 +128,8 @@ def _check_domain(
     return perturbation_domain
 
 
-def get_AB(model: DecomonModel) -> Dict[str, List[keras.Variable]]:
-    dico_AB: Dict[str, List[keras.Variable]] = {}
+def get_AB(model: DecomonModel) -> dict[str, list[keras.Variable]]:
+    dico_AB: dict[str, list[keras.Variable]] = {}
     perturbation_domain = model.perturbation_domain
     if not (isinstance(perturbation_domain, GridDomain) and perturbation_domain.opt_option == Option.milp):
         return dico_AB
@@ -144,8 +144,8 @@ def get_AB(model: DecomonModel) -> Dict[str, List[keras.Variable]]:
     return dico_AB
 
 
-def get_AB_finetune(model: DecomonModel) -> Dict[str, keras.Variable]:
-    dico_AB: Dict[str, keras.Variable] = {}
+def get_AB_finetune(model: DecomonModel) -> dict[str, keras.Variable]:
+    dico_AB: dict[str, keras.Variable] = {}
     perturbation_domain = model.perturbation_domain
     if not (isinstance(perturbation_domain, GridDomain) and perturbation_domain.opt_option == Option.milp):
         return dico_AB

--- a/src/decomon/models/utils.py
+++ b/src/decomon/models/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import keras
 import keras.ops as K
@@ -41,7 +41,7 @@ class ConvertMethod(str, Enum):
     FORWARD_HYBRID = "forward-hybrid"
 
 
-def get_ibp_affine_from_method(method: Union[str, ConvertMethod]) -> Tuple[bool, bool]:
+def get_ibp_affine_from_method(method: Union[str, ConvertMethod]) -> tuple[bool, bool]:
     method = ConvertMethod(method)
     if method in [ConvertMethod.FORWARD_IBP, ConvertMethod.CROWN_FORWARD_IBP]:
         return True, False
@@ -90,7 +90,7 @@ def get_input_tensors(
     perturbation_domain: PerturbationDomain,
     ibp: bool = True,
     affine: bool = True,
-) -> Tuple[keras.KerasTensor, List[keras.KerasTensor]]:
+) -> tuple[keras.KerasTensor, list[keras.KerasTensor]]:
     input_dim = get_input_dim(model)
     mode = get_mode(ibp=ibp, affine=affine)
     dc_decomp = False
@@ -158,8 +158,8 @@ def get_input_dim(layer: Layer) -> int:
 
 
 def prepare_inputs_for_layer(
-    inputs: Union[Tuple[keras.KerasTensor, ...], List[keras.KerasTensor], keras.KerasTensor]
-) -> Union[Tuple[keras.KerasTensor, ...], List[keras.KerasTensor], keras.KerasTensor]:
+    inputs: Union[tuple[keras.KerasTensor, ...], list[keras.KerasTensor], keras.KerasTensor]
+) -> Union[tuple[keras.KerasTensor, ...], list[keras.KerasTensor], keras.KerasTensor]:
     """Prepare inputs for keras/decomon layers.
 
     Some Keras layers do not like list of tensors even with one single tensor.
@@ -173,8 +173,8 @@ def prepare_inputs_for_layer(
 
 
 def wrap_outputs_from_layer_in_list(
-    outputs: Union[Tuple[keras.KerasTensor, ...], List[keras.KerasTensor], keras.KerasTensor]
-) -> List[keras.KerasTensor]:
+    outputs: Union[tuple[keras.KerasTensor, ...], list[keras.KerasTensor], keras.KerasTensor]
+) -> list[keras.KerasTensor]:
     if not isinstance(outputs, list):
         if isinstance(outputs, tuple):
             return list(outputs)
@@ -184,7 +184,7 @@ def wrap_outputs_from_layer_in_list(
         return outputs
 
 
-def split_activation(layer: Layer) -> List[Layer]:
+def split_activation(layer: Layer) -> list[Layer]:
     # get activation
     config = layer.get_config()
     activation = config.pop("activation", None)
@@ -218,7 +218,7 @@ def split_activation(layer: Layer) -> List[Layer]:
         return [layer_wo_activation, activation_layer]
 
 
-def preprocess_layer(layer: Layer) -> List[Layer]:
+def preprocess_layer(layer: Layer) -> list[Layer]:
     return split_activation(layer)
 
 
@@ -226,16 +226,16 @@ def is_input_node(node: Node) -> bool:
     return len(node.input_tensors) == 0
 
 
-def get_depth_dict(model: Model) -> Dict[int, List[Node]]:
+def get_depth_dict(model: Model) -> dict[int, list[Node]]:
     depth_keys = list(model._nodes_by_depth.keys())
     depth_keys.sort(reverse=True)
 
     nodes_list = []
 
-    dico_depth: Dict[int, int] = {}
-    dico_nodes: Dict[int, List[Node]] = {}
+    dico_depth: dict[int, int] = {}
+    dico_nodes: dict[int, list[Node]] = {}
 
-    def fill_dico(node: Node, dico_depth: Optional[Dict[int, int]] = None) -> Dict[int, int]:
+    def fill_dico(node: Node, dico_depth: Optional[dict[int, int]] = None) -> dict[int, int]:
         if dico_depth is None:
             dico_depth = {}
 
@@ -311,7 +311,7 @@ class Convert2Mode(Layer):
             model_input_dim=self.input_dim,
         )
 
-    def call(self, inputs: List[BackendTensor], **kwargs: Any) -> List[BackendTensor]:
+    def call(self, inputs: list[BackendTensor], **kwargs: Any) -> list[BackendTensor]:
         compute_ibp_from_affine = self.mode_from == ForwardMode.AFFINE and self.mode_to != ForwardMode.AFFINE
         tight = self.mode_from == ForwardMode.HYBRID and self.mode_to != ForwardMode.AFFINE
         compute_dummy_affine = self.mode_from == ForwardMode.IBP and self.mode_to != ForwardMode.IBP
@@ -331,7 +331,7 @@ class Convert2Mode(Layer):
             [x, u_c, w_u, b_u, l_c, w_l, b_l, h, g]
         )
 
-    def compute_output_shape(self, input_shape: List[Tuple[Optional[int], ...]]) -> List[Tuple[Optional[int], ...]]:
+    def compute_output_shape(self, input_shape: list[tuple[Optional[int], ...]]) -> list[tuple[Optional[int], ...]]:
         (
             x_shape,
             u_c_shape,
@@ -347,7 +347,7 @@ class Convert2Mode(Layer):
             [x_shape, u_c_shape, w_u_shape, b_u_shape, l_c_shape, w_l_shape, b_l_shape, h_shape, g_shape]
         )
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         config = super().get_config()
         config.update(
             {"mode_from": self.mode_from, "mode_to": self.mode_to, "perturbation_domain": self.perturbation_domain}

--- a/src/decomon/types/__init__.py
+++ b/src/decomon/types/__init__.py
@@ -1,7 +1,7 @@
 """Typing module"""
 
 
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Union
 
 import keras
 
@@ -20,4 +20,4 @@ Tensor = Union[keras.KerasTensor, BackendTensor]
 """Type for any tensor, from keras or backend."""
 
 
-DecomonInputs = List[Tensor]
+DecomonInputs = list[Tensor]

--- a/src/decomon/utils.py
+++ b/src/decomon/utils.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, List, Optional, Tuple, Union
+from collections.abc import Callable
+from typing import Any, Optional, Union
 
 import keras.ops as K
 import numpy as np
@@ -91,7 +92,7 @@ def get_bound_grid(
     W_l: Tensor,
     b_l: Tensor,
     n: int,
-) -> Tuple[Tensor, Tensor]:
+) -> tuple[Tensor, Tensor]:
     upper = get_upper_bound_grid(x, W_u, b_u, n)
     lower = get_lower_bound_grid(x, W_l, b_l, n)
 
@@ -99,7 +100,7 @@ def get_bound_grid(
 
 
 # convert max Wx +b s.t Wx+b<=0 into a subset-sum problem with positive values
-def convert_lower_search_2_subset_sum(x: Tensor, W: Tensor, b: Tensor, n: int) -> Tuple[Tensor, Tensor]:
+def convert_lower_search_2_subset_sum(x: Tensor, W: Tensor, b: Tensor, n: int) -> tuple[Tensor, Tensor]:
     x_min = x[:, 0]
     x_max = x[:, 1]
 
@@ -131,7 +132,7 @@ def get_linear_hull_relu(
     upper_g: float = 0.0,
     lower_g: float = 0.0,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     slope = Slope(slope)
     # in case upper=lower, this cases are
     # considered with index_dead and index_linear
@@ -200,17 +201,17 @@ def get_linear_hull_relu(
     return [w_u, b_u, w_l, b_l]
 
 
-def get_linear_hull_sigmoid(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> List[Tensor]:
+def get_linear_hull_sigmoid(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> list[Tensor]:
     x = [upper, lower]
     return get_linear_hull_s_shape(x, func=K.sigmoid, f_prime=sigmoid_prime, mode=ForwardMode.IBP, **kwargs)
 
 
-def get_linear_hull_tanh(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> List[Tensor]:
+def get_linear_hull_tanh(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> list[Tensor]:
     x = [upper, lower]
     return get_linear_hull_s_shape(x, func=K.tanh, f_prime=tanh_prime, mode=ForwardMode.IBP, **kwargs)
 
 
-def get_linear_softplus_hull(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> List[Tensor]:
+def get_linear_softplus_hull(upper: Tensor, lower: Tensor, slope: Union[str, Slope], **kwargs: Any) -> list[Tensor]:
     slope = Slope(slope)
     # in case upper=lower, this cases are
     # considered with index_dead and index_linear
@@ -265,12 +266,12 @@ def get_linear_softplus_hull(upper: Tensor, lower: Tensor, slope: Union[str, Slo
 
 
 def subtract(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of inputs_0-inputs_1
 
     Args:
@@ -292,12 +293,12 @@ def subtract(
 
 
 def add(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of inputs_0+inputs_1
 
     Args:
@@ -340,13 +341,13 @@ def add(
 
 
 def relu_(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     slope: Union[str, Slope] = Slope.V_SLOPE,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     if perturbation_domain is None:
         perturbation_domain = BoxDomain()
 
@@ -401,12 +402,12 @@ def relu_(
 
 
 def minus(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of minus(x)=-x.
 
     Args:
@@ -440,14 +441,14 @@ def minus(
 
 
 def maximum(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     finetune: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of element-wise max
 
     Args:
@@ -481,14 +482,14 @@ def maximum(
 
 
 def minimum(
-    inputs_0: List[Tensor],
-    inputs_1: List[Tensor],
+    inputs_0: list[Tensor],
+    inputs_1: list[Tensor],
     dc_decomp: bool = False,
     perturbation_domain: Optional[PerturbationDomain] = None,
     mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
     finetune: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """LiRPA implementation of element-wise min
 
     Args:
@@ -521,7 +522,7 @@ def minimum(
 
 
 def get_linear_hull_s_shape(
-    inputs: List[Tensor],
+    inputs: list[Tensor],
     func: TensorFunction = K.sigmoid,
     f_prime: TensorFunction = sigmoid_prime,
     perturbation_domain: Optional[PerturbationDomain] = None,
@@ -529,7 +530,7 @@ def get_linear_hull_s_shape(
     slope: Union[str, Slope] = Slope.V_SLOPE,
     dc_decomp: bool = False,
     **kwargs: Any,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """Computing the linear hull of shape functions  given the pre activation neurons
 
     Args:
@@ -612,7 +613,7 @@ def get_t_upper(
     s_l: Tensor,
     func: TensorFunction = K.sigmoid,
     f_prime: TensorFunction = sigmoid_prime,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """linear interpolation between lower and upper bounds on the function func to have a symbolic approximation of the best
     coefficient for the affine upper bound
 
@@ -670,7 +671,7 @@ def get_t_lower(
     s_u: Tensor,
     func: TensorFunction = K.sigmoid,
     f_prime: TensorFunction = sigmoid_prime,
-) -> List[Tensor]:
+) -> list[Tensor]:
     """linear interpolation between lower and upper bounds on the function func to have a symbolic approximation of the best
     coefficient for the affine lower bound
 

--- a/src/decomon/wrapper.py
+++ b/src/decomon/wrapper.py
@@ -1,4 +1,5 @@
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from collections.abc import Callable, Sequence
+from typing import Optional, Union
 
 import keras
 import numpy as np
@@ -146,7 +147,7 @@ def get_adv_box(
         n_label = source_labels.shape[-1]
 
         # two possitible cases: the model improves the bound based on the knowledge of the labels
-        output: List[npt.NDArray[np.float_]]
+        output: list[npt.NDArray[np.float_]]
         if decomon_model.backward_bounds:
             C = np.diag([1] * n_label)[None] - source_labels[:, :, None]
             output = decomon_model.predict_on_single_batch_np([z, C])  # type: ignore
@@ -339,7 +340,7 @@ def check_adv_box(
         source_labels_list = [
             source_labels[batch_size * i : batch_size * (i + 1)] for i in range(len(x_reshaped) // batch_size + r)
         ]
-        target_labels_list: List[Optional[npt.NDArray[np.int_]]]
+        target_labels_list: list[Optional[npt.NDArray[np.int_]]]
         if (
             (target_labels is not None)
             and (not isinstance(target_labels, int))
@@ -470,7 +471,7 @@ def get_range_box(
     x_max: npt.NDArray[np.float_],
     batch_size: int = -1,
     n_sub_boxes: int = 1,
-) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
+) -> tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
     """bounding the outputs of a model in a given box
     if the constant is negative, then it is a formal guarantee that there is no adversarial examples
 
@@ -652,7 +653,7 @@ def get_range_noise(
     eps: float,
     p: float = np.inf,
     batch_size: int = -1,
-) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
+) -> tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
     """Bounds the output of a model in an Lp Ball
 
     Args:
@@ -756,7 +757,7 @@ def get_range_noise(
 
 def refine_boxes(
     x_min: npt.NDArray[np.float_], x_max: npt.NDArray[np.float_], n_sub_boxes: int = 10
-) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
+) -> tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
     # flatten x_min and x_max
     shape = list(x_min.shape[1:])
     output_dim = np.prod(shape)
@@ -771,7 +772,7 @@ def refine_boxes(
 
     def split(
         x_min: npt.NDArray[np.float_], x_max: npt.NDArray[np.float_], j: npt.NDArray[np.int_]
-    ) -> Tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
+    ) -> tuple[npt.NDArray[np.float_], npt.NDArray[np.float_]]:
         n_0 = len(x_min)
         n_k = x_min.shape[1]
 
@@ -977,7 +978,7 @@ def get_adv_noise(
         source_labels_list = [
             source_labels[batch_size * i : batch_size * (i + 1)] for i in range(len(x_reshaped) // batch_size + r)
         ]
-        target_labels_list: List[Optional[npt.NDArray[np.int_]]]
+        target_labels_list: list[Optional[npt.NDArray[np.int_]]]
         if (
             (target_labels is not None)
             and (not isinstance(target_labels, int))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import keras
 import keras.config as keras_config
@@ -155,12 +155,12 @@ def method(request):
 
 
 class ModelNumpyFromKerasTensors:
-    def __init__(self, inputs: List[KerasTensor], outputs: List[KerasTensor]):
+    def __init__(self, inputs: list[KerasTensor], outputs: list[KerasTensor]):
         self.inputs = inputs
         self.outputs = outputs
         self._model = Model(inputs, outputs)
 
-    def __call__(self, inputs_: List[np.ndarray]):
+    def __call__(self, inputs_: list[np.ndarray]):
         output_tensors = self._model(inputs_)
         if isinstance(output_tensors, list):
             return [K.convert_to_numpy(output) for output in output_tensors]
@@ -200,8 +200,8 @@ class Helpers:
 
     @staticmethod
     def predict_on_small_numpy(
-        model: Model, x: Union[np.ndarray, List[np.ndarray]]
-    ) -> Union[np.ndarray, List[np.ndarray]]:
+        model: Model, x: Union[np.ndarray, list[np.ndarray]]
+    ) -> Union[np.ndarray, list[np.ndarray]]:
         """Make predictions for model directly on small numpy arrays
 
         Avoid using `model.predict()` known to be not designed for small arrays,
@@ -347,10 +347,10 @@ class Helpers:
 
     @staticmethod
     def get_inputs_for_mode_from_full_inputs(
-        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]],
+        inputs: Union[list[Tensor], list[npt.NDArray[np.float_]]],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
+    ) -> Union[list[Tensor], list[npt.NDArray[np.float_]]]:
         """Extract from full inputs the ones corresponding to the selected mode.
 
         Args:
@@ -385,7 +385,7 @@ class Helpers:
 
     @staticmethod
     def get_inputs_np_for_decomon_model_from_full_inputs(
-        inputs: List[npt.NDArray[np.float_]],
+        inputs: list[npt.NDArray[np.float_]],
     ) -> npt.NDArray[np.float_]:
         """Extract from full numpy inputs the ones for a decomon model prediction.
 
@@ -400,8 +400,8 @@ class Helpers:
 
     @staticmethod
     def get_input_ref_bounds_from_full_inputs(
-        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]],
-    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
+        inputs: Union[list[Tensor], list[npt.NDArray[np.float_]]],
+    ) -> Union[list[Tensor], list[npt.NDArray[np.float_]]]:
         """Extract lower and upper bound for input ref from full inputs
 
         Args:
@@ -415,9 +415,9 @@ class Helpers:
 
     @staticmethod
     def prepare_full_np_inputs_for_convert_model(
-        inputs: List[npt.NDArray[np.float_]],
+        inputs: list[npt.NDArray[np.float_]],
         dc_decomp: bool = True,
-    ) -> List[npt.NDArray[np.float_]]:
+    ) -> list[npt.NDArray[np.float_]]:
         """Prepare full numpy inputs for convert_forward or convert_backward.
 
         W_u and W_l will be idendity matrices, and b_u, b_l zeros vectors.
@@ -445,10 +445,10 @@ class Helpers:
 
     @staticmethod
     def get_input_tensors_for_decomon_convert_from_full_inputs(
-        inputs: List[Tensor],
+        inputs: list[Tensor],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-    ) -> List[Tensor]:
+    ) -> list[Tensor]:
         """Extract from full tensor inputs the ones for a conversion to decomon model.
 
         Args:
@@ -485,7 +485,7 @@ class Helpers:
 
     @staticmethod
     def get_input_ref_from_full_inputs(
-        inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]]
+        inputs: Union[list[Tensor], list[npt.NDArray[np.float_]]]
     ) -> Union[Tensor, npt.NDArray[np.float_]]:
         """Extract from full inputs the input of reference for the original Keras layer.
 
@@ -527,11 +527,11 @@ class Helpers:
 
     @staticmethod
     def get_full_outputs_from_outputs_for_mode(
-        outputs_for_mode: Union[List[Tensor], List[npt.NDArray[np.float_]]],
+        outputs_for_mode: Union[list[Tensor], list[npt.NDArray[np.float_]]],
         mode: Union[str, ForwardMode] = ForwardMode.HYBRID,
         dc_decomp: bool = True,
-        full_inputs: Optional[Union[List[Tensor], List[npt.NDArray[np.float_]]]] = None,
-    ) -> Union[List[Tensor], List[npt.NDArray[np.float_]]]:
+        full_inputs: Optional[Union[list[Tensor], list[npt.NDArray[np.float_]]]] = None,
+    ) -> Union[list[Tensor], list[npt.NDArray[np.float_]]]:
         mode = ForwardMode(mode)
         if dc_decomp:
             if mode == ForwardMode.HYBRID:
@@ -577,7 +577,7 @@ class Helpers:
             return 6
 
     @staticmethod
-    def get_input_dim_from_full_inputs(inputs: Union[List[Tensor], List[npt.NDArray[np.float_]]]) -> int:
+    def get_input_dim_from_full_inputs(inputs: Union[list[Tensor], list[npt.NDArray[np.float_]]]) -> int:
         """Get input_dim for to_decomon or to_backward from full inputs
 
         Args:


### PR DESCRIPTION
Starting from python 3.9, we can
- replace Tuple, Dict, List, Type from typing by buitins tuple, dict, list, type
- replace typing.Callable by collections.abc.Callable
- replace typing.Sequence by collections.abc.Sequence

See https://peps.python.org/pep-0585/