### PR TITLE
Fix github workflow, part 3

### DIFF
--- a/src/decomon/layers/activations/activation.py
+++ b/src/decomon/layers/activations/activation.py
@@ -95,10 +95,10 @@ class DecomonBaseActivation(DecomonLayer):
     def forward_affine_propagate(
         self, input_affine_bounds: list[Tensor], input_constant_bounds: list[Tensor]
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-        w_l_in, b_l_in, w_u_in, b_u_in = input_affine_bounds
-        lower, upper = input_constant_bounds
+        if self.finetune and self.diagonal and len(input_affine_bounds) > 0:
+            w_l_in, b_l_in, w_u_in, b_u_in = input_affine_bounds
+            lower, upper = input_constant_bounds
 
-        if self.finetune and self.diagonal:
             # warning not working if diagonal propagation !
             w_l_in_ = K.reshape(w_l_in, [-1] + list(self.model_input_shape) + self.layer_input_shape_wo_batchsize)
             w_u_in_ = K.reshape(w_u_in, [-1] + list(self.model_input_shape) + self.layer_input_shape_wo_batchsize)

--- a/src/decomon/layers/backward/convolutional/conv1d.py
+++ b/src/decomon/layers/backward/convolutional/conv1d.py
@@ -16,7 +16,7 @@ class DecomonBackwardConv1D(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = ConvKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum, add_bias=False)
+        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/convolutional/conv2d.py
+++ b/src/decomon/layers/backward/convolutional/conv2d.py
@@ -16,7 +16,7 @@ class DecomonBackwardConv2D(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = ConvKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum, add_bias=False)
+        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/convolutional/conv3d.py
+++ b/src/decomon/layers/backward/convolutional/conv3d.py
@@ -16,7 +16,7 @@ class DecomonBackwardConv3D(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = ConvKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum, add_bias=False)
+        self.layer_backward_neg = ConvKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/convolutional/depthwise_conv1d.py
+++ b/src/decomon/layers/backward/convolutional/depthwise_conv1d.py
@@ -16,9 +16,7 @@ class DecomonBackwardDepthwiseConv1D(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = DepthwiseConvKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = DepthwiseConvKernelConstraint(
-            layer=self.layer_backward, ops=K.minimum, add_bias=False
-        )
+        self.layer_backward_neg = DepthwiseConvKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/convolutional/depthwise_conv2d.py
+++ b/src/decomon/layers/backward/convolutional/depthwise_conv2d.py
@@ -16,9 +16,7 @@ class DecomonBackwardDepthwiseConv2D(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = DepthwiseConvKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = DepthwiseConvKernelConstraint(
-            layer=self.layer_backward, ops=K.minimum, add_bias=False
-        )
+        self.layer_backward_neg = DepthwiseConvKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/core/dense.py
+++ b/src/decomon/layers/backward/core/dense.py
@@ -16,7 +16,7 @@ class DecomonBackwardDense(DecomonBackwardLinearLayer):
         # create positive and negative version
 
         self.layer_backward_pos = DenseKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = DenseKernelConstraint(layer=self.layer_backward, ops=K.minimum, add_bias=False)
+        self.layer_backward_neg = DenseKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/normalization/batch_normalization.py
+++ b/src/decomon/layers/backward/normalization/batch_normalization.py
@@ -19,9 +19,7 @@ class DecomonBackwardBatchNormalization(DecomonBackwardLinearLayer):
         super().__init__(*args, **kwargs)
         # create positive and negative version
         self.layer_backward_pos = BatchNormalizationKernelConstraint(layer=self.layer_backward, ops=K.maximum)
-        self.layer_backward_neg = BatchNormalizationKernelConstraint(
-            layer=self.layer_backward, ops=K.minimum, add_bias=False
-        )
+        self.layer_backward_neg = BatchNormalizationKernelConstraint(layer=self.layer_backward, ops=K.minimum)
 
         # pre built the layers
 

--- a/src/decomon/layers/backward/normalization/utils.py
+++ b/src/decomon/layers/backward/normalization/utils.py
@@ -14,7 +14,7 @@ class BatchNormalizationKernelConstraint(Wrapper):
         self,
         layer: BatchNormalization,
         ops: Callable[[Tensor, Tensor], Tensor] = K.maximum,
-        add_bias: bool = True,
+        add_bias: bool = False,
         **kwargs: Any,
     ):
         super().__init__(layer=layer, **kwargs)

--- a/src/decomon/layers/convolutional/base_conv.py
+++ b/src/decomon/layers/convolutional/base_conv.py
@@ -18,8 +18,8 @@ class DecomonBaseConv(DecomonLayer):
         *args: Any,
         **kwargs: Any,
     ):
-        layer_pos = ConvKernelConstraint(layer=layer, ops=K.maximum, add_bias=True)
-        layer_neg = ConvKernelConstraint(layer=layer, ops=K.minimum, add_bias=False)
+        layer_pos = ConvKernelConstraint(layer=layer, ops=K.maximum)
+        layer_neg = ConvKernelConstraint(layer=layer, ops=K.minimum)
         super().__init__(layer=layer, layer_pos=layer_pos, layer_neg=layer_neg, *args, **kwargs)  # type: ignore
 
 
@@ -32,6 +32,6 @@ class DecomonBaseDepthwiseConv(DecomonLayer):
         *args: Any,
         **kwargs: Any,
     ):
-        layer_pos = DepthwiseConvKernelConstraint(layer=layer, ops=K.maximum, add_bias=True)
-        layer_neg = DepthwiseConvKernelConstraint(layer=layer, ops=K.minimum, add_bias=False)
+        layer_pos = DepthwiseConvKernelConstraint(layer=layer, ops=K.maximum)
+        layer_neg = DepthwiseConvKernelConstraint(layer=layer, ops=K.minimum)
         super().__init__(layer=layer, layer_pos=layer_pos, layer_neg=layer_neg, *args, **kwargs)  # type: ignore

--- a/src/decomon/layers/convolutional/utils.py
+++ b/src/decomon/layers/convolutional/utils.py
@@ -14,7 +14,11 @@ from decomon.types import Tensor
 
 class ConvKernelConstraint(Wrapper):
     def __init__(
-        self, layer: BaseConv, ops: Callable[[Tensor, Tensor], Tensor] = K.maximum, add_bias: bool = True, **kwargs: Any
+        self,
+        layer: BaseConv,
+        ops: Callable[[Tensor, Tensor], Tensor] = K.maximum,
+        add_bias: bool = False,
+        **kwargs: Any,
     ):
         super().__init__(layer=layer, **kwargs)
         self.ops = ops
@@ -67,7 +71,7 @@ class DepthwiseConvKernelConstraint(Wrapper):
         self,
         layer: BaseDepthwiseConv,
         ops: Callable[[Tensor, Tensor], Tensor] = K.maximum,
-        add_bias: bool = True,
+        add_bias: bool = False,
         **kwargs: Any,
     ):
         super().__init__(layer=layer, **kwargs)

--- a/src/decomon/layers/core/dense.py
+++ b/src/decomon/layers/core/dense.py
@@ -18,8 +18,8 @@ class DecomonDense(DecomonLayer):
         *args: Any,
         **kwargs: Any,
     ):
-        layer_pos = DenseKernelConstraint(layer=layer, ops=K.maximum, add_bias=True)
-        layer_neg = DenseKernelConstraint(layer=layer, ops=K.minimum, add_bias=False)
+        layer_pos = DenseKernelConstraint(layer=layer, ops=K.maximum)
+        layer_neg = DenseKernelConstraint(layer=layer, ops=K.minimum)
 
         super().__init__(*args, layer=layer, layer_pos=layer_pos, layer_neg=layer_neg, **kwargs)  # type: ignore
 

--- a/src/decomon/layers/core/utils.py
+++ b/src/decomon/layers/core/utils.py
@@ -10,7 +10,7 @@ from decomon.types import Tensor
 
 class DenseKernelConstraint(Wrapper):
     def __init__(
-        self, layer: Dense, ops: Callable[[Tensor, Tensor], Tensor] = K.maximum, add_bias: bool = True, **kwargs: Any
+        self, layer: Dense, ops: Callable[[Tensor, Tensor], Tensor] = K.maximum, add_bias: bool = False, **kwargs: Any
     ):
         super().__init__(layer=layer, **kwargs)
         self.ops = ops

--- a/src/decomon/layers/layer.py
+++ b/src/decomon/layers/layer.py
@@ -493,18 +493,18 @@ class DecomonLayer(Wrapper):
                 diagonal=diagonal,
             )
         else:
-            w_l_in_ = K.reshape(w_l_in, [-1] + layer_input_shape_wo_batchsize)
-            w_u_in_ = K.reshape(w_u_in, [-1] + layer_input_shape_wo_batchsize)
+            w_l_in = K.reshape(w_l_in, [-1] + layer_input_shape_wo_batchsize)
+            w_u_in = K.reshape(w_u_in, [-1] + layer_input_shape_wo_batchsize)
             if len(b_u_in.shape) == 0:
                 # b_u_in is a scalar value
-                b_u_in_ = K.zeros_like([1] + layer_input_shape_wo_batchsize) + b_u_in
+                b_u_in = K.zeros([1] + layer_input_shape_wo_batchsize, dtype=b_u_in.dtype) + b_u_in
             else:
-                b_u_in_ = K.reshape(b_u_in, [-1] + layer_input_shape_wo_batchsize)
+                b_u_in = K.reshape(b_u_in, [-1] + layer_input_shape_wo_batchsize)
             if len(b_l_in.shape) == 0:
                 # b_l_in is a scalar value
-                b_l_in_ = K.zeros_like([1] + layer_input_shape_wo_batchsize) + b_l_in
+                b_l_in = K.zeros([1] + layer_input_shape_wo_batchsize, dtype=b_l_in.dtype) + b_l_in
             else:
-                b_l_in_ = K.reshape(b_l_in, [-1] + layer_input_shape_wo_batchsize)
+                b_l_in = K.reshape(b_l_in, [-1] + layer_input_shape_wo_batchsize)
             if self.use_bias:
                 bias = get_bias(layer)
             else:
@@ -513,9 +513,9 @@ class DecomonLayer(Wrapper):
             if is_from_linear:
                 # this means that b_u = b_l and w_l = w_u
                 # apply layer
-                b_l_out = layer(b_l_in_)[0]
+                b_l_out = layer(b_l_in)[0]
                 b_u_out = b_l_out
-                w_l_out = layer(w_l_in_)
+                w_l_out = layer(w_l_in)
                 if self.use_bias:
                     w_l_out = w_l_out - bias
                 w_l_out = K.reshape(w_l_out, list(self.model_input_shape) + layer_output_shape_wo_batchsize)
@@ -524,8 +524,8 @@ class DecomonLayer(Wrapper):
                 return (w_l_out, b_l_out, w_u_out, b_u_out)
             else:
                 if self.increasing:
-                    w_l_out = layer(w_l_in_)
-                    w_u_out = layer(w_u_in_)
+                    w_l_out = layer(w_l_in)
+                    w_u_out = layer(w_u_in)
                     if self.use_bias:
                         w_l_out = w_l_out - bias
                         w_u_out = w_u_out - bias
@@ -535,8 +535,8 @@ class DecomonLayer(Wrapper):
                     b_u_out = layer(b_u_in)
                     return (w_l_out, b_l_out, w_u_out, b_u_out)
                 elif self.decreasing:
-                    w_l_out = layer(w_u_in_)
-                    w_u_out = layer(w_l_in_)
+                    w_l_out = layer(w_u_in)
+                    w_u_out = layer(w_l_in)
                     if self.use_bias:
                         w_l_out = w_l_out - bias
                         w_u_out = w_u_out - bias
@@ -547,11 +547,11 @@ class DecomonLayer(Wrapper):
                     return (w_l_out, b_l_out, w_u_out, b_u_out)
                 elif not (layer_pos is None) and not (layer_neg is None):
                     w_l_out = K.reshape(
-                        layer_pos(w_l_in_) + layer_neg(w_u_in_),
+                        layer_pos(w_l_in) + layer_neg(w_u_in),
                         [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize,
                     )
                     w_u_out = K.reshape(
-                        layer_pos(w_u_in_) + layer_neg(w_l_in_),
+                        layer_pos(w_u_in) + layer_neg(w_l_in),
                         [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize,
                     )
                     b_l_out = layer_pos(b_l_in) + layer_neg(b_u_in)

--- a/src/decomon/layers/layer.py
+++ b/src/decomon/layers/layer.py
@@ -404,7 +404,14 @@ class DecomonLayer(Wrapper):
             return (self.layer(upper), self.layer(lower))
 
         if not (self.layer_pos is None) and not (self.layer_neg is None):
-            return (self.layer_pos(lower) + self.layer_neg(upper), self.layer_pos(upper) + self.layer_neg(lower))
+            if self.use_bias:
+                bias = get_bias(self.layer)
+                return (
+                    self.layer_pos(lower) + self.layer_neg(upper) + bias,
+                    self.layer_pos(upper) + self.layer_neg(lower) + bias,
+                )
+            else:
+                return (self.layer_pos(lower) + self.layer_neg(upper), self.layer_pos(upper) + self.layer_neg(lower))
 
         if self.linear:
             w, b = self.get_affine_representation()
@@ -460,6 +467,10 @@ class DecomonLayer(Wrapper):
             - The input bounds must match the expected shapes defined by `layer_input_shape_wo_batchsize`.
 
         """
+        if len(input_affine_bounds) == 0:
+            # special case: empty bounds <=> identity bounds
+            w, b = self.get_affine_representation()
+            return (w, b, w, b)
 
         w_l_in, b_l_in, w_u_in, b_u_in = input_affine_bounds
 
@@ -467,7 +478,7 @@ class DecomonLayer(Wrapper):
         is_from_diagonal = self.inputs_outputs_spec.is_diagonal_bounds(input_affine_bounds)
 
         if is_from_diagonal:
-            w_out, b_out = get_affine_representation_wo_bias(layer, diagonal=self.diagonal)  # Not Implemented
+            w_out, b_out = self.get_affine_representation()
             layer_affine_bounds = [w_out, b_out] * 2
 
             from_linear_layer = (self.inputs_outputs_spec.is_wo_batch_bounds(input_affine_bounds), True)
@@ -494,34 +505,44 @@ class DecomonLayer(Wrapper):
                 b_l_in_ = K.zeros_like([1] + layer_input_shape_wo_batchsize) + b_l_in
             else:
                 b_l_in_ = K.reshape(b_l_in, [-1] + layer_input_shape_wo_batchsize)
+            if self.use_bias:
+                bias = get_bias(layer)
+            else:
+                bias = 0
 
             if is_from_linear:
+                # this means that b_u = b_l and w_l = w_u
                 # apply layer
-                w_l_out = K.reshape(layer(w_l_in_), list(self.model_input_shape) + layer_output_shape_wo_batchsize)
                 b_l_out = layer(b_l_in_)[0]
-                w_u_out = K.reshape(layer(w_u_in_), list(self.model_input_shape) + layer_output_shape_wo_batchsize)
-                b_u_out = layer(b_u_in_)[0]
+                b_u_out = b_l_out
+                w_l_out = layer(w_l_in_)
+                if self.use_bias:
+                    w_l_out = w_l_out - bias
+                w_l_out = K.reshape(w_l_out, list(self.model_input_shape) + layer_output_shape_wo_batchsize)
+                w_u_out = w_l_out
 
                 return (w_l_out, b_l_out, w_u_out, b_u_out)
             else:
                 if self.increasing:
-                    w_l_out = K.reshape(
-                        layer(w_l_in_), [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize
-                    )
+                    w_l_out = layer(w_l_in_)
+                    w_u_out = layer(w_u_in_)
+                    if self.use_bias:
+                        w_l_out = w_l_out - bias
+                        w_u_out = w_u_out - bias
+                    w_l_out = K.reshape(w_l_out, [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize)
+                    w_u_out = K.reshape(w_u_out, [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize)
                     b_l_out = layer(b_l_in)
-                    w_u_out = K.reshape(
-                        layer(w_u_in_), [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize
-                    )
                     b_u_out = layer(b_u_in)
                     return (w_l_out, b_l_out, w_u_out, b_u_out)
                 elif self.decreasing:
-                    w_l_out = K.reshape(
-                        layer(w_u_in_), [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize
-                    )
+                    w_l_out = layer(w_u_in_)
+                    w_u_out = layer(w_l_in_)
+                    if self.use_bias:
+                        w_l_out = w_l_out - bias
+                        w_u_out = w_u_out - bias
+                    w_l_out = K.reshape(w_l_out, [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize)
+                    w_u_out = K.reshape(w_u_out, [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize)
                     b_l_out = layer(b_u_in)
-                    w_u_out = K.reshape(
-                        layer(w_l_in_), [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize
-                    )
                     b_u_out = layer(b_l_in)
                     return (w_l_out, b_l_out, w_u_out, b_u_out)
                 elif not (layer_pos is None) and not (layer_neg is None):
@@ -529,16 +550,31 @@ class DecomonLayer(Wrapper):
                         layer_pos(w_l_in_) + layer_neg(w_u_in_),
                         [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize,
                     )
-                    b_l_out = layer_pos(b_l_in) + layer_neg(b_u_in)
                     w_u_out = K.reshape(
                         layer_pos(w_u_in_) + layer_neg(w_l_in_),
                         [-1] + list(self.model_input_shape) + layer_output_shape_wo_batchsize,
                     )
+                    b_l_out = layer_pos(b_l_in) + layer_neg(b_u_in)
                     b_u_out = layer_pos(b_u_in) + layer_neg(b_l_in)
+                    if self.use_bias:
+                        b_l_out = b_l_out + bias
+                        b_u_out = b_u_out + bias
 
                     return (w_l_out, b_l_out, w_u_out, b_u_out)
                 else:
-                    raise NotImplementedError()
+                    w, b = self.get_affine_representation()
+                    layer_affine_bounds = [w, b, w, b]
+                    from_linear_layer = (is_from_linear, self.linear)
+                    diagonal = (
+                        is_from_diagonal,
+                        self.inputs_outputs_spec.is_diagonal_bounds(layer_affine_bounds),
+                    )
+                    return combine_affine_bounds(
+                        affine_bounds_1=input_affine_bounds,
+                        affine_bounds_2=layer_affine_bounds,
+                        from_linear_layer=from_linear_layer,
+                        diagonal=diagonal,
+                    )
 
     def forward_affine_propagate(
         self, input_affine_bounds: list[Tensor], input_constant_bounds: list[Tensor]

--- a/src/decomon/layers/merging/base_merge.py
+++ b/src/decomon/layers/merging/base_merge.py
@@ -236,8 +236,8 @@ class DecomonMerge(DecomonLayer):
 
             # reshape
             if is_from_linear:
-                b_l_in_list_ = [b[None] for b in b_l_in_list]
-                b_u_in_list_ = [b[None] for b in b_u_in_list]
+                b_l_in_list = [b[None] for b in b_l_in_list]
+                b_u_in_list = [b[None] for b in b_u_in_list]
                 w_l_out = self.layer(w_l_in_list)
                 w_u_out = self.layer(w_u_in_list)
                 b_l_out = self.layer(b_l_in_list)[0]
@@ -246,25 +246,25 @@ class DecomonMerge(DecomonLayer):
                 return (w_l_out, b_l_out, w_u_out, b_u_out)
 
             # reshape w
-            w_l_in_list_ = [
+            w_l_in_list = [
                 K.reshape(w_l_i, [-1] + list(self.model_input_shape) + e)
                 for (w_l_i, e) in zip(w_l_in_list, self.layer_input_shape_wo_batchsize)
             ]
-            w_u_in_list_ = [
+            w_u_in_list = [
                 K.reshape(w_u_i, [-1] + list(self.model_input_shape) + e)
                 for (w_u_i, e) in zip(w_u_in_list, self.layer_input_shape_wo_batchsize)
             ]
 
             if self.increasing:
-                w_l_out = self.layer(w_l_in_list_)
-                w_u_out = self.layer(w_u_in_list_)
+                w_l_out = self.layer(w_l_in_list)
+                w_u_out = self.layer(w_u_in_list)
                 b_l_out = self.layer(b_l_in_list)
                 b_u_out = self.layer(b_u_in_list)
                 return (w_l_out, b_l_out, w_u_out, b_u_out)
 
             if self.decreasing:
-                w_l_out = self.layer(w_l_in_list_)
-                w_u_out = self.layer(w_u_in_list_)
+                w_l_out = self.layer(w_l_in_list)
+                w_u_out = self.layer(w_u_in_list)
                 b_l_out = self.layer(b_l_in_list)
                 b_u_out = self.layer(b_u_in_list)
                 return (w_l_out, b_l_out, w_u_out, b_u_out)

--- a/src/decomon/layers/merging/base_merge.py
+++ b/src/decomon/layers/merging/base_merge.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import keras
 import keras.ops as K
@@ -228,46 +228,55 @@ class DecomonMerge(DecomonLayer):
         """
 
         is_from_linear = self.inputs_outputs_spec.is_wo_batch_bounds(input_affine_bounds)
+        is_from_diag = self.inputs_outputs_spec.is_diagonal_bounds(input_affine_bounds)
         if self.linear:
-            w_l_in_list = [e[0] for e in input_affine_bounds]
-            b_l_in_list = [e[1] for e in input_affine_bounds]
-            w_u_in_list = [e[2] for e in input_affine_bounds]
-            b_u_in_list = [e[3] for e in input_affine_bounds]
+            if is_from_linear or self.increasing or self.decreasing:  # shortcuts by using self.layer directly
+                w_l_in_list = [e[0] for e in input_affine_bounds]
+                b_l_in_list = [e[1] for e in input_affine_bounds]
+                w_u_in_list = [e[2] for e in input_affine_bounds]
+                b_u_in_list = [e[3] for e in input_affine_bounds]
 
-            # reshape
-            if is_from_linear:
-                b_l_in_list = [b[None] for b in b_l_in_list]
-                b_u_in_list = [b[None] for b in b_u_in_list]
-                w_l_out = self.layer(w_l_in_list)
-                w_u_out = self.layer(w_u_in_list)
-                b_l_out = self.layer(b_l_in_list)[0]
-                b_u_out = self.layer(b_u_in_list)[0]
+                if is_from_linear:
+                    b_l_in_list = [b[None] for b in b_l_in_list]
+                    b_u_in_list = [b[None] for b in b_u_in_list]
+                    w_l_out = self.layer(w_l_in_list)
+                    w_u_out = self.layer(w_u_in_list)
+                    b_l_out = self.layer(b_l_in_list)[0]
+                    b_u_out = self.layer(b_u_in_list)[0]
 
-                return (w_l_out, b_l_out, w_u_out, b_u_out)
+                    return (w_l_out, b_l_out, w_u_out, b_u_out)
 
-            # reshape w
-            w_l_in_list = [
-                K.reshape(w_l_i, [-1] + list(self.model_input_shape) + e)
-                for (w_l_i, e) in zip(w_l_in_list, self.layer_input_shape_wo_batchsize)
-            ]
-            w_u_in_list = [
-                K.reshape(w_u_i, [-1] + list(self.model_input_shape) + e)
-                for (w_u_i, e) in zip(w_u_in_list, self.layer_input_shape_wo_batchsize)
-            ]
+                # reshape w
+                if is_from_diag:
+                    w_l_in_list = [K.reshape(w_l_i, [-1] + list(self.model_input_shape)) for w_l_i in w_l_in_list]
+                    w_u_in_list = [K.reshape(w_u_i, [-1] + list(self.model_input_shape)) for w_u_i in w_u_in_list]
+                else:
+                    w_l_in_list = [
+                        K.reshape(w_l_i, [-1] + list(self.model_input_shape) + e)
+                        for (w_l_i, e) in zip(w_l_in_list, self.layer_input_shape_wo_batchsize)
+                    ]
+                    w_u_in_list = [
+                        K.reshape(w_u_i, [-1] + list(self.model_input_shape) + e)
+                        for (w_u_i, e) in zip(w_u_in_list, self.layer_input_shape_wo_batchsize)
+                    ]
 
-            if self.increasing:
-                w_l_out = self.layer(w_l_in_list)
-                w_u_out = self.layer(w_u_in_list)
-                b_l_out = self.layer(b_l_in_list)
-                b_u_out = self.layer(b_u_in_list)
-                return (w_l_out, b_l_out, w_u_out, b_u_out)
+                if self.increasing:
+                    w_l_out = self.layer(w_l_in_list)
+                    w_u_out = self.layer(w_u_in_list)
+                    b_l_out = self.layer(b_l_in_list)
+                    b_u_out = self.layer(b_u_in_list)
+                    return (w_l_out, b_l_out, w_u_out, b_u_out)
 
-            if self.decreasing:
-                w_l_out = self.layer(w_l_in_list)
-                w_u_out = self.layer(w_u_in_list)
-                b_l_out = self.layer(b_l_in_list)
-                b_u_out = self.layer(b_u_in_list)
-                return (w_l_out, b_l_out, w_u_out, b_u_out)
+                elif self.decreasing:
+                    w_l_out = self.layer(w_l_in_list)
+                    w_u_out = self.layer(w_u_in_list)
+                    b_l_out = self.layer(b_l_in_list)
+                    b_u_out = self.layer(b_u_in_list)
+                    return (w_l_out, b_l_out, w_u_out, b_u_out)
+
+                else:
+                    # should never come here
+                    raise NotImplementedError()
 
             else:
                 w, b = self.get_affine_representation()
@@ -415,6 +424,32 @@ class DecomonMerge(DecomonLayer):
                 )
             )
         return propagated_affine_bounds
+
+    def compute_output_shape_forward(
+        self, input_shape: list[tuple[Optional[int], ...]]
+    ) -> list[tuple[Optional[int], ...]]:
+        # We override in case of shortcuts possible by using self.layer in forward_affine_propagate()
+        if self.linear and self.affine:  # affine propagation with linear layer
+            (
+                affine_bounds_to_propagate_shape,
+                constant_oracle_bounds_shape,
+                perturbation_domain_inputs_shape,
+            ) = self.inputs_outputs_spec.split_input_shape(input_shape)
+            is_from_diag = self.inputs_outputs_spec.is_diagonal_bounds_shape(affine_bounds_to_propagate_shape)
+            is_from_linear = self.inputs_outputs_spec.is_wo_batch_bounds_shape(affine_bounds_to_propagate_shape)
+            if is_from_linear and is_from_diag:
+                (
+                    affine_bounds_propagated_shape,
+                    constant_bounds_propagated_shape,
+                ) = self.inputs_outputs_spec.split_output_shape(super().compute_output_shape_forward(input_shape))
+                # remains diago => w and b share shapes
+                w_l_shape, b_l_shape, w_u_shape, b_u_shape = affine_bounds_propagated_shape
+                affine_bounds_propagated_shape = [b_l_shape, b_l_shape, b_u_shape, b_u_shape]  # type: ignore
+                return self.inputs_outputs_spec.flatten_outputs_shape(
+                    affine_bounds_propagated_shape=affine_bounds_propagated_shape,
+                    constant_bounds_propagated_shape=constant_bounds_propagated_shape,
+                )
+        return super().compute_output_shape_forward(input_shape)
 
     def get_forward_oracle(
         self,

--- a/src/decomon/layers/utils/affine.py
+++ b/src/decomon/layers/utils/affine.py
@@ -70,10 +70,6 @@ def get_bias(layer: Layer) -> Tensor:
     """
 
     input_shape_wo_batch: list[int] = list(layer.input.shape[1:])
-
-    w_b: Tensor = K.zeros([1] + input_shape_wo_batch)
-    bias: Tensor = layer(w_b)[0]  # output_shape_wo_batch
-
     w_b = K.expand_dims(K.zeros(input_shape_wo_batch), 0)
     bias = layer(w_b)[0]  # output_shape_wo_batch
     return bias

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -1,7 +1,7 @@
 import keras.ops as K
 import numpy as np
 import pytest
-from keras.layers import Activation, Dense, Input
+from keras.layers import Activation, Dense, Identity, Input
 from keras.models import Model
 from pytest_cases import parametrize
 
@@ -16,7 +16,7 @@ from decomon.perturbation_domain import BoxDomain
 def test_clone_nok_several_inputs():
     a = Input((1,))
     b = Input((2,))
-    model = Model([a, b], a)
+    model = Model([a, b], a + b)
 
     with pytest.raises(ValueError, match="only 1 input"):
         clone(model)

--- a/tests/test_merge_layers.py
+++ b/tests/test_merge_layers.py
@@ -10,7 +10,7 @@ from decomon.layers.merging.add import DecomonAdd, DecomonMerge
 from decomon.types import Tensor
 
 
-# Defining non-linear and/or non-diagonal versions of DecomonAdd
+# Defining non-linear and/or non-diagonal / non-increasing versions of DecomonAdd
 class DecomonNonDiagAdd(DecomonMerge):
     layer: Add
     linear = True
@@ -75,6 +75,10 @@ class DecomonNonLinearNonDiagAdd(DecomonMerge):
         return sum(lower), sum(upper)
 
 
+class DecomonNonIncreasingAdd(DecomonAdd):
+    increasing = False
+
+
 T = TypeVar("T")
 
 
@@ -86,6 +90,7 @@ def repeat_input(input: T, n_repeat) -> list[T]:
     "decomon_layer_class, decomon_layer_kwargs, keras_layer_class, keras_layer_kwargs, arity, is_actually_linear",
     [
         (DecomonAdd, {}, Add, {}, 2, None),
+        (DecomonNonIncreasingAdd, {}, Add, {}, 2, True),
         (DecomonNonDiagAdd, {}, Add, {}, 2, True),
         (DecomonNonLinearAdd, {}, Add, {}, 2, True),
         (DecomonNonLinearNonDiagAdd, {}, Add, {}, 2, True),


### PR DESCRIPTION
We fix mainly foward affine propagation for decomon (merging or not) layers:
- take into account properly the bias
- fix compute_output_shape to take into account the new shapes resulting from the shortcuts (eg if self.increasing)
- take into account potential empty input bounds (meaning identity bounds)
- use really the reshaped inputs when passed through self.layer