### PR TITLE
Test autolirpa (our fork) comparison in a separate tox env 

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -65,6 +65,12 @@ jobs:
         python-version: ["3.9", "3.11"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         backend: ["tf", "torch", "jax"]
+        autolirpa: [ "", "autolirpa" ]
+        exclude:
+          - backend: "tf"
+            autolirpa: "autolirpa"
+          - backend: "jax"
+            autolirpa: "autolirpa"
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -103,13 +109,17 @@ jobs:
           platformversion=platform_mapping[platform.system()]
           toxenv = f"{pythonversion}-{platformversion}"
           toxenv += "-${{ matrix.backend }}"
+          if "${{ matrix.autolirpa }}" == "autolirpa":
+              toxenv += "-autolirpa"
           set_toxenv_cmd = f"TOXENV={toxenv}"
           print(f"Picked: {toxenv}")
           with Path(os.environ["GITHUB_ENV"]).open("ta") as file_handler:
                file_handler.write(set_toxenv_cmd)
       - name: Run tox target env for ${{ env.TOXENV }}
         run: |
-          python -m tox -e convert-doc-to-test  # extract code blocks from doc to test them
+          if [[ "${{ matrix.autolirpa }}" != "autolirpa"  ]]; then
+            python -m tox -e convert-doc-to-test  # extract code blocks from doc to test them
+          fi
           # set default torch device to cpu if on macos-latest to avois mps-related errors
           export KERAS_TORCH_DEVICE=cpu
           python -m tox  # launch environment set by TOXENV at previous step

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     pre-commit
     convert-doc-to-test
     type
-    py{39,311}-{linux,macos,win}-{tf,torch,jax}
+    py{39,311}-{linux,macos,win}-{tf,torch,jax}{-autolirpa,}
 
 [testenv]
 platform = linux: linux
@@ -18,7 +18,7 @@ deps =
     tf: tensorflow>=2.16  # backend for keras 3
     torch: torch>=2.1.0  # backend for keras 3
     jax: jax>=0.4.20 # backend for keras 3
-    torch: auto_LiRPA@git+https://github.com/ducoffeM/auto_LiRPA  # comparison to autolirpa
+    autolirpa: auto_LiRPA@git+https://github.com/ducoffeM/auto_LiRPA  # comparison to autolirpa
 
 passenv =
     macos-torch: KERAS_TORCH_DEVICE
@@ -30,11 +30,12 @@ commands =
     pip list
     python -c 'import keras; print(keras.config.backend())'
     pytest -v \
-    !torch: --ignore tests/autolirpa \
     py39-linux-tf:    --cov decomon \
     py39-linux-tf:    --cov-report xml:coverage.xml \
     py39-linux-tf:    --cov-report html:coverage_html \
     py39-linux-tf:    --cov-report term \
+    !autolirpa: --ignore tests/autolirpa \
+    autolirpa: tests/autolirpa \
     {posargs}
 description =
     pytest environment

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     tf: tensorflow>=2.16  # backend for keras 3
     torch: torch>=2.1.0  # backend for keras 3
     jax: jax>=0.4.20 # backend for keras 3
-    torch: auto_LiRPA@git+https://github.com/Verified-Intelligence/auto_LiRPA  # comparison to autolirpa
+    torch: auto_LiRPA@git+https://github.com/ducoffeM/auto_LiRPA  # comparison to autolirpa
 
 passenv =
     macos-torch: KERAS_TORCH_DEVICE


### PR DESCRIPTION
- Add autolirpa option in github action matrix
- Add autolirpa option in tox envs
- Launch autolirpa tests in the dedicated env
- Launch all other tests in the regular env