### PR TITLE
Force pytest<8.4 as it seems incompatible with pytest-cases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ platform = linux: linux
            macos: darwin
            win: win32
 deps =
-    pytest
+    pytest<8.4  # pytest 8.4 not yet compatible with pytest-cov
     pytest-cases
     py39-linux-tf: pytest-cov
     tf: tensorflow>=2.16  # backend for keras 3


### PR DESCRIPTION
For now, pytest-cases fails with pytest==8.4, see
smarie/python-pytest-cases#364.